### PR TITLE
Record what vdct2template cannot convert, and script the workflow

### DIFF
--- a/.claude/skills/vdct-conversion/SKILL.md
+++ b/.claude/skills/vdct-conversion/SKILL.md
@@ -218,6 +218,21 @@ currAmpSingle.template:  $(name)
 Then copy the `.template` files into the pattern folder and author the
 `*.ibek.support.yaml`.
 
+### Picking the release — neither `ls -t` nor `sort -V` is safe
+
+A module lives under several EPICS releases (`/dls_sw/prod/R3.14.11/...`,
+`R3.14.12.3`, `R3.14.12.7`), and "latest in prod" means the newest *version
+directory under the newest EPICS release* — usually `R3.14.12.7`. Taking the
+first `/dls_sw/prod/*/support/<mod>` glob hit gives you `R3.14.11`, which for
+OXCS700 is 2-4 against a real latest of 2-22.
+
+Within a release, DLS version dirs use dashes (`2-13`), but strays exist:
+gardasoftLED has a mis-numbered `2.9` that `sort -V` ranks **after** `2-13`
+even though it predates it by 17 months. Check mtimes when the ordering looks
+odd — `ls -latr` on the module dir settles it, and `ls -1t` is wrong in the
+other direction because it also ranks `.tar.gz` archives and whatever was last
+touched.
+
 ### Worked example — currAmp 1-45 (validated)
 
 | File | Role | Outcome |
@@ -234,6 +249,71 @@ Then 9 annotation-only macros across 4 files get `=` defaults (listed above), an
 `currAmp.template` is dropped — `Db/Makefile` never installs it, so it is build-time
 only. Result: 6 entity models, 8 shipped templates, proved identical to the VDCT
 build (section 6c).
+
+### Driver scripts
+
+`convert-module.sh <module> <dls-dir> <out>` runs the whole of section 4 from a
+clean copy of the read-only DLS sources, then applies the per-module fixups in
+section 4a. `validate-module.sh` is section 6c, `macro-report.sh` derives the
+parameter set for section 5, and `make-test-ioc.py` builds the every-entity
+`ioc.yaml` that section 6a needs.
+
+---
+
+## 4a. What vdct2template cannot do
+
+Three failure modes the tool leaves for you. All three were found converting
+OXCryo / OXCS700 / gardasoftLED / microlab500, and each is silent — the tool
+exits 0 and writes plausible output.
+
+### Nested expansion loses the middle layer's `_` prefix
+
+`OXCB700.vdb` → `OXcommonCB.vdb` → `OXcommon.vdb`. A file that is *both* an
+include target and an expansion gets written twice: once by `Macros.process()`
+(reads the raw `.vdb`, applies the `_` prefix, leaves `expand()` intact), then
+again by the `Expansion` branch (converts `expand()`, no `_` prefix). The
+second write wins, so the parent substitutes `_CTEMP_DRVL` while the child
+still reads `$(CTEMP_DRVL)`.
+
+You cannot fix it by prefixing again — both levels would want `_CTEMP_DRVL` and
+`substitute "_CTEMP_DRVL=$(_CTEMP_DRVL)"` is a msi self-reference. When the
+middle layer passes the macro straight through unchanged, just **delete its
+`substitute` lines**: the grandparent's substitution is still in scope when the
+grandchild is included one level down.
+
+### VDCT instance-port references are left as literal macros
+
+`field(LNK3, "$(microlab500Right.STARTUP).PROC")` with
+`#! TemplateField("microlab500Right","STARTUP",...)` means "the record bound to
+the STARTUP port of that expand instance". VisualDCT resolves it at flatten
+time; vdct2template treats `microlab500Right.STARTUP` as an ordinary macro name
+and msi then reports it undefined.
+
+Resolve by hand to the name the include produces — the child names the record
+`$(_P)$(_R):$(_SIDE):STARTUP` and the parent passes `_SIDE=RIGHT`, so it is
+`$(P)$(R):RIGHT:STARTUP`. Find them with:
+
+```bash
+grep -n '\$([A-Za-z_][A-Za-z0-9_]*\.[A-Za-z]' <Db>/*.vdb | grep -v ':#!'
+```
+
+Rare — 2 occurrences in the 4-module set, none in the other three modules.
+
+### A child that is *also* installed standalone must not get the `_` prefix
+
+`Db/Makefile` installs `PP600SeriesChannel.template` **and** `PP612LED.vdb`
+expands it twice. Prefixed, the standalone entity breaks; unprefixed, the
+include breaks — unless the parent passes literals, which is the common case
+(`macro(N,"1")`, `macro(N,"2")`).
+
+The `_` prefix is only needed when the passed *value* references the same macro
+name (`macro(N,"$(N=1)")` → a self-referential `substitute`). With literals,
+drop the prefix and the one file serves both roles: an msi `substitute` beats a
+value supplied from the substitution file, verified with a hostile `-M N=99`
+against `PP612LED.template` — channels still came out `CH1`/`CH2`.
+
+Detect the case with `comm -12` between the `DB +=` list in `Db/Makefile` and
+the set of `expand()` targets.
 
 ---
 

