### PR TITLE
Add builder2ibek reconvert subcommand

### DIFF
--- a/.claude/commands/beamline-reconvert.md
+++ b/.claude/commands/beamline-reconvert.md
@@ -6,136 +6,80 @@ description: Re-run xml2yaml on all IOCs for a beamline and validate with genera
 # Beamline Reconvert Workflow
 
 Re-convert all builder XML IOCs for beamline `$1` (e.g. `BL21I` or `i21`)
-using the latest ibek-support definitions. This is a fast, single-agent
-operation.
+using the latest ibek-support definitions. Use this after changing support
+YAMLs or converters.
 
-Use this after changing support YAMLs or converters to refresh all ioc.yaml
-files in the services repo and validate them.
+`reconvert` runs `generate2` calls sequentially in a single EPICS_ROOT
+tempdir; parallelisation is out of scope for this command.
+
+If `xml2yaml` fails, fix the converter in `src/builder2ibek/converters/`
+and re-run `reconvert`. If `generate2` fails, do NOT re-run `xml2yaml` —
+invoke `/support-fix`.
 
 ---
 
 ## Step 1 — Resolve services repo
 
 Follow [services-repo-resolution.md](../skills/shared/services-repo-resolution.md)
-using `$2` (if provided) or the beamline prefix `$1`.
+using `$2` (if provided) or the beamline prefix `$1`. Tell the user which
+services repo is being used.
 
 ---
 
-## Step 2 — Discover all IOC XMLs
-
-Normalize the beamline prefix `$1` to the full `BLXXY` form used in paths:
-- `i21` → `BL21I`, `i19` → `BL19I`, `b07` → `BL07B`, etc.
-- If `$1` is already in `BL…` form, use it directly.
-
-The BUILDER module is at a **fixed, specific path**. Check work area first,
-fall back to prod:
+## Step 2 — Run the reconvert subcommand
 
 ```bash
-# Try work area first (most current):
-ls /dls_sw/work/R3.14.12.7/support/BL21I-BUILDER/etc/makeIocs/*.xml 2>/dev/null
-
-# If empty, fall back to prod (use latest version):
-ls /dls_sw/prod/R3.14.12.7/support/BL21I-BUILDER/*/etc/makeIocs/*.xml 2>/dev/null
+uv run builder2ibek reconvert $1 --services-repo <services-repo> --json
 ```
 
-Replace `BL21I` with the actual normalized prefix.
+Discovers BUILDER XMLs (work area first, prod fallback), matches lowercased
+XML stems to `<services-repo>/services/<ioc-name>/config/ioc.yaml`,
+re-runs `xml2yaml` for each match (preserving the existing `description`
+field), then schema-validates every reconverted ioc.yaml with
+`ibek runtime generate2 --no-pvi` inside one EPICS_ROOT tempdir.
 
-**Do NOT search or `find` across `/dls_sw/`** — the path is deterministic
-from the beamline prefix as shown above.
+Flags: `--no-validate` skips the generate2 pass; `--only <ioc-name>`
+(repeatable) limits the run.
 
-Filter out template XMLs (files containing `$(macro)` syntax) — these are not
-standalone IOC definitions.
-
-List all XMLs found with a count.
+Exit codes: `0` clean · `2` ≥1 `xml2yaml` error · `3` ≥1 `generate2`
+failure · `1` hard failure. If the subcommand exits with code ≥ 4 or
+emits no JSON, fall back to Appendix A. Do not silently skip validation.
 
 ---
 
-## Step 3 — Discover existing IOC folders
+## Step 3 — Report
 
-List all subdirectories under `<services-repo>/services/` that contain
-`config/ioc.yaml`:
+Parse the JSON on stdout and summarise: reconverted count, skipped
+(grouped by `reason`), each conversion error's message, validation
+pass/fail counts with stderr tails for any failure. Then run
+`git -C <services-repo> diff --stat` to show the file delta.
 
