### PR TITLE
Port Claude sandbox to python-copier-template

### DIFF
--- a/.claude/commands/ioc-convert.md
+++ b/.claude/commands/ioc-convert.md
@@ -283,7 +283,26 @@ To check what macros a db file expects:
 grep "^# % macro" /dls_sw/prod/R3.14.12.7/support/<module>/<version>/db/<file>.db
 ```
 
-### 5c. Report and suggest commits
+### 5c. Refresh the global schema
+
+The isolated `EPICS_ROOT` from Phase 0 keeps this run's schema separate, but it
+also means the **global** schema at `/epics/ibek-defs/ioc.schema.json` (which
+the editor's yaml-language-server reads — see line 1 of every `ioc.yaml`) is
+unaware of any new support YAMLs created during this run. The result is
+spurious "unknown type" warnings in the IDE on freshly-converted ioc.yaml
+files, even though `ibek runtime generate2` succeeded.
+
+If any support YAMLs were created or modified during this run, refresh the
+global schema so the editor sees the new entity types:
+
+```bash
+EPICS_ROOT=/epics ./update-schema
+```
+
+If no support YAMLs changed (pure ioc.yaml-only conversion), this step can be
+skipped.
+
+### 5d. Report and suggest commits
 
 Once clean, **do not commit anything**. Report to the user:
 

--- a/.claude/skills/beamline-gui/SKILL.md
+++ b/.claude/skills/beamline-gui/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: beamline-gui
+description: DLS beamline EDM screen layout and conventions — use when locating, reading, or editing `*.edl` files for hardware-status / IOC-status synoptics, debugging wrong-target buttons (PC / Terminal / Start-Stop), or making sense of EDM positional layout.
+---
+
+# Beamline GUI (EDM Screens)
+
+DLS beamline GUIs are EDM `.edl` files. This skill covers where they live and
+how the common synoptic screens are wired.
+
+---
+
+## Where the screens live
+
+Pattern (same for every beamline):
+
+```
+/dls_sw/{work,prod}/R<EPICS-VER>/ioc/BLxxI/BL/
+  BLxxIApp/opi/edl/*.edl     # SOURCE — edit these
+  data/*.edl                 # deployed copy — overwritten by build; do not edit
+```
+
+`*.edl~` are EDM editor backups — ignore.
+
+`/dls_sw/work/` is the unreleased tree (edit here); `/dls_sw/prod/` is the
+released equivalent (read-only).
+
+**EPICS version varies per beamline.** `R3.14.12.7` is currently the most
+common, but older beamlines may still live under `R3.14.11`, `R3.14.12.3`,
+`R3.14.8.2`, etc., and newer / RTEMS-based ones under `R7.0.7`. Don't hard-code
+the version — discover it:
+
+```bash
+ls -d /dls_sw/{work,prod}/R*/ioc/BLxxI/BL 2>/dev/null
+```
+
+Pick the most recent / actively-modified tree (check mtimes on the `edl/`
+directory if there are several).
+
+---
+
+## Key screens
+
+| File | Purpose |
+|---|---|
+| `BLxxI-hardware-status.edl` | Top-level synoptic for the beamline |
+| `BLxxI-ioc-status-embed.edl` | Per-IOC rows; embedded in hardware-status via `activePipClass` |
+
+The hardware-status screen embeds the ioc-status-embed via `displayFileName`.
+
+---
+
+## How a row is laid out
+
+EDM is positional. A row of buttons shares a single `y` coordinate; the row's
+human-readable name is a `(Static Text)` object at the same y on the left.
+Buttons sit at increasing `x`. **Object order in the file does not follow
+visual order — match by coordinates, not file position.**
+
+Typical row (left to right):
+
+| Element | Class | Real wiring lives in |
+|---|---|---|
+| Row label | `activeXTextClass` | `value { "Merlin 01 IOC" }` — cosmetic |
+| IOC button | `relatedDisplayClass` | `displayFileName: ioc_stats_soft`, `symbols: ioc=$(dom)-XX-IOC-NN` |
+| Traffic light | `activeSymbolClass` | `controlPvs: <IOC>:LOAD.SEVR` |
+| Terminal | `shellCmdClass` | `command: gnome-terminal -x console <IOC>` |
+| Start/Stop | `relatedDisplayClass` | `procServControl.edl`, `symbols: procServ=<IOC>` |
+| PC | `shellCmdClass` | `command: dls-remote-desktop.sh ... <hostname>` |
+| Save/Restore icon | `relatedDisplayClass` | `save_restoreStatus_more`, `symbols: P=<IOC>` |
+
+`$(dom)` is the beamline domain macro (e.g. `BL20I`), substituted at runtime.
+
+---
+
+## Finding the code behind a visible button
+
+1. Grep the row's static-text label (the name shown on screen):
+   ```bash
+   grep -n '"Merlin 02 IOC"' BLxxI-ioc-status-embed.edl
+   ```
+2. Read around the hit to find the row's `y` coordinate.
+3. Grep `buttonLabel` (or the action class — `shellCmdClass`, `relatedDisplayClass`)
+   and look for objects with the same y — those are the buttons in that row.
+
+Don't trust `buttonLabel` text alone: the visible label and the actual target
+in `command` / `symbols` can disagree. That mismatch is the "wrong PC" bug class.
+
+---
+
+## Wiring/label mismatch (the wrong-target bug)
+
+Each PC / Terminal / Start-Stop button has a `command` string (or `symbols`
+substitution) naming the real target. The visible label is decorative. When
+a button "opens the wrong thing", the fix is in `command` or `symbols`, not
+in the label or the static text next to it.
+
+Two buttons that target swapped hosts get fixed by swapping the `command`
+strings — coordinates, colours, and labels stay put.
+
+---
+
+## Editing rules
+
+- Edit `BLxxIApp/opi/edl/<file>.edl` — never `data/<file>.edl` (deployed
+  output, overwritten on build).
+- Never touch `*.edl~` (EDM autosave).
+- When swapping wiring between rows, preserve x/y/colours/labels; change only
+  the `command` / `symbols` lines.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,7 @@
 # Changes here will be overwritten by Copier
-_commit: 5.0.2
+_commit: 5.0.3-3-gd645eb3
 _src_path: gh:diamondlightsource/python-copier-template
+add_claude: true
 author_email: giles.knap@diamond.ac.uk
 author_name: Giles Knap
 description: Conversion tool for DLS XML builder IOC instances to ibek ioc.yaml
@@ -9,6 +10,8 @@ docker: false
 docs_type: sphinx
 git_platform: github.com
 github_org: epics-containers
+install_gh: true
+install_glab: true
 package_name: builder2ibek
 pypi: true
 repo_name: builder2ibek

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,8 @@
         "VSCODE_GIT_ASKPASS_MAIN": "",
         "VSCODE_GIT_ASKPASS_NODE": "",
         "VSCODE_GIT_ASKPASS_EXTRA_ARGS": "",
+        // Mark this shell as running inside the devcontainer
+        "IN_DEVCONTAINER": "1",
         // Put things that allow it in the persistent cache
         "PRE_COMMIT_HOME": "/cache/pre-commit",
         "UV_CACHE_DIR": "/cache/uv",
@@ -61,8 +63,8 @@
                 "streetsidesoftware.code-spell-checker",
                 "moshfeu.compare-folders",
                 "nsd.vscode-epics",
-                "anthropic.claude-code",
-                "github.copilot-chat"
+                "ms-azuretools.vscode-docker",
+                "anthropic.claude-code"
             ]
         }
     },

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -8,4 +8,6 @@ curl -fsSL https://claude.ai/install.sh | bash
 uv venv --clear
 uv sync
 pre-commit install --install-hooks
-git submodule update --init
+
+# Initialise git submodules if any are declared
+[ -f .gitmodules ] && git submodule update --init || true

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -8,9 +8,9 @@ set -euo pipefail
 git config --global credential.helper ''
 git config --global --unset-all url.ssh://git@github.com/.insteadOf 2>/dev/null || true
 
-# Force all GitHub SSH URLs to use HTTPS so the gh credential helper handles
-# auth. This keeps the container SSH-key-free (Claude stays sandboxed) while
-# still allowing push/pull on repos whose remotes are set to git@github.com:.
+# Force all SSH-style remotes to use HTTPS so the gh/glab credential helpers
+# handle auth. This keeps the container SSH-key-free (Claude stays sandboxed)
+# while still allowing push/pull on repos whose remotes are set to git@...:.
 git config --global url."https://github.com/".insteadOf "git@github.com:"
 git config --global url."https://gitlab.diamond.ac.uk/".insteadOf "git@gitlab.diamond.ac.uk:"
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,4 +24,4 @@ It is recommended that developers use a [vscode devcontainer](https://code.visua
 
 This project was created using the [Diamond Light Source Copier Template](https://github.com/DiamondLightSource/python-copier-template) for Python projects.
 
-For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/5.0.2/how-to.html).
+For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/5.0.3/how-to.html).

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,29 @@
 ARG PYTHON_VERSION=3.13
 FROM ghcr.io/diamondlightsource/ubuntu-devcontainer:noble AS developer
 
-# install gh
+# Add any system dependencies for the developer/build environment here
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    graphviz \
+    && apt-get dist-clean
+
+# Node is required by Claude Code's hook runtime
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    nodejs \
+    && apt-get dist-clean
+
+# GitHub CLI — used by Claude to authenticate to github.com via PAT
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
-    tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh just && \
-    rm -rf /var/lib/apt/lists/*
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    apt-get dist-clean
+
+# GitLab CLI — used by Claude to authenticate to gitlab instances via PAT.
+# No apt repo, so install from the upstream release tarball.
+ARG GLAB_VERSION=1.92.1
+RUN curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+      | tar -xz -C /tmp bin/glab && \
+    install -m 0755 /tmp/bin/glab /usr/local/bin/glab && \
+    rm -rf /tmp/bin

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 A tool suite for converting DLS XMLbuilder IOC projects to
 [epics-containers](https://github.com/epics-containers) ibek.
 
-Source          | <https://github.com/epics-containers/builder2ibek>
+What            | Where
 :---:           | :---:
+Source          | <https://github.com/epics-containers/builder2ibek>
 PyPI            | `pip install builder2ibek`
 Documentation   | <https://epics-containers.github.io/builder2ibek>
 Releases        | <https://github.com/epics-containers/builder2ibek/releases>

--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+# Start Claude Code in sandbox mode (no SSH agent, skip permission prompts)
+claude:
+    SSH_AUTH_SOCK= IS_SANDBOX=1 claude --dangerously-skip-permissions
+
+
 # Authenticate gh CLI with a GitHub PAT (token not stored in shell history)
 gh-auth:
     #!/bin/bash
@@ -15,8 +20,3 @@ glab-auth hostname="gitlab.diamond.ac.uk":
     echo "$t" | glab auth login --stdin --hostname {{ hostname }} --git-protocol https
     unset t
     glab auth status
-
-
-# Start Claude Code in sandbox mode (uses container-local SSH agent only)
-claude:
-    SSH_AUTH_SOCK= IS_SANDBOX=1 claude --dangerously-skip-permissions --chrome

--- a/src/builder2ibek/converters/insertionDevice.py
+++ b/src/builder2ibek/converters/insertionDevice.py
@@ -1,0 +1,17 @@
+from builder2ibek.converters.globalHandler import globalHandler
+from builder2ibek.types import Entity, Generic_IOC
+
+xml_component = "insertionDevice"
+
+
+@globalHandler
+def handler(entity: Entity, entity_type: str, ioc: Generic_IOC):
+    """
+    XML to YAML converter for the insertionDevice support module.
+    """
+
+    entity.remove("name")
+
+    if entity_type == "insertionDevice4V_generic_DTTemplate":
+        if hasattr(entity, "comptable"):
+            entity.comptable = str(entity.comptable)


### PR DESCRIPTION
## Summary
- Migrate the project skeleton to `python-copier-template` (devcontainer, Dockerfile, justfile, postCreate/postStart, contributing docs).
- Add a `beamline-gui` skill for locating, reading, and editing DLS beamline `.edl` files.
- Add an `insertionDevice` converter (drops leaf `name`, coerces `comptable` to str) plus a new `ibek-support-dls/insertionDevice/` support YAML covering the four AutoSubstitution templates used by idlab-builder TS99 IOCs.
- `/ioc-convert` skill: add a Phase 5c step to refresh the global schema at `/epics/ibek-defs` after a run so the editor stops flagging newly-added entity types as unknown.

## Test plan
- [ ] `uv run pytest` passes locally
- [ ] Devcontainer rebuilds cleanly from `.devcontainer/`
- [ ] `pre-commit run --all-files` passes
- [ ] `/ioc-convert` on a fresh builder XML completes end-to-end and leaves the editor schema in a clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)