### PR TITLE
autosave: emit one PV per req line, not several per line

### DIFF
--- a/.claude/skills/shared/autosave-conversion.md
+++ b/.claude/skills/shared/autosave-conversion.md
@@ -65,12 +65,15 @@ differs (3.14 lands `.HIGH=60`, RTEMS lands `.HIGH=0`).
 ### The fix: autosave the FIELD, not the readback record
 `.HIGH` (the field) holds a value fine on both platforms — so save/restore *it*:
 ```
-# dlsPLC_temperature_settings.req  (note: <record> <field>, dot-field of the temp record)
+# dlsPLC_temperature_settings.req  (note: <record>.<field>, dot-field of the temp record)
 # from
-$(device)$(temp):HIGH VAL      # the :HIGH ai record — futile on EPICS 7
+$(device)$(temp):HIGH          # the :HIGH ai record — futile on EPICS 7
 # to
-$(device)$(temp) HIGH          # the <temp>.HIGH alarm-limit field — the real limit
+$(device)$(temp).HIGH          # the <temp>.HIGH alarm-limit field — the real limit
 ```
+The dot is not optional — see [req file syntax](#req-file-syntax-one-pv-per-line)
+below. `$(device)$(temp) HIGH` (space) silently saves `$(device)$(temp).VAL`
+instead, i.e. the temperature reading rather than its alarm limit.
 With `.HIGH` restored directly, `HIGH_INIT`/`:HIGH` become harmless leftovers
 (restore lands on `.HIGH`; `:HIGH` mirrors it via `CP`). It's the **req file**
 that fixes the live IOC — **no template logic change is required**. Two riders:
@@ -87,6 +90,33 @@ A readback record that mirrors a field via `CP`/`CPP` is **not autosave-able on
 EPICS 7** — restore the underlying field. Fingerprint: a put to the readback PV
 reads straight back as the field's value; one alarm-limit sibling holds (`:HIHI`,
 a plain `ao`) while the readback one (`:HIGH`) collapses to 0.
+
+---
+
+## Req file syntax: one PV per line
+
+autosave's `readReqFile()` (`asApp/src/save_restore.c`) parses each line with
+
+```c
+sscanf(eline, "%s", name);
+```
+
+so it takes **only the first whitespace delimited token and silently discards
+the rest of the line** — no warning, no error, the extra fields simply never get
+saved. A line must therefore name exactly one PV:
+
+```
+$(P)$(R).CALC        # correct — one line per field
+$(P)$(R).SCAN
+$(P)$(R) CALC SCAN   # WRONG — saves $(P)$(R).VAL only; CALC and SCAN are dropped
+```
+
+`VAL` is written as the bare record name (`$(P)$(R)`), which is the same PV and
+the spelling `builder2ibek migrate-autosave` uses in the `.sav` files.
+
+This is what `builder2ibek autosave` emits, so **regenerate rather than
+hand-edit**; `db2autosave.write_req_file()` carries the same note. A `#% autosave
+N` comment listing several fields expands to one line per field.
 
 ---
 