-```bash
-find <services-repo>/services -maxdepth 2 -name ioc.yaml -path '*/config/*' \
-  | sed 's|/config/ioc.yaml||' | sort
-```
-
-Match each XML to its services folder (XML stem **lowercased** = folder name).
-Only reconvert IOCs that have an existing folder with `config/ioc.yaml` —
-skip XMLs with no matching services folder (they haven't been converted yet).
-
-Report any XMLs being skipped and why.
-
----
-
-## Step 4 — Reconvert all IOCs
-
-For each matched IOC, derive a terse description of the device it controls
-from the XML filename and contents (e.g. "Geobrick 06", "Vacuum system").
-Keep it short — a few words, no full sentences.
-
-**CRITICAL: `<ioc-name>` must be lowercase** (e.g. `bl21i-mo-ioc-01`, not
-`BL21I-MO-IOC-01`). The services folder name is always the XML stem
-lowercased. Then run:
-
-```bash
-uv run builder2ibek xml2yaml <path/to/IOC.xml> --yaml <services-repo>/services/<ioc-name>/config/ioc.yaml --description "<description>"
-```
-
-Run these sequentially (they're fast). Capture and report any conversion
-errors. Continue with the remaining IOCs if one fails.
-
----
-
-## Step 5 — Schema-validate with generate2
-
-Create a temporary `EPICS_ROOT` and set up ibek definitions:
-
-```bash
-export EPICS_ROOT=$(mktemp -d /tmp/epics-reconvert-XXXXXX)
-./update-schema
-```
-
-`ibek runtime generate2` requires a **config directory** (not a file) that
-contains `ioc.yaml`. Create a temp config dir, copy each ioc.yaml into it,
-and run generate2:
-
-```bash
-TMPCONFIG=$(mktemp -d /tmp/reconvert-config-XXXXXX)
-
-for ioc_yaml in <services-repo>/services/*/config/ioc.yaml; do
-  ioc_name=$(basename $(dirname $(dirname "$ioc_yaml")))
-  cp "$ioc_yaml" "$TMPCONFIG/ioc.yaml"
-  echo "--- Validating $ioc_name ---"
-  ibek runtime generate2 --no-pvi "$TMPCONFIG" 2>&1 || true
-done
-
-rm -rf "$TMPCONFIG" "$EPICS_ROOT"
-```
-
-Only loop over the IOCs that were reconverted in Step 4 (not all services
-folders). The generated runtime output goes to `$EPICS_ROOT` and is
-discarded — only the schema validation matters.
-
-Report all validation/generation errors grouped by IOC. Continue with the
-remaining IOCs if one fails.
-
----
-
-## Step 6 — Report
-
-Summarize:
-
-1. **Reconverted** — number of IOCs reconverted successfully
-2. **Skipped** — XMLs with no matching services folder
-3. **Conversion errors** — IOCs where xml2yaml failed (with error messages)
-4. **Validation** — pass/fail count per IOC, details of any generate2 failures
-5. **Files changed** — run `git -C <services-repo> diff --stat` to show what
-   changed
-
-Do not commit anything. Suggest git commands:
+Do not commit anything. Suggest:
 
 ```bash
 git -C <services-repo> add services/
 git -C <services-repo> commit -m "Reconvert IOCs with latest ibek-support"
+```
+
+---
+
+## Appendix A — Manual procedure (fallback)
+
+```bash
+# 1. Discover XMLs (work first, then prod — use <BLXXY> normalized form)
+ls /dls_sw/work/R3.14.12.7/support/<BLXXY>-BUILDER/etc/makeIocs/*.xml \
+  || ls /dls_sw/prod/R3.14.12.7/support/<BLXXY>-BUILDER/*/etc/makeIocs/*.xml
+
+# 2. For each XML whose lowercased stem matches a services folder:
+uv run builder2ibek xml2yaml <xml> --yaml <services-repo>/services/<ioc-name>/config/ioc.yaml
+
+# 3. Schema-validate each one:
+export EPICS_ROOT=$(mktemp -d /tmp/epics-reconvert-XXXXXX)
+./update-schema
+TMPCONFIG=$(mktemp -d /tmp/reconvert-config-XXXXXX)
+for ioc_yaml in <services-repo>/services/*/config/ioc.yaml; do
+  cp "$ioc_yaml" "$TMPCONFIG/ioc.yaml"
+  ibek runtime generate2 --no-pvi "$TMPCONFIG" 2>&1 || true
+done
+rm -rf "$TMPCONFIG" "$EPICS_ROOT"
 ```

--- a/src/builder2ibek/__main__.py
+++ b/src/builder2ibek/__main__.py
@@ -6,6 +6,7 @@ from builder2ibek import __version__
 from builder2ibek.convert import convert_file
 from builder2ibek.db2autosave import parse_templates
 from builder2ibek.dbcompare import compare_dbs
+from builder2ibek.reconvert import reconvert_cli
 
 cli = typer.Typer()
 
@@ -98,6 +99,47 @@ def db_compare(
         ignore=ignore,
         remove_duplicates=remove_duplicates,
         output=output,
+    )
+
+
+@cli.command()
+def reconvert(
+    beamline: str = typer.Argument(..., help="Beamline prefix (e.g. 'i21' or 'BL21I')"),
+    services_repo: Path = typer.Option(
+        ..., "--services-repo", help="Path to the beamline services repo"
+    ),
+    validate: bool = typer.Option(
+        True,
+        "--validate/--no-validate",
+        help="Schema-validate each reconverted ioc.yaml with ibek generate2",
+    ),
+    descriptions_json: Path | None = typer.Option(
+        None,
+        "--descriptions-json",
+        help="Optional JSON object mapping ioc-name -> one-line description. "
+        "Overrides descriptions read from existing ioc.yaml files.",
+    ),
+    only: list[str] = typer.Option(
+        [],
+        "--only",
+        help="Limit to specific ioc-names (repeatable, case-insensitive)",
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON on stdout"
+    ),
+):
+    """
+    Re-run xml2yaml on all IOCs for a beamline's services repo and
+    optionally schema-validate each result with ibek generate2. Sequential
+    inside one EPICS_ROOT tempdir.
+    """
+    reconvert_cli(
+        beamline,
+        services_repo,
+        validate=validate,
+        descriptions_json=descriptions_json,
+        only=list(only) or None,
+        json_out=json_out,
     )
 
 

--- a/src/builder2ibek/reconvert.py
+++ b/src/builder2ibek/reconvert.py
@@ -1,0 +1,333 @@
+"""
+Re-run xml2yaml on every IOC in a beamline's services repo and (optionally)
+schema-validate each result with `ibek runtime generate2`. This is the
+machine-driven core of the `/beamline-reconvert` slash command: the LLM
+handles services-repo resolution and the final human-readable report;
+everything between is mechanical and lives here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from builder2ibek.convert import convert_file
+
+BUILDER_WORK = Path("/dls_sw/work/R3.14.12.7/support")
+BUILDER_PROD = Path("/dls_sw/prod/R3.14.12.7/support")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SCHEMA = REPO_ROOT / "update-schema"
+IOC_SCHEMA = "/epics/ibek-defs/ioc.schema.json"
+
+_SHORT_BL_RE = re.compile(r"^([A-Za-z])([0-9]{1,2})([A-Za-z])?$")
+
+
+def normalize_beamline(prefix: str) -> str:
+    """Canonicalise beamline prefix: 'i21' -> 'BL21I', 'b07' -> 'BL07B',
+    'BL19I' -> 'BL19I'."""
+    if prefix.upper().startswith("BL"):
+        return prefix.upper()
+    m = _SHORT_BL_RE.match(prefix)
+    if not m:
+        raise ValueError(f"cannot parse beamline prefix {prefix!r}")
+    letter1, digits, letter2 = m.groups()
+    trailing = (letter2 or letter1).upper()
+    return f"BL{int(digits):02d}{trailing}"
+
+
+def discover_xmls(beamline: str) -> tuple[list[Path], Path | None, str]:
+    """Return (xmls, source_dir, source) for a normalised beamline prefix.
+
+    Tries the work area first, then the latest version directory in prod.
+    """
+    work_dir = BUILDER_WORK / f"{beamline}-BUILDER" / "etc" / "makeIocs"
+    if work_dir.is_dir():
+        xmls = sorted(work_dir.glob("*.xml"))
+        if xmls:
+            return xmls, work_dir, "work"
+
+    prod_module = BUILDER_PROD / f"{beamline}-BUILDER"
+    if prod_module.is_dir():
+        versions = sorted(p for p in prod_module.iterdir() if p.is_dir())
+        if versions:
+            prod_dir = versions[-1] / "etc" / "makeIocs"
+            if prod_dir.is_dir():
+                xmls = sorted(prod_dir.glob("*.xml"))
+                if xmls:
+                    return xmls, prod_dir, "prod"
+
+    return [], None, ""
+
+
+def _is_template_xml(xml: Path) -> bool:
+    name = xml.name
+    return "$(" in name or "template" in name.lower()
+
+
+def _read_existing_description(ioc_yaml: Path) -> str:
+    if not ioc_yaml.is_file():
+        return ""
+    try:
+        data = YAML(typ="safe").load(ioc_yaml)
+    except Exception:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    value = data.get("description") or ""
+    return str(value)
+
+
+@dataclass
+class ReconvertResult:
+    beamline: str
+    services_repo: str
+    builder_xml_dir: str | None
+    source: str
+    xmls_found: int
+    validate: bool
+    ioc_candidates: list[dict] = field(default_factory=list)
+    skipped: list[dict] = field(default_factory=list)
+    reconverted: list[dict] = field(default_factory=list)
+    conversion_errors: list[dict] = field(default_factory=list)
+    validation: list[dict] = field(default_factory=list)
+
+
+def run_reconvert(
+    beamline_prefix: str,
+    services_repo: Path,
+    *,
+    validate: bool = True,
+    descriptions: dict[str, str] | None = None,
+    only: list[str] | None = None,
+) -> tuple[ReconvertResult, int]:
+    """Orchestrate discovery, xml2yaml, and optional generate2 validation.
+
+    Exit codes returned: 0 clean, 2 conversion errors, 3 validation failures,
+    1 hard failure. ValueError / FileNotFoundError raised for bad input —
+    the caller maps those to exit code 1.
+    """
+    descriptions = descriptions or {}
+    only_set = {n.lower() for n in (only or [])}
+
+    beamline = normalize_beamline(beamline_prefix)
+
+    if not services_repo.is_dir():
+        raise FileNotFoundError(f"services-repo not found: {services_repo}")
+
+    xmls, source_dir, source = discover_xmls(beamline)
+    result = ReconvertResult(
+        beamline=beamline,
+        services_repo=str(services_repo),
+        builder_xml_dir=str(source_dir) if source_dir else None,
+        source=source,
+        xmls_found=len(xmls),
+        validate=validate,
+    )
+
+    if not xmls:
+        raise FileNotFoundError(f"no BUILDER XMLs found for {beamline} in work or prod")
+
+    services_dir = services_repo / "services"
+
+    for xml in xmls:
+        if _is_template_xml(xml):
+            result.skipped.append({"xml": str(xml), "reason": "macro-template"})
+            continue
+        ioc_name = xml.stem.lower()
+        services_folder = services_dir / ioc_name
+        ioc_yaml = services_folder / "config" / "ioc.yaml"
+        if not ioc_yaml.is_file():
+            result.skipped.append({"xml": str(xml), "reason": "no-services-folder"})
+            continue
+        if only_set and ioc_name not in only_set:
+            result.skipped.append({"xml": str(xml), "reason": "filtered-by-only"})
+            continue
+        result.ioc_candidates.append(
+            {
+                "xml": str(xml),
+                "ioc_name": ioc_name,
+                "services_folder": str(services_folder),
+                "ioc_yaml": str(ioc_yaml),
+            }
+        )
+
+    for cand in result.ioc_candidates:
+        ioc_name = cand["ioc_name"]
+        xml = Path(cand["xml"])
+        ioc_yaml = Path(cand["ioc_yaml"])
+        description = descriptions.get(ioc_name) or _read_existing_description(ioc_yaml)
+        try:
+            # Route any stray converter prints to stderr so `--json` on
+            # stdout stays parseable.
+            with contextlib.redirect_stdout(sys.stderr):
+                convert_file(xml, ioc_yaml, IOC_SCHEMA, description=description)
+            result.reconverted.append({"ioc_name": ioc_name, "status": "ok"})
+        except Exception as e:  # noqa: BLE001 — report any converter error
+            result.conversion_errors.append(
+                {"ioc_name": ioc_name, "error": f"{type(e).__name__}: {e}"}
+            )
+
+    if validate and result.reconverted:
+        _run_validation(result)
+
+    if result.conversion_errors:
+        return result, 2
+    if any(v["status"] == "fail" for v in result.validation):
+        return result, 3
+    return result, 0
+
+
+def _run_validation(result: ReconvertResult) -> None:
+    """Validate each reconverted ioc.yaml with `ibek runtime generate2`.
+
+    One EPICS_ROOT tempdir and one config tempdir are created per
+    `reconvert` invocation; the generate2 calls run sequentially inside
+    them. CLAUDE.md hard rule 6 (EPICS_ROOT isolation) is satisfied per
+    invocation — parallelism is out of scope for this command.
+    """
+    with (
+        tempfile.TemporaryDirectory(prefix="epics-reconvert-") as epics_root,
+        tempfile.TemporaryDirectory(prefix="reconvert-config-") as tmp_config,
+    ):
+        env = os.environ.copy()
+        env["EPICS_ROOT"] = epics_root
+
+        schema_proc = subprocess.run(
+            [str(UPDATE_SCHEMA)],
+            env=env,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+        )
+        if schema_proc.returncode != 0:
+            for item in result.reconverted:
+                result.validation.append(
+                    {
+                        "ioc_name": item["ioc_name"],
+                        "status": "fail",
+                        "stderr": (
+                            "update-schema failed: "
+                            + (schema_proc.stderr or schema_proc.stdout).strip()
+                        ),
+                    }
+                )
+            return
+
+        cfg_ioc = Path(tmp_config) / "ioc.yaml"
+        by_name = {c["ioc_name"]: c for c in result.ioc_candidates}
+        for item in result.reconverted:
+            ioc_name = item["ioc_name"]
+            cand = by_name.get(ioc_name)
+            if cand is None:
+                continue
+            shutil.copy(cand["ioc_yaml"], cfg_ioc)
+            proc = subprocess.run(
+                ["ibek", "runtime", "generate2", "--no-pvi", str(tmp_config)],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            if proc.returncode == 0:
+                result.validation.append({"ioc_name": ioc_name, "status": "ok"})
+            else:
+                result.validation.append(
+                    {
+                        "ioc_name": ioc_name,
+                        "status": "fail",
+                        "stderr": (proc.stderr or proc.stdout).strip(),
+                    }
+                )
+
+
+def _render_human(result: ReconvertResult) -> str:
+    lines = [
+        f"Beamline:      {result.beamline}",
+        f"Services repo: {result.services_repo}",
+    ]
+    if result.builder_xml_dir:
+        lines.append(
+            f"Builder XMLs:  {result.xmls_found} ({result.source}: "
+            f"{result.builder_xml_dir})"
+        )
+    lines.append(f"Reconverted:   {len(result.reconverted)}")
+    lines.append(f"Skipped:       {len(result.skipped)}")
+    lines.append(f"Conversion errors: {len(result.conversion_errors)}")
+    if not result.validate:
+        lines.append("Validation:    skipped (--no-validate)")
+    else:
+        passes = sum(1 for v in result.validation if v["status"] == "ok")
+        fails = sum(1 for v in result.validation if v["status"] == "fail")
+        lines.append(f"Validation:    {passes} pass, {fails} fail")
+
+    if result.conversion_errors:
+        lines.append("")
+        lines.append("Conversion errors:")
+        for err in result.conversion_errors:
+            lines.append(f"  - {err['ioc_name']}: {err['error']}")
+
+    failed = [v for v in result.validation if v["status"] == "fail"]
+    if failed:
+        lines.append("")
+        lines.append("Validation failures:")
+        for v in failed:
+            lines.append(f"  - {v['ioc_name']}:")
+            tail = v.get("stderr", "").splitlines()[-5:]
+            for line in tail:
+                lines.append(f"      {line}")
+    return "\n".join(lines)
+
+
+def reconvert_cli(
+    beamline: str,
+    services_repo: Path,
+    *,
+    validate: bool = True,
+    descriptions_json: Path | None = None,
+    only: list[str] | None = None,
+    json_out: bool = False,
+) -> None:
+    """CLI entry point. Emits human-readable or JSON output and calls
+    `sys.exit` with the appropriate code."""
+    try:
+        descriptions: dict[str, str] | None = None
+        if descriptions_json is not None:
+            raw = json.loads(Path(descriptions_json).read_text())
+            if not isinstance(raw, dict):
+                raise ValueError(
+                    "--descriptions-json must contain a JSON object "
+                    "mapping ioc-name to description"
+                )
+            descriptions = {str(k).lower(): str(v) for k, v in raw.items()}
+
+        result, exit_code = run_reconvert(
+            beamline,
+            services_repo,
+            validate=validate,
+            descriptions=descriptions,
+            only=only,
+        )
+    except (FileNotFoundError, ValueError) as e:
+        msg = f"{type(e).__name__}: {e}"
+        if json_out:
+            print(json.dumps({"error": msg}))
+        else:
+            print(f"error: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    if json_out:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(_render_human(result))
+
+    sys.exit(exit_code)

--- a/tests/test_reconvert_cli.py
+++ b/tests/test_reconvert_cli.py
@@ -1,0 +1,136 @@
+"""Tests for builder2ibek.reconvert."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from builder2ibek import reconvert as rc
+
+SAMPLES = Path(__file__).parent / "samples"
+
+
+def test_normalize_beamline_short_forms():
+    assert rc.normalize_beamline("i21") == "BL21I"
+    assert rc.normalize_beamline("i04") == "BL04I"
+    assert rc.normalize_beamline("b07") == "BL07B"
+    assert rc.normalize_beamline("p45") == "BL45P"
+
+
+def test_normalize_beamline_already_normalized():
+    assert rc.normalize_beamline("BL21I") == "BL21I"
+    assert rc.normalize_beamline("bl19i") == "BL19I"
+
+
+def test_normalize_beamline_invalid():
+    with pytest.raises(ValueError):
+        rc.normalize_beamline("bogus-prefix")
+
+
+def test_is_template_filename():
+    assert rc._is_template_xml(Path("GIGE-FIT-TEMPLATE.xml"))
+    assert rc._is_template_xml(Path("ClaspTemplate.xml"))
+    assert rc._is_template_xml(Path("$(IOC)-foo.xml"))
+    assert not rc._is_template_xml(Path("BL21I-MO-IOC-01.xml"))
+
+
+def test_read_existing_description(tmp_path: Path):
+    ioc_yaml = tmp_path / "ioc.yaml"
+    ioc_yaml.write_text("ioc_name: test\ndescription: Cryo cooler\nentities: []\n")
+    assert rc._read_existing_description(ioc_yaml) == "Cryo cooler"
+
+    missing = tmp_path / "absent.yaml"
+    assert rc._read_existing_description(missing) == ""
+
+
+def _fake_services_repo(tmp_path: Path, ioc_name: str) -> Path:
+    """Create a minimal services repo with a single ioc.yaml."""
+    repo = tmp_path / "fake-services"
+    cfg = repo / "services" / ioc_name / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "ioc.yaml").write_text(
+        "ioc_name: placeholder\ndescription: Old description\nentities: []\n"
+    )
+    return repo
+
+
+def test_run_reconvert_no_matching_services_folder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    xml = SAMPLES / "BL11I-CS-IOC-09.xml"
+    monkeypatch.setattr(rc, "discover_xmls", lambda _b: ([xml], xml.parent, "work"))
+
+    repo = tmp_path / "empty-services"
+    (repo / "services").mkdir(parents=True)
+
+    result, code = rc.run_reconvert("i11", repo, validate=False)
+
+    assert code == 0
+    assert result.ioc_candidates == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0]["reason"] == "no-services-folder"
+    assert result.reconverted == []
+
+
+def test_run_reconvert_happy_path_no_validate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    xml = SAMPLES / "BL11I-CS-IOC-09.xml"
+    monkeypatch.setattr(rc, "discover_xmls", lambda _b: ([xml], xml.parent, "work"))
+
+    ioc_name = xml.stem.lower()
+    repo = _fake_services_repo(tmp_path, ioc_name)
+
+    result, code = rc.run_reconvert("i11", repo, validate=False)
+
+    assert code == 0
+    assert len(result.reconverted) == 1
+    assert result.reconverted[0]["ioc_name"] == ioc_name
+    assert result.conversion_errors == []
+    assert result.validation == []
+
+    rewritten = repo / "services" / ioc_name / "config" / "ioc.yaml"
+    text = rewritten.read_text()
+    # Existing description should have been preserved through the round-trip.
+    assert "Old description" in text
+    # And the file should look like a real converted IOC, not the placeholder.
+    assert "EPICS_TZ" in text
+
+
+def test_run_reconvert_only_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    xml = SAMPLES / "BL11I-CS-IOC-09.xml"
+    monkeypatch.setattr(rc, "discover_xmls", lambda _b: ([xml], xml.parent, "work"))
+    repo = _fake_services_repo(tmp_path, xml.stem.lower())
+
+    result, code = rc.run_reconvert(
+        "i11", repo, validate=False, only=["some-other-ioc"]
+    )
+
+    assert code == 0
+    assert result.reconverted == []
+    reasons = {s["reason"] for s in result.skipped}
+    assert "filtered-by-only" in reasons
+
+
+def test_run_reconvert_bad_beamline_raises(tmp_path: Path):
+    (tmp_path / "services").mkdir()
+    with pytest.raises(ValueError):
+        rc.run_reconvert("not-a-beamline", tmp_path, validate=False)
+
+
+def test_run_reconvert_missing_services_repo(tmp_path: Path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError):
+        rc.run_reconvert("i11", missing, validate=False)
+
+
+def test_cli_help():
+    cmd = [sys.executable, "-m", "builder2ibek", "reconvert", "--help"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "reconvert" in result.stdout
+    assert "--services-repo" in result.stdout
+    assert "--no-validate" in result.stdout


### PR DESCRIPTION
## Summary

- New top-level `builder2ibek reconvert <beamline> --services-repo <path>` Typer subcommand replacing the mechanical `xml2yaml` + `generate2` loops in `/beamline-reconvert` (PR 3 from `review/commands-simplify`).
- `.claude/commands/beamline-reconvert.md` shrinks from 141 → 85 lines (~40%); Appendix A keeps the manual procedure available as a fallback.
- Reuses `convert_file` unchanged. One `tempfile.TemporaryDirectory` per invocation for EPICS_ROOT (sequential, per user decision Q1). JSON output on `--json`; exit codes `0` clean / `2` conversion error / `3` validation failure / `1` hard failure.

Live spot-check on `i04 --services-repo /workspaces/i04-services`: 25/25 reconverted with `--no-validate --json`, clean JSON stdout; single-IOC `--validate --only bl04i-va-ioc-01` also passed.

Incidental workaround: `src/builder2ibek/converters/deviocstats.py:24` has a stray `print()` that corrupted `--json` stdout. Not in scope to fix here; the reconvert loop redirects `convert_file`'s stdout to stderr so `--json` stays parseable. Worth a separate cleanup PR.

## Test plan

- [x] `uv run pytest` — 39/39 passing (28 pre-existing + 11 new `tests/test_reconvert_cli.py` covering beamline normalization, template filtering, description round-trip, skip paths, filters, error paths, CLI help).
- [x] Regression: `uv run pytest tests/test_file_conversion.py` — 25/25 pinned `xml2yaml` outputs unchanged.
- [x] Live: `uv run builder2ibek reconvert i04 --services-repo /workspaces/i04-services --no-validate --json` — 25 reconverted, 0 errors, exit 0, JSON on stdout.
- [x] Live: `uv run builder2ibek reconvert i04 --services-repo /workspaces/i04-services --only bl04i-va-ioc-01 --json` — 1 reconverted + validated, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)