### PR TITLE
skills: document the testing/CI machinery and the positioner motor rule

### DIFF
--- a/.claude/skills/shared/module-special-cases.md
+++ b/.claude/skills/shared/module-special-cases.md
@@ -28,3 +28,19 @@ The public module at `ibek-support/iocStats/` defines
 `module: devIocStats` with `iocAdminSoft` using the `$(IOCSTATS)` macro.
 Do **not** create a `ibek-support-dls/devIocStats/` — the DLS-specific
 copy was removed as redundant.
+
+## `positioner.motorpositioner` — `motor` is a suffix, not a PV
+
+`motorpositioner.template` resolves the link as `$(P)$(motor).RBV`, and the
+motorpositioner takes its `P` from the parent multipositioner (`P: "{{MP.P}}"`).
+So `motor` holds the referenced motor's **`M`** (or **`Q`** for
+`softMotorForPiezo`) — a bare suffix like `:Y`, which looks wrong but is what
+XMLbuilder emitted.
+
+Setting `motor` to `P + M` duplicates the prefix and produces a dead link:
+`BL04I-MO-MAPT-01BL04I-MO-MAPT-01:Y.RBV`.
+
+This only works while the motor and the multipositioner share a prefix, which
+XMLbuilder asserted and `converters/positioner.py` now checks. If you see
+`motor ... prefix does not match multipositioner ... prefix`, the XML is
+referencing a motor on another device, and `$(P)$(motor)` cannot express it.

