### PR TITLE
Get CI green: colour-proof the --help test, move the ibek-support pin forward

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,19 +50,27 @@ def sample_needs_dls(sample_yaml: Path) -> bool:
     return not used <= COMMUNITY_MODULES
 
 
-def _run_update_schema(tmp_path_factory):
-    env = os.environ.copy()
-    # Use a temp dir when /epics is not writable (e.g. CI runners)
-    epics_root = Path(env.get("EPICS_ROOT", "/epics"))
-    if not os.access(epics_root.parent, os.W_OK) and not epics_root.exists():
-        tmpdir = tmp_path_factory.mktemp("epics")
-        env["EPICS_ROOT"] = str(tmpdir)
+def _epics_root(tmp_path_factory) -> Path:
+    """Where ibek-defs should be built.
+
+    Prefer $EPICS_ROOT (or /epics) when it is writable, as in the devcontainer.
+    Otherwise use a temp dir — but one derived from getbasetemp().parent, which
+    is the same path in every xdist worker, rather than mktemp(), which gives
+    each worker a directory of its own.
+    """
+    epics_root = Path(os.environ.get("EPICS_ROOT", "/epics"))
+    if not os.access(epics_root, os.W_OK):
+        epics_root = tmp_path_factory.getbasetemp().parent / "epics"
+        epics_root.mkdir(exist_ok=True)
+    return epics_root
+
+
+def _run_update_schema():
     result = subprocess.run(
         [str(REPO_ROOT / "update-schema")],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        env=env,
     )
     assert result.returncode == 0, f"update-schema failed:\n{result.stderr}"
 
@@ -82,15 +90,24 @@ def ibek_defs(tmp_path_factory, worker_id):
     """
     if not HAS_COMMUNITY_SUPPORT:
         pytest.skip("no support submodules available to build ibek-defs from")
+
+    # Export EPICS_ROOT rather than passing it to update-schema alone:
+    # test_generate runs `ibek runtime generate2` as a subprocess of its own,
+    # and that has to find the same ibek-defs. Setting it only for the
+    # update-schema call built the definitions into a directory nothing else
+    # could see, so generate2 fell back to /epics -- absent on a CI runner --
+    # and resolved only ibek's builtin models.
+    os.environ["EPICS_ROOT"] = str(_epics_root(tmp_path_factory))
+
     if worker_id == "master":
         # non-xdist run: just do it
-        _run_update_schema(tmp_path_factory)
+        _run_update_schema()
         return
     shared_tmp = tmp_path_factory.getbasetemp().parent
     done = shared_tmp / "schema.done"
     with FileLock(str(shared_tmp / "schema.lock")):
         if not done.exists():
-            _run_update_schema(tmp_path_factory)
+            _run_update_schema()
             done.touch()
 
 

--- a/tests/test_reconvert_cli.py
+++ b/tests/test_reconvert_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -129,7 +130,16 @@ def test_run_reconvert_missing_services_repo(tmp_path: Path):
 
 def test_cli_help():
     cmd = [sys.executable, "-m", "builder2ibek", "reconvert", "--help"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Typer renders --help through rich, which colours each option name. That
+    # splits "--services-repo" into escape-separated fragments, so a plain
+    # substring assert cannot find it. rich only colours when it thinks it has a
+    # terminal -- pytest's captured pipe is not one, but CI sets FORCE_COLOR,
+    # which is why this passed locally and failed there. Pin the subprocess to
+    # plain, unwrapped output rather than depending on that detection. COLUMNS
+    # keeps rich from wrapping a long option name across two lines.
+    env = {**os.environ, "NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"}
+    env.pop("FORCE_COLOR", None)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     assert result.returncode == 0
     assert "reconvert" in result.stdout
     assert "--services-repo" in result.stdout


### PR DESCRIPTION
Main is currently red. #118 made CI actually execute the suite, which exposed
three pre-existing problems that the old autouse fixture had been hiding.

## 1. `ibek-defs` was built where nothing could find it

The real cause of every community `test_generate` failure, and a bug in #118's
own fixture. `_run_update_schema` set `EPICS_ROOT` in a local `env` dict passed
to `update-schema` alone. `test_generate` then runs `ibek runtime generate2` as
a subprocess of its own with no `env` argument, so it inherited `os.environ`,
found no `EPICS_ROOT`, and fell back to `/epics` — which does not exist on a CI
runner. The definitions were built into a temp dir nothing else could see, and
generate2 resolved only ibek's builtin models:

```
Input tag 'pmac.PowerPMAC' found using 'type' does not match any of the
expected tags: 'ibek.repeat', 'ibek.wait_ip', 'ibek.wait_usb'
```

Hence four failures in CI that pass locally, where a populated `/epics` is
already on disk. Fixed by exporting `EPICS_ROOT` into `os.environ` so every
child agrees on it. Two related bugs fall out of the same change:

- the temp path now derives from `getbasetemp().parent` instead of `mktemp()`,
  so all xdist workers share one directory. Previously only the lock winner
  built it and every other worker pointed at somewhere empty.
- it falls back to a temp dir whenever the target is not *writable*, not only
  when it is *absent*. A read-only `/epics` used to trip the update-schema
  assert rather than route around it.

## 2. `test_cli_help` — a test bug, not a code bug

The test shells out to `builder2ibek reconvert --help` and asserts a plain
substring:

```python
assert "--services-repo" in result.stdout
```

Typer renders help through rich, which colours each option name, so the string
actually arrives as `\x1b[1;36m-\x1b[0m\x1b[1;36m-services\x1b[0m\x1b[1;36m-repo\x1b[0m`.

rich only colours when it thinks it has a terminal. pytest's captured pipe is
not one, but CI sets `FORCE_COLOR` — which is exactly why this passed locally
and failed in CI. Reproduce with:

```bash
FORCE_COLOR=1 pytest tests/test_reconvert_cli.py::test_cli_help
```

Fixed by pinning the subprocess env to plain, unwrapped output rather than
depending on rich's terminal detection. Verified under both `FORCE_COLOR=0`
and `FORCE_COLOR=1`.

## 3. The ibek-support pin was *behind*, not ahead

`test_generate[motorpositioner]` also failed locally because the committed pin
`0d93760` predates the entity model the sample was generated from. The fix is to
move the pin forward, not to regenerate the sample:

| ibek-support pin | community samples, locally |
|---|---|
| `0d93760` (before) | 1 failed, 8 passed, 21 skipped |
| `e0f411d` (after) | **9 passed**, 0 failed, 21 skipped |

`e0f411d` is current ibek-support main, including #193 (terminalServer NCHANS)
and #192 (regenerated autosave req files).

## Result

Verified under exact CI conditions — `ibek-support` only, no `EPICS_ROOT` set:

```
30 passed, 21 skipped
```

## Still outstanding — deliberately not in this PR

With **both** submodules at their tips, 12 tests fail, and all 12 are dls-marked
samples; zero community samples fail. Those need regenerating against
ibek-support-dls `749cbb4`, whose backlog and terminalServer dedup changed their
generated `st.cmd`/`ioc.subst`. CI skips them either way, so they do not block
going green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)