--- a/.claude/skills/vdct-conversion/convert-module.sh
+++ b/.claude/skills/vdct-conversion/convert-module.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Convert one DLS VDCT support module's Db sources to msi-native templates.
+#
+#   convert-module.sh <module> <dls-module-dir> <out-dir>
+#
+# Implements section 4 of the vdct-conversion skill, plus the two fixups that
+# vdct2template cannot do itself (see FIXUPS below).  Re-runnable: it always
+# starts from a clean copy of the read-only DLS sources.
+set -euo pipefail
+
+MOD=$1
+SRC=$2
+OUT=$3
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+rm -rf "$OUT"; mkdir -p "$OUT"
+find "$SRC" -maxdepth 3 -path '*App/Db/*' \
+     \( -name '*.vdb' -o -name '*.template' -o -name '*.db' \) \
+     -exec cp {} "$OUT"/ \;
+chmod u+w "$OUT"/*
+
+bash "$HERE/rename-vdct-orphans.sh" "$OUT" > "$OUT/.renames"
+PYTHONPATH=$HERE uv run --no-project --with typer --with typing_extensions \
+    python -m vdct2template --no-use-builder "$OUT" > "$OUT/.convert.log" 2>&1 \
+    || { cat "$OUT/.convert.log"; exit 1; }
+
+# drop the now-redundant VDCT sources
+for v in "$OUT"/*.vdb; do
+    [ -f "${v%.vdb}.template" ] && rm "$v" || echo "KEEP (no .template): $v"
+done
+
+# ---------------------------------------------------------------- FIXUPS ----
+case "$MOD" in
+OXCryo)
+    # Nested expansion: OXCB700/OXCB800/OXNH700 -> OXcommonCB -> OXcommon.
+    # vdct2template writes a middle-layer file twice and the second write (as
+    # an Expansion) loses the `_` prefix its parents substitute with.  Both
+    # levels pass CTEMP_DRVL/CTEMP_DRVH straight through unchanged, so the
+    # middle layer's re-substitution is redundant *and* would be a msi
+    # self-reference (`_CTEMP_DRVL=$(_CTEMP_DRVL)`).  Delete it: the parent's
+    # `substitute "_CTEMP_DRVL=..."` is still in scope when OXcommon.template
+    # is included one level down.
+    sed -i '/^substitute "_CTEMP_DRV[LH]=\$(CTEMP_DRV[LH])"$/d' \
+        "$OUT/OXcommonCB.template"
+    ;;
+gardasoftLED)
+    # PP600SeriesChannel.template has two roles: DLS installs it standalone
+    # (Db/Makefile) *and* PP612LED expands it twice.  vdct2template's `_`
+    # prefix would make the standalone form unusable.  The prefix is only
+    # needed when the parent passes a value that references the same macro
+    # name; here the parent passes literals (N=1, N=2), and a `substitute`
+    # beats a global -M/subst value, so the unprefixed name is safe for both.
+    sed -i 's/^substitute "_N=/substitute "N=/' "$OUT/PP612LED.template"
+    sed -i 's/\$(_N)/$(N)/g' "$OUT/PP600SeriesChannel.template"
+    ;;
+microlab500)
+    # VDCT instance-port references.  `$(microlab500Left.STARTUP)` means "the
+    # record bound to the STARTUP port of the microlab500Left expand instance";
+    # VisualDCT resolves it at flatten time, vdct2template leaves it alone.
+    # The child names that record "$(_P)$(_R):$(_SIDE):STARTUP" and the parent
+    # expands it with _SIDE=LEFT / _SIDE=RIGHT.
+    sed -i -e 's|\$(microlab500Left\.STARTUP)|$(P)$(R):LEFT:STARTUP|g' \
+           -e 's|\$(microlab500Right\.STARTUP)|$(P)$(R):RIGHT:STARTUP|g' \
+        "$OUT/microlab500whole.template"
+    ;;
+esac
+# -----------------------------------------------------------------------------
+
+bash "$HERE/default-annotation-macros.sh" "$OUT" > "$OUT/.defaults"
+
+# assert no VDCT syntax survived and no source was left behind
+if grep -l '^#!\|^ *expand(\|^template() {' "$OUT"/*.template 2>/dev/null; then
+    echo "ERROR: VDCT syntax survives in $MOD" >&2; exit 1
+fi
+if ls "$OUT"/*.vdb >/dev/null 2>&1; then
+    echo "ERROR: unconverted .vdb left in $MOD" >&2; exit 1
+fi
+echo "$MOD: converted $(ls "$OUT"/*.template | wc -l) templates"

--- a/.claude/skills/vdct-conversion/macro-report.sh
+++ b/.claude/skills/vdct-conversion/macro-report.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Report the entity-model parameter set for each installed template.
+#
+#   macro-report.sh <converted-dir> <template> [<template> ...]
+#
+# Walks the msi include closure, then splits the macros a caller must supply
+# from those the templates default themselves.  `_`-prefixed macros are
+# supplied by the parent's `substitute` and are never parameters.
+set -uo pipefail
+DIR=$1; shift
+
+closure() {   # emit this template and everything it includes, transitively
+    local t=$1
+    echo "$t"
+    grep -ho '^include *"[^"]*"' "$DIR/$t" 2>/dev/null \
+        | sed 's/include *"//;s/"//' | while read -r c; do closure "$c"; done
+}
+
+for t in "$@"; do
+    files=$(closure "$t" | sort -u)
+    echo "=== $t   [closure: $(echo $files | tr '\n' ' ')]"
+
+    all=$(cd "$DIR" && cat $files | grep -o '\$([A-Za-z_][A-Za-z0-9_]*[^)]*)')
+    # macros the parent supplies itself via `substitute` are not parameters
+    subst=$(cd "$DIR" && cat $files | grep -ho '^substitute *"[A-Za-z_][A-Za-z0-9_]*=' \
+        | sed 's/substitute *"//;s/=$//' | sort -u)
+    # names appearing at least once with no default
+    req=$(echo "$all" | grep -v '=' | sed 's/\$(//;s/)//' | grep -v '^_' | sort -u)
+    req=$(comm -23 <(echo "$req") <(echo "$subst"))
+    # names that always carry a default
+    defd=$(echo "$all" | grep '=' | sed 's/\$(//;s/[=)].*//' | grep -v '^_' | sort -u)
+    defd=$(comm -23 <(echo "$defd") <(echo "$req"))
+
+    echo "  required: $(echo $req)"
+    echo "  defaulted: $(echo $defd)"
+    echo "  docs:"
+    (cd "$DIR" && cat $files) | grep -h '^# *% *macro,' | sed 's/^# *% *macro, */    /' | sort -u
+    echo
+done

