### PR TITLE
Correct module-special-cases.md devIocStats entry

### DIFF
--- a/.claude/skills/shared/module-special-cases.md
+++ b/.claude/skills/shared/module-special-cases.md
@@ -22,7 +22,9 @@ Do NOT create a duplicate `IOCinfo/` folder — always use `IOCInfo/`.
 `pmacCoord` has its own support YAML in `ibek-support-dls/pmacCoord/`, distinct
 from the `pmac` module in `ibek-support/pmac/`. Do not merge them.
 
-## `devIocStats` — lives in `ibek-support-dls`
+## `devIocStats` — use the public `ibek-support/iocStats`
 
-Despite being a community module, the DLS support YAML is at
-`ibek-support-dls/devIocStats/`. Do not create a second copy in `ibek-support/`.
+The public module at `ibek-support/iocStats/` defines
+`module: devIocStats` with `iocAdminSoft` using the `$(IOCSTATS)` macro.
+Do **not** create a `ibek-support-dls/devIocStats/` — the DLS-specific
+copy was removed as redundant.


### PR DESCRIPTION
## Summary

- `.claude/skills/shared/module-special-cases.md` told future Claude sessions that `devIocStats` lives in `ibek-support-dls/devIocStats/` — that folder was removed some time back in favour of the public `ibek-support/iocStats/` module (which already declares `module: devIocStats`).
- Rewrite the entry to direct readers to the public module and explicitly warn against recreating the DLS copy.

## Test plan

- [x] Skill-doc-only change, no code or test impact.
- [x] Verified the public module at `ibek-support/iocStats/` exists and declares `devIocStats`.
- [x] Verified `ibek-support-dls/devIocStats/` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)