### PR TITLE
skills: promote four lessons out of auto-memory

### DIFF
--- a/.claude/skills/ibek-concepts/SKILL.md
+++ b/.claude/skills/ibek-concepts/SKILL.md
@@ -51,6 +51,25 @@ Determined from `# % macro` declarations at the top of the compiled `.db` file
 - Macros **with** a default (e.g. `MASS_RANGE`) → optional ibek parameters
   (so instances can override)
 
+### `$(MODULE)` in a database path: underscores, never hyphens
+
+For a module whose directory name contains a hyphen (`SR-VA`,
+`Hy8401ip-asyn`), the RELEASE macro ibek-support's ansible writes is
+uppercased **with hyphens replaced by underscores** —
+`macro: "{{ module | replace('-', '_') | upper }}"` in
+`_ansible/roles/support/vars/main.yml`. So it is `$(SR_VA)`, never `$(SR-VA)`.
+
+msi macro names accept only alphanumerics and underscore, so a hyphenated
+reference survives expansion as a literal and fails with `msi: No template
+file` — and it fails **late**, crashing generic-IOC startup at the msi step
+after `generate2` has already produced a perfectly good `ioc.subst`/`st.cmd`.
+
+Grep after editing:
+
+```bash
+grep -rn 'file: \$([A-Z0-9]*-' ibek-support*
+```
+
 ---
 
 ## name parameter and type: id
@@ -87,6 +106,24 @@ These need:
 - Parameters + `databases` section only (no `pre_init`/`post_init`)
 - `.*:` in `databases.args`
 - Drop `name` (gui label, not a cross-reference)
+
+---
+
+## XML template entities (`Xml` classes) use `sub_entities`
+
+A builder.py class inheriting from `Xml` corresponds to an XML template in
+`etc/makeIocs/`. Model it as **one entity with `sub_entities`** referencing
+entity types from other modules — do **not** write a converter that expands it
+into individual child entities in `ioc.yaml`.
+
+That keeps `ioc.yaml` minimal and reusable: one entity with a few macro
+parameters (`dom`, `plc_ip`, `ts_ip`) instead of dozens of expanded children,
+preserving the template abstraction the XML author intended.
+
+To do it: read the template from `etc/makeIocs/`, write an entity model whose
+`sub_entities` reference existing entity models, use Jinja2 `{{ param }}` for
+the macro substitution, and write no converter at all. Worked example:
+`ibek-support-dls/SR-VA/SR-VA.ibek.support.yaml` (`d2PumpCart`).
 
 ---
 

--- a/.claude/skills/ibek-support-ansible/SKILL.md
+++ b/.claude/skills/ibek-support-ansible/SKILL.md
@@ -41,6 +41,29 @@ inside containers.
 
 Items default to pre-build. Set `post_build: true` to run after make.
 
+### Module order in a generic IOC Dockerfile
+
+Each `RUN ansible.sh <module>` is a separate layer, so a module must be built
+**after** everything its dbd or link line needs. The authoritative order is the
+`core` group in `ibek-support/build-groups.yml`:
+
+```
+calc  sscan  asyn  busy  autosave  sequencer  std
+```
+
+Two dependencies in there are easy to miss, and both were shipped broken:
+
+- **`std` must follow `asyn`.** `stdInclude.dbd` includes `asyn.dbd`, so building
+  it first gives `dbdExpand.pl: Can't find file 'asyn.dbd'`.
+- **`std` needs `sequencer`.** `std_SRCS` includes `femto.st` and `delayDo.st`,
+  which need `snc` to become objects, and `std_LIBS += asyn seq pv`. Without it:
+  `make: *** No rule to make target 'femto.o', needed by 'libstd.a'`. No IOC uses
+  the sequencer directly, which is exactly why it gets left out.
+
+A missing-dependency failure surfaces at whichever module is built too early, not
+at the one that is absent — read the error for what it *wanted*, not where it
+stopped.
+
 ---
 
 ## Adding new install.yml variables