--- a/.claude/skills/vdct-conversion/make-test-ioc.py
+++ b/.claude/skills/vdct-conversion/make-test-ioc.py
@@ -1,0 +1,38 @@
+"""Emit an ioc.yaml instantiating every entity model in a pattern's support yaml.
+
+make-test-ioc.py <pattern-dir> > <config-dir>/ioc.yaml
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+pattern = Path(sys.argv[1])
+support = next(pattern.glob("*.ibek.support.yaml"))
+defs = yaml.safe_load(support.read_text())
+module = defs["module"]
+
+DUMMY = {"str": "TEST", "int": 1, "float": 1.0, "bool": True, "id": None}
+
+entities = []
+for n, model in enumerate(defs["entity_models"]):
+    e = {"type": f"{module}.{model['name']}"}
+    for pname, p in (model.get("parameters") or {}).items():
+        if "default" in p:
+            continue
+        t = p.get("type", "str")
+        # ids must be unique across the IOC
+        e[pname] = f"{model['name']}{n}" if t == "id" else DUMMY.get(t, "TEST")
+    entities.append(e)
+
+print(
+    yaml.safe_dump(
+        {
+            "ioc_name": f"test-{module}",
+            "description": "schema check",
+            "entities": entities,
+        },
+        sort_keys=False,
+    )
+)

--- a/.claude/skills/vdct-conversion/validate-module.sh
+++ b/.claude/skills/vdct-conversion/validate-module.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Prove a converted module is semantically identical to the DLS VDCT build.
+#
+#   validate-module.sh <module> <dls-module-dir> <converted-dir>
+#
+# For every template DLS installs into db/, expand both sides with the same
+# macro values and compare canonical (sorted record -> sorted field) sets.
+# This is section 6c of the vdct-conversion skill.
+set -uo pipefail
+
+MOD=$1
+SRC=$2
+NEW=$3
+HERE=$(cd "$(dirname "$0")" && pwd)
+MSI=${MSI:-/dls_sw/epics/R7.0.7/base/bin/linux-x86_64/msi}
+TMP=$(mktemp -d)
+
+fail=0
+for dls in "$SRC"/db/*.template; do
+    t=$(basename "$dls")
+    if [ ! -f "$NEW/$t" ]; then
+        echo "MISSING in conversion: $t"; fail=1; continue
+    fi
+
+    # every macro named on either side, with defaults stripped
+    macros=$( { cat "$dls" "$NEW/$t"; } \
+        | grep -o '\$([A-Za-z_][A-Za-z0-9_]*[^)]*)' \
+        | sed 's/[=)].*//;s/\$(//' | sort -u | grep -v '^_' )
+    m=$(for x in $macros; do printf '%s=<%s>,' "$x" "$x"; done)
+
+    ( cd "$SRC/db" && $MSI -I. -M "${m%,}" "$t" ) > "$TMP/$t.dls.db" 2> "$TMP/$t.dls.err"
+    ( cd "$NEW"     && $MSI -I. -M "${m%,}" "$t" ) > "$TMP/$t.new.db" 2> "$TMP/$t.new.err"
+
+    if [ -s "$TMP/$t.new.err" ]; then
+        echo "MSI ERROR ($t): $(head -2 "$TMP/$t.new.err" | tr '\n' ' ')"; fail=1; continue
+    fi
+    # unresolved macros on the new side are a conversion bug
+    if grep -qo '\$([A-Za-z_][^)]*)' "$TMP/$t.new.db"; then
+        echo "UNRESOLVED ($t): $(grep -o '\$([A-Za-z_][^)]*)' "$TMP/$t.new.db" | sort -u | tr '\n' ' ')"
+        fail=1
+    fi
+
+    for side in dls new; do
+        uv run --no-project python "$HERE/canon-db.py" "$TMP/$t.$side.db" > "$TMP/$t.$side.canon"
+    done
+
+    if diff -q "$TMP/$t.dls.canon" "$TMP/$t.new.canon" > /dev/null; then
+        echo "OK      $t  ($(grep -c '^record\|^[a-z]* ' "$TMP/$t.new.canon" 2>/dev/null || echo ?) records)"
+    else
+        echo "DIFFERS $t"
+        diff "$TMP/$t.dls.canon" "$TMP/$t.new.canon" | head -20
+        fail=1
+    fi
+done
+echo "canon dir: $TMP"
+exit $fail


### PR DESCRIPTION
Follow-up to #113. Converting the four `ibek-runtime-streamdevice` patterns that had lost their VDCT sub-template hierarchy (`OXCryo`, `OXCS700`, `gardasoftLED`, `microlab500`) turned up gaps in the skill, and left behind a workflow worth keeping.

## Three things vdct2template gets wrong silently

Each exits 0 and writes plausible output. New section 4a documents them with the fix for each.

| | symptom | fix |
|---|---|---|
| **Nested expansion** | `OXCB700 → OXcommonCB → OXcommon`. The middle file is written twice; the second write drops the `_` prefix its parent substitutes with, so the parent sets `_CTEMP_DRVL` while the child reads `$(CTEMP_DRVL)` | delete the middle layer's pass-through `substitute` lines — re-prefixing is impossible because both levels want `_CTEMP_DRVL`, and `substitute "_CTEMP_DRVL=$(_CTEMP_DRVL)"` is a msi self-reference |
| **VDCT instance-port refs** | `$(microlab500Right.STARTUP)` survives as a literal macro name; VisualDCT resolves it at flatten time, msi reports it undefined | resolve to the record name the include produces, `$(P)$(R):RIGHT:STARTUP` |
| **Dual-role child** | `PP600SeriesChannel.template` is both installed standalone and expanded twice by `PP612LED`; prefixed the standalone entity breaks, unprefixed the include breaks | when the parent passes literals, drop the prefix — a `substitute` beats a value from the substitution file (verified with a hostile `-M N=99`) |

## Picking the release

Neither `ls -t` nor `sort -V` is safe. `/dls_sw/prod/*/support/<mod>` glob order gives you the *oldest* EPICS release, and DLS version dirs occasionally stray from the dashed convention — `gardasoftLED/2.9` sorts after `2-13` but predates it by 17 months, which is how one pattern ended up pinned to a stale release.

## Scripted workflow

The conversion is now re-runnable against a newer release rather than a one-off, which is what the `ibek-runtime-streamdevice` README's "reproducible derivation" rule asks for:

| script | section |
|---|---|
| `convert-module.sh` | 4 + 4a, from a clean copy of the read-only DLS sources |
| `validate-module.sh` | 6c, canonical record/field equivalence against the DLS VDCT build |
| `macro-report.sh` | 5, parameter set over the msi include closure |
| `make-test-ioc.py` | 6a, an `ioc.yaml` instantiating every entity model |

Together they proved all 20 templates across the four modules expand to record/field sets identical to DLS's VDCT build, with `ibek runtime generate2` clean and zero undefined macros under msi.

The corresponding `ibek-runtime-streamdevice` changes are not yet raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooling to convert DLS support modules into templates.
  - Added macro reports showing required, defaulted, and documented macros.
  - Added test IOC generation with entity models, defaults, and sample values.
  - Added validation that compares converted templates and detects missing files, conversion errors, and unresolved macros.

- **Documentation**
  - Added guidance for selecting module releases and handling known conversion edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->