### PR TITLE
devcontainer: install glab and persist its auth

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,6 +19,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     apt-get update && apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
+# Install glab (GitLab CLI) — no apt repo, use the release tarball from gitlab.com
+ARG GLAB_VERSION=1.92.1
+RUN curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+      | tar -xz -C /tmp bin/glab && \
+    install -m 0755 /tmp/bin/glab /usr/local/bin/glab && \
+    rm -rf /tmp/bin
+
 FROM base as developer
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -97,6 +97,12 @@
             "target": "/root/.config/gh",
             "type": "volume"
         },
+        // Persist glab auth across container rebuilds (GitLab CLI, for ibek-support-dls)
+        {
+            "source": "glab-auth-${localWorkspaceFolderBasename}",
+            "target": "/root/.config/glab-cli",
+            "type": "volume"
+        },
         // Mount Claude config from host (settings, memory, skills)
         {
             "source": "${localEnv:HOME}/.claude",

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ lockfiles/
 .claude/commands/ioc-convert/last-services-repo
 .claude/commands/ioc-check/last-services-repo
 DONE
+.claude/scheduled_tasks.lock

--- a/justfile
+++ b/justfile
@@ -8,6 +8,15 @@ gh-auth:
     gh auth status
 
 
+# Authenticate glab CLI with a GitLab PAT (token not stored in shell history). --git-protocol https prevents glab's SSH insteadOf rewrite.
+glab-auth hostname="gitlab.diamond.ac.uk":
+    #!/bin/bash
+    read -sp "GitLab PAT for {{ hostname }}: " t && echo
+    echo "$t" | glab auth login --stdin --hostname {{ hostname }} --git-protocol https
+    unset t
+    glab auth status
+
+
 # Start Claude Code in sandbox mode (uses container-local SSH agent only)
 claude:
     SSH_AUTH_SOCK= IS_SANDBOX=1 claude --dangerously-skip-permissions --chrome


### PR DESCRIPTION
## Summary

Adds GitLab CLI (\`glab\`) to parallel \`gh\`'s existing treatment, so MRs against \`ibek-support-dls\` (hosted on \`gitlab.diamond.ac.uk\`) can be opened from inside the devcontainer without leaving the sandbox.

- **Dockerfile**: install \`glab\` 1.92.1 from the release tarball on gitlab.com (there is no apt repo). Version pinned via \`ARG GLAB_VERSION\` so it's a one-liner to bump.
- **devcontainer.json**: mount a per-workspace \`glab-auth-<basename>\` named volume at \`/root/.config/glab-cli\` — same pattern as the existing \`gh-auth-<basename>\` mount, so \`glab\` auth survives container rebuilds.
- **justfile**: add a \`glab-auth\` recipe that prompts for a PAT without leaving it in shell history and runs \`glab auth login --git-protocol https\`. The \`--git-protocol https\` flag is important: without it, glab adds a global \`url.ssh://git@gitlab.diamond.ac.uk.insteadOf=https://gitlab.diamond.ac.uk\` rewrite that silently breaks HTTPS pushes (there is no usable SSH key in the container).
- **.gitignore**: ignore \`.claude/scheduled_tasks.lock\` so Claude's scheduled-task state doesn't show up as uncommitted.

## Test plan
- [x] \`just --list\` shows both \`gh-auth\` and \`glab-auth\`.
- [ ] Rebuild the devcontainer, run \`just glab-auth\`, confirm auth persists after a second rebuild.
- [ ] Push a branch to a GitLab repo over HTTPS after running \`just glab-auth\` — confirm no SSH fallback.