--- a/.claude/skills/shared/testing-and-ci.md
+++ b/.claude/skills/shared/testing-and-ci.md
@@ -1,0 +1,90 @@
+# Testing and CI
+
+How the test suite gets its inputs, and the guards that stop it lying to you.
+
+**A green local run does not mean a green CI run.** The two environments differ
+in ways that hide real failures — see [Reproducing CI](#reproducing-ci-locally).
+
+## Where entity models come from
+
+Both `update-schema` and `src/builder2ibek/support_defaults.py` glob
+`ibek-support*/*/*.ibek.support.yaml` at the repo root. Only those files matter
+to a test — nothing else in a module folder is read.
+
+`ibek-support-dls` is on Diamond's internal GitLab, which GitHub Actions cannot
+reach. `tests/vendored-support-dls/` holds a checked-in copy of the support
+YAMLs the samples need (23 modules), and CI copies them into `ibek-support-dls/`
+so every sample runs.
+
+```bash
+python3 tests/vendor_support_dls.py --check     # OK / PENDING / STALE
+python3 tests/vendor_support_dls.py --update    # refresh from the submodule
+python3 tests/vendor_support_dls.py --install   # populate ibek-support-dls/ (CI)
+```
+
+The vendored tree lives under `tests/` **deliberately**, so it does not match
+the `ibek-support*` glob. A normal local checkout never sees it, and conversion
+work uses the real submodule. `--install` refuses to touch an `ibek-support-dls/`
+that already has content.
+
+`--update` refuses unless the submodule is at the committed pin **and clean**:
+the vendored files must correspond to a commit others can fetch, so an
+uncommitted edit has to be pushed and the pin bumped first. If a skill has just
+edited `ibek-support-dls/`, `--check` reporting `PENDING` is the expected
+answer, not a failure. Report it; do not try to fix it.
+
+## After bumping a submodule pin
+
+Two things must follow, and a guard catches each:
+
+```bash
+git submodule update --checkout ibek-support-dls   # match the committed pin
+python3 tests/vendor_support_dls.py --update       # dls only
+./tests/samples/make_samples.sh                    # both repos
+```
+
+| guard | fires when |
+|---|---|
+| `test_vendored_copy_records_the_committed_pin` | vendored copy predates the dls pin |
+| `test_samples_were_generated_from_the_committed_pin` | samples predate either pin |
+
+**Both read `git ls-tree HEAD`, so they fire once the pin is _committed_, not
+while it is staged.** `git add` followed by pytest will report all-pass. CI only
+ever sees committed state, so this is a local-only gap.
+
+`make_samples.sh` records what it used in `tests/samples/GENERATED_AGAINST`.
+Re-run it after any pin bump even when no sample output changes — the record
+tracks the revisions built from, not whether the outputs differed.
+
+`tests/check_pin_freshness.py` covers the opposite mistake: a pin that has *not*
+moved while upstream has. It warns and never fails, and runs weekly from
+`periodic.yml`.
+
+## Reproducing CI locally
+
+Two differences hide failures:
+
+1. `/epics` exists here (pre-populated, read-only) but is **absent** on a
+   runner. Anything resolving `ibek-defs` from the default `/epics` succeeds
+   here and fails there.
+2. Exporting `EPICS_ROOT` on the command line makes it worse: `subprocess.run`
+   without `env=` inherits it, so child processes find definitions CI's children
+   cannot.
+
+```bash
+env -u EPICS_ROOT uv run pytest -q
+```
+
+## Foot-guns
+
+- **`make_samples.sh` deletes a sample's outputs when `generate2` rejects it**
+  and keeps going, so a partial regeneration leaves files simply absent. It
+  exits non-zero and names them at the end — do not ignore that.
+- **A test that skips is not a test that passes.** An autouse fixture calling
+  `pytest.skip` takes the whole session with it; this suite once reported
+  success while running zero tests. `test_support_submodule_present` and
+  `test_dls_models_available` exist to fail loudly instead.
+- **Never compare a thing against itself.** The vendored drift guards skip
+  unless `ibek-support-dls/.git` exists, because after `--install` that
+  directory holds the vendored files and comparing them would pass while
+  proving nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,15 @@ uv run builder2ibek xml2yaml <path/to/IOC.xml> --yaml <output/ioc.yaml>
 
 # Testing:
 uv run pytest
-./tests/samples/make_samples.sh   # regenerate sample outputs
-./update-schema                   # rebuild global ioc schema
+env -u EPICS_ROOT uv run pytest      # as CI runs it -- local /epics hides failures
+./tests/samples/make_samples.sh      # regenerate sample outputs (after any pin bump)
+./update-schema                      # rebuild global ioc schema
+python3 tests/vendor_support_dls.py --check   # is the vendored dls copy current?
 ```
+
+See [.claude/skills/shared/testing-and-ci.md](.claude/skills/shared/testing-and-ci.md)
+for the vendored ibek-support-dls copy, the pin guards, and what to run after
+bumping a submodule.
 
 ## Slash Commands
 


### PR DESCRIPTION
Captures two things from the autosave/CI work so the next session doesn't have to
rediscover them.

## `shared/testing-and-ci.md` (new)

Nothing documented how the suite gets its inputs, which is how several of this
week's bugs stayed invisible. Covers:

- where entity models come from (both consumers glob `ibek-support*/*/*.ibek.support.yaml` — nothing else is read)
- the vendored `ibek-support-dls` copy and its three modes, including why it sits under `tests/` and why `--update` refuses a dirty submodule
- what must follow a pin bump, and which guard catches each omission
- reproducing CI locally, and why exporting `EPICS_ROOT` actively hides failures

Plus the foot-guns worth warning about: `make_samples.sh` deleting outputs on
failure, an autouse fixture that skips taking the whole session with it, and why
the vendored drift guards **skip** rather than compare a copy against itself.

It also records that the pin guards read `git ls-tree HEAD`, so they fire on a
*committed* pin and not a staged one — I was misled by that locally.

## `module-special-cases.md` — `positioner.motorpositioner`

`motor` holds a bare suffix like `:Y`, because the template resolves
`$(P)$(motor).RBV` with `P` from the parent multipositioner. It looks wrong and
is correct; setting it to `P + M` duplicates the prefix and yields a dead link.
Exactly the trap #110 is fixing, and worth a note so it isn't reintroduced.

## `CLAUDE.md`

Links the new file and adds `env -u EPICS_ROOT uv run pytest` to the test
commands.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring motor positioners and avoiding invalid cross-device references.
  * Expanded testing and CI documentation with test discovery, sample regeneration, schema rebuilding, support-file freshness checks, and local CI troubleshooting.
  * Updated contributor instructions with the latest testing workflow and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->