### PR TITLE
tests: skip only what needs ibek-support-dls, not the whole session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -6,8 +7,47 @@ import pytest
 from filelock import FileLock
 
 REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_SUPPORT = REPO_ROOT / "ibek-support"
 DLS_SUPPORT = REPO_ROOT / "ibek-support-dls"
+
+HAS_COMMUNITY_SUPPORT = any(COMMUNITY_SUPPORT.glob("*/*.ibek.support.yaml"))
 HAS_DLS_SUPPORT = any(DLS_SUPPORT.glob("*/*.ibek.support.yaml"))
+
+# entity models ibek provides itself, so they need no support repo
+BUILTIN_MODULES = {"ibek"}
+
+_MODULE_RE = re.compile(r"^module:\s*(\S+)", re.M)
+_ENTITY_TYPE_RE = re.compile(r"^\s*-?\s*type:\s*([A-Za-z0-9_-]+)\.", re.M)
+
+
+def _declared_modules(support: Path) -> set[str]:
+    """The module names declared by the support YAMLs in a support repo.
+
+    Note this is the `module:` key, not the folder name — they differ in case
+    for some modules.
+    """
+    modules = set()
+    for support_yaml in support.glob("*/*.ibek.support.yaml"):
+        match = _MODULE_RE.search(support_yaml.read_text())
+        if match:
+            modules.add(match.group(1))
+    return modules
+
+
+COMMUNITY_MODULES = _declared_modules(COMMUNITY_SUPPORT) | BUILTIN_MODULES
+
+
+def sample_needs_dls(sample_yaml: Path) -> bool:
+    """True if a sample uses any entity model ibek-support does not declare.
+
+    Such a model can only come from ibek-support-dls, so the sample cannot be
+    generated without that submodule. Derived from the sample rather than
+    hardcoded, so it stays correct as modules move between the two repos.
+    """
+    if not sample_yaml.exists():
+        return True
+    used = set(_ENTITY_TYPE_RE.findall(sample_yaml.read_text()))
+    return not used <= COMMUNITY_MODULES
 
 
 def _run_update_schema(tmp_path_factory):
@@ -27,16 +67,21 @@ def _run_update_schema(tmp_path_factory):
     assert result.returncode == 0, f"update-schema failed:\n{result.stderr}"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def update_schema(tmp_path_factory, worker_id):
-    """Regenerate the ibek schema before tests so support YAMLs stay in sync.
+@pytest.fixture(scope="session")
+def ibek_defs(tmp_path_factory, worker_id):
+    """Populate $EPICS_ROOT/ibek-defs from whichever support repos are present.
+
+    Only tests that run `ibek runtime generate2` need this, so it is requested
+    explicitly rather than being autouse — an autouse fixture that skips takes
+    the whole session with it, which is how this suite came to run zero tests
+    in CI while still reporting success.
 
     With pytest-xdist, every worker wants to run this — but they all write to
     the same $EPICS_ROOT/ibek-defs, so the classic xdist file-lock pattern
     runs it exactly once and lets the rest wait for the sentinel.
     """
-    if not HAS_DLS_SUPPORT:
-        pytest.skip("ibek-support-dls not available")
+    if not HAS_COMMUNITY_SUPPORT:
+        pytest.skip("no support submodules available to build ibek-defs from")
     if worker_id == "master":
         # non-xdist run: just do it
         _run_update_schema(tmp_path_factory)
@@ -52,6 +97,11 @@ def update_schema(tmp_path_factory, worker_id):
 requires_dls = pytest.mark.skipif(
     not HAS_DLS_SUPPORT,
     reason="ibek-support-dls submodule not available",
+)
+
+requires_support = pytest.mark.skipif(
+    not HAS_COMMUNITY_SUPPORT,
+    reason="ibek-support submodule not available",
 )
 
 

--- a/tests/test_file_conversion.py
+++ b/tests/test_file_conversion.py
@@ -12,14 +12,46 @@ import pytest
 
 from builder2ibek.convert import convert_file
 from builder2ibek.converters.epics_base import InterruptVector
-from tests.conftest import requires_dls
+from tests.conftest import (
+    HAS_COMMUNITY_SUPPORT,
+    requires_dls,
+    requires_support,
+    sample_needs_dls,
+)
 
 SAMPLES = Path(__file__).parent / "samples"
 SAMPLE_XMLS = sorted(SAMPLES.glob("*.xml"))
-SAMPLE_IDS = [x.stem for x in SAMPLE_XMLS]
+
+# Both conversion steps depend on the support repos: generate2 needs every
+# module a sample uses to be in ibek-defs, and xml2yaml consults the same YAMLs
+# via support_defaults to strip parameters that match a model's default. So
+# mark each sample with what it actually requires, rather than skipping the lot.
+SAMPLE_PARAMS = [
+    pytest.param(
+        xml,
+        marks=[requires_dls]
+        if sample_needs_dls(SAMPLES / f"{xml.stem.lower()}.yaml")
+        else [],
+        id=xml.stem,
+    )
+    for xml in SAMPLE_XMLS
+]
 
 
-@pytest.mark.parametrize("sample_xml", SAMPLE_XMLS, ids=SAMPLE_IDS)
+def test_support_submodule_present():
+    """Guard against the whole suite silently skipping.
+
+    Without ibek-support nearly every test below skips, which previously left
+    CI green while running nothing at all. Fail loudly instead.
+    """
+    assert HAS_COMMUNITY_SUPPORT, (
+        "ibek-support submodule not initialised — run "
+        "`git submodule update --init ibek-support`"
+    )
+
+
+@requires_support
+@pytest.mark.parametrize("sample_xml", SAMPLE_PARAMS)
 def test_convert(sample_xml: Path):
     """Test that xml2yaml produces the expected YAML for a sample XML."""
     expected_yaml = SAMPLES / f"{sample_xml.stem.lower()}.yaml"
@@ -32,9 +64,9 @@ def test_convert(sample_xml: Path):
     InterruptVector.reset()
 
 
-@requires_dls
-@pytest.mark.parametrize("sample_xml", SAMPLE_XMLS, ids=SAMPLE_IDS)
-def test_generate(sample_xml: Path):
+@requires_support
+@pytest.mark.parametrize("sample_xml", SAMPLE_PARAMS)
+def test_generate(sample_xml: Path, ibek_defs):
     """
     Test the full pipeline for a sample XML: XML → YAML → st.cmd + ioc.subst.
 


