### PR TITLE
tests: catch stale samples, and warn about stale pins

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -11,3 +11,13 @@ jobs:
     uses: ./.github/workflows/_tox.yml
     with:
       tox: docs -- -b linkcheck
+
+  # Warns, never fails: a pin lagging main is often the correct state, but
+  # nothing else would ever tell us it had happened. ibek-support-dls is on
+  # Diamond's internal GitLab and is reported unreachable from here.
+  pin-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check submodule pins against their remote main
+        run: python3 tests/check_pin_freshness.py

--- a/tests/check_pin_freshness.py
+++ b/tests/check_pin_freshness.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Warn when a submodule pin has fallen behind its remote main.
+
+This is the other half of test_sample_pins.py, and the two catch opposite
+mistakes. That test fails when a pin moves and the samples are not regenerated.
+This warns when a pin has *not* moved but upstream has -- at which point the
+repo is internally consistent and entirely green while testing against support
+modules that are months old. Nothing else notices that.
+
+Deliberately never fails. A pin lagging main is normal for days at a time and
+is often the correct state; it is a thing to be told about, not blocked on. Run
+weekly from periodic.yml, and by hand whenever you like:
+
+    python3 tests/check_pin_freshness.py
+
+ibek-support-dls is on Diamond's internal GitLab, so this can only reach it from
+inside the network. From a GitHub runner that submodule is reported unreachable
+and skipped rather than treated as a problem.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SUBMODULES = ("ibek-support", "ibek-support-dls")
+LS_REMOTE_TIMEOUT = 30
+
+IN_ACTIONS = os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _warn(message: str) -> None:
+    """Emit as a GitHub annotation under Actions, plain text elsewhere."""
+    if IN_ACTIONS:
+        # One line only -- annotations do not render embedded newlines.
+        print(f"::warning::{message.replace(chr(10), ' ')}")
+    else:
+        print(f"WARNING: {message}")
+
+
+def _committed_pin(submodule: str) -> str:
+    out = subprocess.run(
+        ["git", "ls-tree", "HEAD", submodule],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    return out[2]
+
+
+def _submodule_url(submodule: str) -> str:
+    return subprocess.run(
+        ["git", "config", "-f", ".gitmodules", f"submodule.{submodule}.url"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _remote_main(url: str) -> str | None:
+    """Tip of main upstream, or None if the remote cannot be reached."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", url, "refs/heads/main"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=LS_REMOTE_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.split()[0]
+
+
+def main() -> int:
+    stale = 0
+    for submodule in SUBMODULES:
+        pinned = _committed_pin(submodule)
+        remote = _remote_main(_submodule_url(submodule))
+
+        if remote is None:
+            print(f"{submodule}: remote unreachable, skipped")
+        elif remote == pinned:
+            print(f"{submodule}: up to date with main ({pinned[:8]})")
+        else:
+            stale += 1
+            _warn(
+                f"{submodule} pin {pinned[:8]} is behind main {remote[:8]}. "
+                f"To take the update: git submodule update --remote {submodule}, "
+                f"./tests/samples/make_samples.sh, and for ibek-support-dls also "
+                f"python3 tests/vendor_support_dls.py --update"
+            )
+
+    print(f"\n{stale} of {len(SUBMODULES)} submodule pins behind main")
+    # Always 0: this reports, it does not gate.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/samples/GENERATED_AGAINST
+++ b/tests/samples/GENERATED_AGAINST
@@ -1,0 +1,3 @@
+# Written by make_samples.sh -- do not hand edit.
+ibek-support e0f411d54a247c62e8338ac783587f9fec1c8b3a
+ibek-support-dls 749cbb458b23c3d13de2c71751adabb3cf6a8a1e

--- a/tests/samples/make_samples.sh
+++ b/tests/samples/make_samples.sh
@@ -49,6 +49,17 @@ done
 
 builder2ibek db-compare ./SR03C-VA-IOC-01_expanded.db ./sr03c-va-ioc-01.db --output ./compare.diff --ignore SR03C-VA-IOC-01:
 
+# Record which support module revisions these outputs were built from, so that
+# bumping a submodule pin without regenerating (or regenerating against a
+# checkout that is not the pin) fails with a sentence rather than a diff.
+# See test_sample_pins.py.
+{
+  echo "# Written by make_samples.sh -- do not hand edit."
+  for repo in ibek-support ibek-support-dls; do
+    echo "$repo $(git -C "../../$repo" rev-parse HEAD)"
+  done
+} > GENERATED_AGAINST
+
 if [ -n "$failed" ]; then
   echo "ERROR: generate2 failed, outputs removed for:$failed"
   exit 1

--- a/tests/test_sample_pins.py
+++ b/tests/test_sample_pins.py
@@ -1,0 +1,72 @@
+"""Catch a submodule pin moving without the samples being regenerated.
+
+The expected st.cmd/ioc.subst/yaml files are a function of the support module
+revisions they were generated from. Bump a pin without re-running
+make_samples.sh -- or regenerate against a checkout that is not the pin -- and
+the samples describe a state of the world that no longer exists.
+
+That drift is what left 10 sample tests failing before #119, presenting as
+inscrutable diffs in generated output rather than as the stale input it was.
+GENERATED_AGAINST records the revisions make_samples.sh actually used; this
+compares them with the pins the repo commits.
+
+Reads the pins out of git rather than the working tree, so it is meaningful
+even where a submodule is not checked out -- CI never clones ibek-support-dls.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+GENERATED_AGAINST = REPO_ROOT / "tests" / "samples" / "GENERATED_AGAINST"
+SUBMODULES = ("ibek-support", "ibek-support-dls")
+
+
+def _committed_pin(submodule: str) -> str:
+    """The SHA this repo commits for a submodule, per git's index."""
+    out = subprocess.run(
+        ["git", "ls-tree", "HEAD", submodule],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    return out[2]
+
+
+def _generated_against() -> dict[str, str]:
+    if not GENERATED_AGAINST.exists():
+        pytest.fail(
+            f"{GENERATED_AGAINST.name} is missing -- "
+            f"run ./tests/samples/make_samples.sh to record the revisions "
+            f"the sample outputs were generated from"
+        )
+    recorded = {}
+    for line in GENERATED_AGAINST.read_text().splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        name, sha = line.split()
+        recorded[name] = sha
+    return recorded
+
+
+@pytest.mark.parametrize("submodule", SUBMODULES)
+def test_samples_were_generated_from_the_committed_pin(submodule: str):
+    recorded = _generated_against()
+
+    assert submodule in recorded, (
+        f"{GENERATED_AGAINST.name} does not mention {submodule} -- "
+        f"re-run ./tests/samples/make_samples.sh"
+    )
+
+    pinned = _committed_pin(submodule)
+    assert recorded[submodule] == pinned, (
+        f"samples were generated against {submodule} {recorded[submodule][:8]} "
+        f"but this repo pins {pinned[:8]}.\n"
+        f"Either regenerate them:\n"
+        f"    git submodule update --checkout {submodule}\n"
+        f"    ./tests/samples/make_samples.sh\n"
+        f"or restore the pin if the bump was unintended."
+    )


### PR DESCRIPTION
Two guards for **opposite** mistakes, neither of which anything currently
notices.

## 1. Pin moved, samples not regenerated → fails

`make_samples.sh` now records the revisions it actually used in
`tests/samples/GENERATED_AGAINST`, and `test_sample_pins.py` compares them with
the pins the repo commits:

```
AssertionError: samples were generated against ibek-support e0f411d5
but this repo pins 0d93760f.
  Either regenerate them:
      git submodule update --checkout ibek-support
      ./tests/samples/make_samples.sh
  or restore the pin if the bump was unintended.
```

This is the state that left 10 sample tests failing before #119 — presenting as
inscrutable diffs in generated output rather than as the stale input it was.
Naming the fix matters most for anyone who has *not* just spent a day in this
code.

It reads pins from git rather than the working tree, so it stays meaningful
where a submodule is not checked out — CI never clones `ibek-support-dls`.

## 2. Pin did *not* move but upstream did → warns

`check_pin_freshness.py` covers the case the above cannot see. When we simply
forget to re-pin, the repo is internally consistent and entirely green while
testing against support modules that may be months old.

```
::warning::ibek-support pin 0d93760f is behind main e0f411d5. To take the
update: git submodule update --remote ibek-support, ./tests/samples/make_samples.sh,
and for ibek-support-dls also python3 tests/vendor_support_dls.py --update
```

**It never fails.** A pin lagging main is normal for days at a time and is often
the correct state — it is a thing to be told about, not blocked on. It runs
weekly from the existing `periodic.yml`, as a GitHub annotation.

`ibek-support-dls` is on Diamond's internal GitLab, so from a runner it reports
`remote unreachable, skipped` rather than being treated as a problem. Run by
hand from inside the network, it checks both.

## Verified

- drift guard **fails** on bump-without-regenerate, and on a missing record file
- freshness check **warns** on a rolled-back pin while still exiting `0`, and
  renders as `::warning::` under Actions
- re-running `make_samples.sh` at the current pins changes **no sample**, which
  is what makes the recorded revisions trustworthy
- full suite: 59 passed

## Scope note

These two do not overlap with `test_vendored_copy_records_the_committed_pin`
from #122, which ties the *vendored copy* to the dls pin. This ties the
*samples* to both pins, and watches both pins against upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