--- a/.claude/skills/shared/autosave-conversion.md
+++ b/.claude/skills/shared/autosave-conversion.md
@@ -101,11 +101,11 @@ autosave's `readReqFile()` (`asApp/src/save_restore.c`) parses each line with
 sscanf(eline, "%s", name);
 ```
 
-so it takes **only the first whitespace delimited token and silently discards
+so it takes **only the first whitespace-delimited token and silently discards
 the rest of the line** — no warning, no error, the extra fields simply never get
 saved. A line must therefore name exactly one PV:
 
-```
+```text
 $(P)$(R).CALC        # correct — one line per field
 $(P)$(R).SCAN
 $(P)$(R) CALC SCAN   # WRONG — saves $(P)$(R).VAL only; CALC and SCAN are dropped

--- a/src/builder2ibek/db2autosave.py
+++ b/src/builder2ibek/db2autosave.py
@@ -8,12 +8,32 @@ regex_autosave = [
 
 
 def write_req_file(f: Path, record_set: set[str]):
+    """
+    Write an autosave request file, one PV per line.
+
+    Each record_set entry is "recordname [FIELD ...]": the record name followed
+    by the fields listed on its `#% autosave` comment. autosave's readReqFile()
+    parses a line with `sscanf(line, "%s", name)`, so it takes only the first
+    whitespace delimited token and silently discards the rest -- a line holding
+    several fields saves the record's .VAL and nothing else. Each field
+    therefore needs its own `recordname.FIELD` line.
+
+    VAL is written as the bare record name: the same PV, and the spelling
+    migrate_autosave uses in the .sav files.
+    """
     print(f"writing file {f}")
 
-    # Each record_set entry is already a canonical autosave req line of the form
-    # "recordname FIELD [FIELD ...]" (space separated). Write one per line,
-    # sorted for deterministic output.
-    f.write_text("\n".join(sorted(record_set)) + "\n")
+    lines: set[str] = set()
+    for entry in record_set:
+        record, *fields = entry.split() or [""]
+        if not record:
+            continue
+        if not fields:
+            lines.add(record)
+        for field in fields:
+            lines.add(record if field == "VAL" else f"{record}.{field}")
+
+    f.write_text("\n".join(sorted(lines)) + "\n")
 
 
 def parse_templates(out_folder: Path, db_list: list[Path]):

--- a/src/builder2ibek/db2autosave.py
+++ b/src/builder2ibek/db2autosave.py
@@ -14,15 +14,17 @@ def write_req_file(f: Path, record_set: set[str]):
     Each record_set entry is "recordname [FIELD ...]": the record name followed
     by the fields listed on its `#% autosave` comment. autosave's readReqFile()
     parses a line with `sscanf(line, "%s", name)`, so it takes only the first
-    whitespace delimited token and silently discards the rest -- a line holding
+    whitespace-delimited token and silently discards the rest -- a line holding
     several fields saves the record's .VAL and nothing else. Each field
     therefore needs its own `recordname.FIELD` line.
 
     VAL is written as the bare record name: the same PV, and the spelling
     migrate_autosave uses in the .sav files.
-    """
-    print(f"writing file {f}")
 
+    Writes nothing if the expansion is empty. Joining an empty set and
+    appending the terminator would yield a file holding one blank line, which
+    is a line naming no PV at all.
+    """
     lines: set[str] = set()
     for entry in record_set:
         record, *fields = entry.split() or [""]
@@ -33,6 +35,11 @@ def write_req_file(f: Path, record_set: set[str]):
         for field in fields:
             lines.add(record if field == "VAL" else f"{record}.{field}")
 
+    if not lines:
+        print(f"no PVs to save, skipping {f}")
+        return
+
+    print(f"writing file {f}")
     f.write_text("\n".join(sorted(lines)) + "\n")
 
 

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-from builder2ibek.db2autosave import parse_templates
+from builder2ibek.db2autosave import parse_templates, write_req_file
 
-MOTOR = Path("tests/samples/motor.template")
+MOTOR = Path(__file__).parent / "samples" / "motor.template"
 
 
 def test_autosave(tmp_path: Path):
@@ -28,7 +28,7 @@ def test_autosave(tmp_path: Path):
 
 def test_autosave_one_pv_per_line(tmp_path: Path):
     """