### PR DESCRIPTION
## CI has been testing nothing

`conftest.py` declared `update_schema` as an **autouse session fixture** that called `pytest.skip()` when `ibek-support-dls` was absent. An autouse session fixture that skips takes every test with it — and `ibek-support-dls` is precisely what CI cannot check out, since it lives on Diamond's internal GitLab.

From the CI run on the `fix-autosave-req-fields` branch:

```
============================= 51 skipped in 3.06s ==============================
```

Green tick, zero tests. Including the ~30 that touch neither submodule.

## Changes

- **`update_schema` → `ibek_defs`**, requested explicitly by the tests that run `generate2` instead of being autouse. A skip can no longer escape past the tests that actually need it.

- **`test_convert` and `test_generate` are parametrized per sample**, marked `requires_dls` only when that sample uses an entity model `ibek-support` does not declare. The set is *derived* by reading the `module:` key out of the support YAMLs rather than hardcoded, so it stays correct as modules move between the two repos — as `positioner` recently did, and note `terminalserver`/`terminalServer` differ only in case, so folder names would not have been a safe key.

- **A guard, `test_support_submodule_present`**, that fails loudly if `ibek-support` itself is missing — so a broken checkout can never again present as a green run of nothing.

## A finding worth flagging

`test_convert` needs the dls YAMLs too, not just `generate2`. `support_defaults.py:21` loads **every** `ibek-support*` YAML to strip parameters whose values match a model default, so `xml2yaml` output changes when a support repo is absent. I had assumed conversion was submodule-independent; running it proved otherwise, which is why dls-using samples are marked on both tests.

## Measured across three checkout states

| checkout | result |
|---|---|
| both submodules | 41 passed, 10 failed — **unchanged**; the 10 are stale samples that fail on `main` too |
| `ibek-support` only (**what CI has**) | **30 passed, 21 skipped, 0 failed** — was 0 run |
| neither | 21 passed, 29 skipped, 1 failed — the new guard fires |

The middle row now covers all 4 community-only samples end to end (`bl21i-mo-ioc-01`, `bl45p-mo-ioc-01`, `cross_ref_test`, `motorpositioner`), which is enough to have caught the `ibek-support` drift that left the samples stale in the first place.

## Not addressed here

The 10 stale-sample failures are a separate PR (regeneration), currently blocked on removing a duplicate `terminalServer` module from `ibek-support-dls`. The remaining dls coverage gap is the subject of two follow-ups you asked for: a vendored dls fixture snapshot, and a pin-drift guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling for community and DLS support availability.
  * Tests now identify which samples require DLS support and apply skips selectively.
  * Added checks to clearly report when required support is unavailable, preventing silent skips.
  * Updated conversion and generation tests to use the appropriate support definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->