### PR TITLE
make_samples.sh: exit non-zero if any sample failed to generate

### DIFF
--- a/tests/samples/make_samples.sh
+++ b/tests/samples/make_samples.sh
@@ -14,6 +14,10 @@ set -e
 # pass a list of XML files as args or use all xml files in the samples dir
 XMLS=${@:-$(ls *.xml)}
 
+# samples that generate2 rejected; reported at the end so that one bad sample
+# does not stop the rest being regenerated
+failed=""
+
 for x in ${XMLS}; do
   stem=$(echo "${x%.xml}" | tr '[:upper:]' '[:lower:]')
   y="${stem}.yaml"
@@ -37,9 +41,15 @@ for x in ${XMLS}; do
   else
     echo " ERROR SKIPPING !!! generate2 SKIP (validation failed)"
     rm -f "${stem}.st.cmd" "${stem}.ioc.subst"
+    failed="$failed $stem"
   fi
 
   rm -rf "$tmpdir"
 done
 
 builder2ibek db-compare ./SR03C-VA-IOC-01_expanded.db ./sr03c-va-ioc-01.db --output ./compare.diff --ignore SR03C-VA-IOC-01:
+
+if [ -n "$failed" ]; then
+  echo "ERROR: generate2 failed, outputs removed for:$failed"
+  exit 1
+fi


### PR DESCRIPTION
`make_samples.sh` deletes a sample's `.st.cmd`/`.ioc.subst` when `generate2`
rejects it and carries on. That keep-going behaviour is the one we want — one
bad sample should not stop the other thirteen being regenerated — but the
script then exited **0**, so a partial regeneration was indistinguishable from
a complete one.

That is how `bl03i-mo-ioc-11` came to have no generated outputs at all. Its
absence read as a deliberate omission rather than a failure, and it went
unnoticed until #120 regenerated everything and three new files appeared.

## The change

Six lines. The loop is untouched, so nothing about the keep-going behaviour
changes.

```diff
 XMLS=${@:-$(ls *.xml)}
+
+# samples that generate2 rejected; reported at the end so that one bad sample
+# does not stop the rest being regenerated
+failed=""

     echo " ERROR SKIPPING !!! generate2 SKIP (validation failed)"
     rm -f "${stem}.st.cmd" "${stem}.ioc.subst"
+    failed="$failed $stem"
   fi

 builder2ibek db-compare ...
+
+if [ -n "$failed" ]; then
+  echo "ERROR: generate2 failed, outputs removed for:$failed"
+  exit 1
+fi
```

Output on failure:

```
 ERROR SKIPPING !!! generate2 SKIP (validation failed)
ERROR: generate2 failed, outputs removed for: motorpositioner
```

## Verified

Ran all three paths, confirming the tree ends up byte-identical afterwards:

| scenario | exit | other samples |
|---|---|---|
| all 14 generate | **0** | 14 regenerated |
| one deliberately broken | **1** | 13 regenerated, broken one's outputs removed |
| restored | **0** | back to 14, `git status` clean |

## One judgement call

The check sits **after** `db-compare`, so a generate2 failure does not skip that
step. The trade-off: if `db-compare` itself fails, `set -e` aborts there and the
summary line is lost — still a non-zero exit, just a less specific one. Moving
the check above `db-compare` swaps which one wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