-    autosave's readReqFile() reads only the first whitespace delimited token of
+    autosave's readReqFile() reads only the first whitespace-delimited token of
     a line and silently drops the rest, so a req line must hold exactly one PV.
     """
     output = tmp_path / "autosave"
@@ -43,3 +43,18 @@ def test_autosave_one_pv_per_line(tmp_path: Path):
         assert text.endswith("\n"), f"{req_file.name} has no trailing newline"
         for line in text.splitlines():
             assert len(line.split()) == 1, f"{req_file.name}: multi-PV line {line!r}"
+
+
+def test_autosave_empty_expansion_writes_nothing(tmp_path: Path):
+    """
+    A record_set that expands to no PVs must not leave a req file behind.
+
+    Joining an empty set and appending the terminator writes a single blank
+    line, i.e. a line naming no PV -- which breaks the invariant asserted by
+    test_autosave_one_pv_per_line above.
+    """
+    req_file = tmp_path / "empty_settings.req"
+
+    write_req_file(req_file, {"", "   "})
+
+    assert not req_file.exists()

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,16 +1,45 @@
-import shutil
 from pathlib import Path
 
 from builder2ibek.db2autosave import parse_templates
 
+MOTOR = Path("tests/samples/motor.template")
 
-def test_autosave():
-    conversion_samples = [
-        Path("tests/samples/motor.template"),
-    ]
 
-    output = Path("/tmp/autosave")
-    shutil.rmtree(output, ignore_errors=True)
+def test_autosave(tmp_path: Path):
+    output = tmp_path / "autosave"
     output.mkdir()
 
-    parse_templates(output, conversion_samples)
+    parse_templates(output, [MOTOR])
+
+    positions = (output / "motor_positions.req").read_text().splitlines()
+    settings = (output / "motor_settings.req").read_text().splitlines()
+
+    # "#% autosave 0 DVAL OFF" -> one line per field
+    assert positions == ["$(P)$(M).DVAL", "$(P)$(M).OFF"]
+
+    # "#% autosave 1 DIR DHLM ... MDEL" -> one line per field
+    assert "$(P)$(M).DIR" in settings
+    assert "$(P)$(M).MDEL" in settings
+
+    # "#% autosave 1 VAL" -> the bare record name
+    assert "$(P)$(M):FERRORMAX" in settings
+    assert "$(P)$(M):FERRORMAX.VAL" not in settings
+
+
+def test_autosave_one_pv_per_line(tmp_path: Path):
+    """
+    autosave's readReqFile() reads only the first whitespace delimited token of
+    a line and silently drops the rest, so a req line must hold exactly one PV.
+    """
+    output = tmp_path / "autosave"
+    output.mkdir()
+
+    parse_templates(output, [MOTOR])
+
+    req_files = sorted(output.glob("*.req"))
+    assert req_files, "no req files written"
+    for req_file in req_files:
+        text = req_file.read_text()
+        assert text.endswith("\n"), f"{req_file.name} has no trailing newline"
+        for line in text.splitlines():
+            assert len(line.split()) == 1, f"{req_file.name}: multi-PV line {line!r}"


### PR DESCRIPTION
## The bug

autosave's `readReqFile()` (`asApp/src/save_restore.c`) parses each request line with

```c
sscanf(eline, "%s", name);
```

It takes **only the first whitespace delimited token and silently discards the rest of the line** — no warning, no error, the remaining fields are simply never saved. Every req file shipped by DLS confirms the format, e.g. `/dls_sw/prod/R3.14.12.7/support/std/3-4-1/stdApp/Db/pid_control_settings.req`:

```
$(P)$(PID).INP
$(P)$(PID).OUTL
$(P)$(PID).VAL
```

`78b76d2` changed `write_req_file()` to emit `recordname FIELD [FIELD ...]` lines, so a `#% autosave` comment listing several fields produced a single line that autosave read as a bare record name — saving `.VAL` and dropping the rest. `userIO/calcout_settings.req` was losing 19 fields this way.

The commit before it (`6a7e830`) did split fields onto their own lines, but concatenated adjacent records with no separator (`$(P)$(M):FERRORMAX.VAL$(P)$(M).DIR`) — which is the bug `78b76d2` was fixing. This does both.

## The fix

One `recordname.FIELD` line per field, newline separated, sorted. `VAL` is written as the bare record name: the same PV, and the spelling `migrate-autosave` already uses in the `.sav` files.

## Skill doc

`.claude/skills/shared/autosave-conversion.md` prescribed `$(device)$(temp) HIGH` as the fix for the dlsPLC `:HIGH=0` bug. Under this parser that saves `$(device)$(temp).VAL` — the temperature reading, not the `.HIGH` alarm limit it was meant to restore. Corrected to `$(device)$(temp).HIGH`, and the one-PV-per-line rule is now documented with the `sscanf` reference.

**Worth checking what is actually deployed on the live dlsPLC IOCs — that fix may never have taken effect.**

## Tests

`tests/test_autosave.py` previously asserted nothing. It now checks the expansion of the sample template's `#% autosave` comments and asserts every generated line holds exactly one PV.

Companion PRs regenerate the affected req files in `ibek-support` and `ibek-support-dls`.

## Verification

`uv run pytest`: 41 passed, 10 failed. The 10 failures are `test_generate`/`test_convert` st.cmd mismatches that reproduce identically on unmodified `main` in this sandbox (verified with a control worktree at `origin/main` and both submodules pinned to the committed revisions) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autosave request generation for record fields, including correct handling of `.HIGH` and `VAL`.
  * Ensured each autosave request line contains exactly one process variable.
  * Skipped blank entries and preserved sorted output with a trailing newline.

* **Documentation**
  * Clarified autosave field syntax and request-file parsing behavior with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->