--- a/.claude/skills/shared/testing-and-ci.md
+++ b/.claude/skills/shared/testing-and-ci.md
@@ -56,6 +56,44 @@ ever sees committed state, so this is a local-only gap.
 Re-run it after any pin bump even when no sample output changes — the record
 tracks the revisions built from, not whether the outputs differed.
 
+`vendor_support_dls.py --update` refuses to run while the checkout and the
+committed pin disagree — it tells you to commit the bump first. So the order is:
+commit the pin, vendor, then `--amend` the vendored files into that same commit.
+Landing them separately leaves one commit that moves the pin without its
+vendored copy, which fails the guard, so history contains a red commit.
+
+### Regenerated samples must be reviewed by a human
+
+**Never commit a regenerated sample set without the user reading the diff.**
+
+The samples are the regression baseline for the whole converter: `test_convert`
+and `test_generate` compare against them. Committing a regenerated set silently
+redefines "correct", so a converter or support-YAML bug that changes `st.cmd` or
+`ioc.subst` gets baked in as the new expected output and the suite goes green on
+it. The diff **is** the review surface. Show it, explain what changed and why it
+is expected, and commit only once the user has said so.
+
+If a run fails partway, `git checkout -- tests/samples/` rather than committing a
+partial or emptied set.
+
+### make_samples.sh needs a writable `EPICS_ROOT`
+
+`generate2` resolves entity models from `$EPICS_ROOT/ibek-defs`, which
+`./update-schema` populates. Where `/epics` is read-only (some sandboxes),
+`update-schema` cannot refresh it, so `generate2` validates every sample against
+a **stale** schema, rejects them all, and `make_samples.sh` deletes all 14
+outputs. The symptom is misleading — it names whichever support YAML sorts first
+(`VALIDATION ERROR READING /epics/ibek-defs/ACCELCryoIP...`), which is not the
+faulty file.
+
+Point both steps at the same writable root, in one shell so it persists:
+
+```bash
+export EPICS_ROOT=$(mktemp -d)
+./update-schema
+./tests/samples/make_samples.sh
+```
+
 `tests/check_pin_freshness.py` covers the opposite mistake: a pin that has *not*
 moved while upstream has. It warns and never fails, and runs weekly from
 `periodic.yml`.


### PR DESCRIPTION
Housekeeping from `/memo`. Auto-memory had grown to 53 lines and was holding
reusable knowledge that belongs where the relevant task will load it. Moved four
items into skills and trimmed memory to 29 lines.

### `shared/testing-and-ci.md`

- **Regenerated samples must be reviewed by a human before commit.** They are the
  regression baseline for `test_convert`/`test_generate`, so committing a
  regenerated set silently redefines "correct" — a converter or support-YAML bug
  that changes `st.cmd`/`ioc.subst` gets baked in as the expected output and the
  suite goes green on it.
- **`make_samples.sh` needs a writable `EPICS_ROOT`.** Where `/epics` is
  read-only, `update-schema` cannot refresh `ibek-defs`, `generate2` validates
  every sample against a stale schema and rejects them all, and the script
  deletes all 14 outputs. The error names whichever support YAML sorts first
  (`ACCELCryoIP`), which is *not* the faulty file — that cost real diagnosis time.
- **`vendor_support_dls.py --update` refuses to run until the pin is committed**,
  so the order is commit pin → vendor → amend. Landing them separately leaves a
  commit that moves the pin without its vendored copy, i.e. a red commit in
  history.

### `ibek-support-ansible/SKILL.md`

Module order in a generic IOC Dockerfile, taken from the `core` group in
`build-groups.yml`. Two dependencies are easy to miss and **both were shipped
broken** in `ioc-streamdevice`:

- `std` must follow `asyn` — `stdInclude.dbd` includes `asyn.dbd`
- `std` needs `sequencer` — `femto.st`/`delayDo.st` need `snc`, and
  `std_LIBS += asyn seq pv`

### `ibek-concepts/SKILL.md`

- `$(MODULE)` in a database path uses **underscores, never hyphens**
  (`$(SR_VA)`), because ansible writes `module | replace('-','_') | upper`. A
  hyphenated reference fails late, at msi during container startup.
- `Xml` template classes get `sub_entities`, not converter expansion.

No production code touched; 60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)