### PR TITLE
Add `builder2ibek catio`: migrate EtherCAT IOCs onto fastcs-catio

### DIFF
--- a/.claude/commands/beamline-convert.md
+++ b/.claude/commands/beamline-convert.md
@@ -25,6 +25,24 @@ files for beamline `$1`.
 List all XMLs found. Ask the user to confirm which ones to convert (default:
 all).
 
+## Step 2a — Set EtherCAT IOCs aside
+
+IOCs involved in an EtherCAT chain must **not** go through the standard
+`xml2yaml` fan-out. `xml2yaml` drops the EtherCAT entities but leaves every
+reference to the chain's PVs pointing at the dead legacy namespace. Those IOCs
+need `/catio-convert`, one run per chain.
+
+Find the scanner IOCs (one per chain) and their consumers:
+
+```bash
+grep -l "EthercatMaster" <makeIocs>/*.xml     # scanners — one per chain
+grep -l "ERIO-" <makeIocs>/*.xml              # scanners + consumers
+```
+
+Exclude both sets from Steps 3–5. Report them to the user and hand the whole
+BUILDER tree to `/catio-convert` afterwards — it discovers and converts all
+chains in one pass.
+
 ## Quick reference — xml2yaml syntax
 
 ```bash

--- a/.claude/commands/catio-convert.md
+++ b/.claude/commands/catio-convert.md
@@ -1,0 +1,121 @@
+---
+argument-hint: <path/to/BLxxI-BUILDER> [<path/to/services-repo>]
+description: Convert every EtherCAT chain in a beamline from the legacy ethercat scanner to fastcs-catio, rewriting all consumer PV references and generating the fastcs-catio IOCs.
+---
+
+# CATio Convert Workflow
+
+Convert every EtherCAT chain declared in the BUILDER tree `$1`, every IOC that
+references those chains, and generate the replacement fastcs-catio IOCs — all
+into the services repo `$2`.
+
+> **Predicting PV names needs `fastcs_catio` importable.** Everything else —
+> chain modelling, diagnostics, the report — works without it. If the run stops
+> with an ImportError, use an interpreter that has both projects installed.
+> [.claude/plans/catio-conversion.md](../plans/catio-conversion.md) carries the
+> design, the verified domain facts, and the decisions (D1–D11) behind them.
+> Do not re-derive the naming rule — it lives in `fastcs_catio.naming`.
+
+---
+
+## What makes this different from `/beamline-convert`
+
+`/beamline-convert` converts each XML in isolation. This one is **cross-IOC and
+whole-beamline**:
+
+* The scanner IOCs are the only place the EtherCAT chains are declared, but
+  their PVs are consumed by *other* IOCs.
+* The EtherCAT entities are **dropped**; generated fastcs-catio IOCs replace
+  them.
+* fastcs-catio auto-discovers each chain and generates **different** PV names,
+  so every reference in every dependent IOC must be rewritten.
+* All chains are handled in **one** invocation, because an IOC may consume more
+  than one chain (`BL21I-VA-IOC-04` does) and must be written once, complete.
+
+Legacy `ERIO-NN` labels carry **no ordering information**. fastcs-catio numbers
+couplers by chain order, so `BL21I-VA-ERIO-01` may well become
+`BL21I-VA-E1RIO-05`. Never assume the number is preserved.
+
+## Step 1 — Resolve services repo
+
+Follow [services-repo-resolution.md](../skills/shared/services-repo-resolution.md)
+using `$2` if provided, otherwise the beamline prefix implied by `$1`.
+
+## Step 2 — Dry run and read the report
+
+```bash
+uv run builder2ibek catio $1 --services-repo <repo> --dry-run
+```
+
+Report to the user, before writing anything:
+
+* every chain discovered, with its scanner IOC, coupler order, derived labels,
+  terminal types and positions;
+* the `E{n}RIO` chain ordinal allocated to each chain, and whether it was newly
+  allocated or carried over from an existing `config/fastcs.yaml`;
+* the predicted fastcs-catio prefix for every module;
+* every IOC that will be modified and how many substitutions each receives;
+* the fastcs-catio IOCs that will be generated;
+* **every diagnostic**.
+
+## Step 3 — Resolve diagnostics before writing
+
+The tool hard-fails rather than guessing (decision D4). Expect these, and treat
+each as a question for the user — **do not work around them**:
+
+| Diagnostic | Meaning | Action |
+|---|---|---|
+| `MODn` out of range | reference beyond the coupler's terminal count | fix the source XML |
+| leaf invalid for terminal type | e.g. `CHANNEL1:INPUT` on an EL3104 | fix the source XML |
+| duplicate coupler label | two couplers derive the same `ERIO-NN` | fix the source XML |
+| coupler label not unanimous | a coupler's `auto_*` entities disagree | fix the source XML |
+| label matches no chain | reference to a chain not in this BUILDER tree | investigate — likely a typo or a cross-beamline reference |
+| unknown terminal type | not in `terminal_types.yaml` | add it upstream; do not pass through |
+
+The I21 XMLs contain **known real bugs** of the first and second kinds — the
+`auto_EL1014` entities in `ERIO-03`/`ERIO-04` restart numbering at `MOD1`
+instead of continuing the coupler's position sequence, and three live
+`rackFan_rio` references point at names nothing declares. These are genuine
+long-standing defects in the source XML. They get fixed upstream, not papered
+over here. See the plan's "Bugs found" section.
+
+## Step 4 — Convert
+
+Re-run without `--dry-run` once the report is clean. Then for each affected
+*legacy* IOC folder, follow the normal `/ioc-convert` phases for support YAML
+creation and `ibek generate2` validation — `catio` produces `ioc.yaml`, it does
+not validate the support modules those IOCs need.
+
+The generated fastcs-catio IOCs need none of that: they are FastCS IOCs, not
+ibek IOCs, and carry no `ioc.yaml`.
+
+## Step 5 — Verify the substitutions landed
+
+```bash
+grep -rn "ERIO" <services-repo>/services/*/config/ioc.yaml
+```
+
+Any surviving legacy `ERIO-NN:MODn` reference in an IOC that `catio` claimed to
+convert is a bug — report it rather than hand-editing.
+
+## Step 6 — Fill in the placeholders
+
+Each generated fastcs-catio IOC has exactly two values `catio` cannot know:
+
+```bash
+grep -rn "REPLACE_WITH_" <services-repo>/services/*catio*/
+```
+
+* `target_ip` — the ADS/TwinCAT server for that chain. Ask the user; it is *per
+  chain*, not per beamline.
+* the container image tag — pin it, do not leave `latest`.
+
+Do not invent either. List them in the final report if unresolved.
+
+## Step 7 — Report
+
+List: chains discovered, `E{n}RIO` ordinal allocation, IOCs converted with
+substitution counts, fastcs-catio IOCs generated, placeholders still unfilled,
+diagnostics resolved, and source XML fixes still outstanding.
+
+Suggest git commands; do not commit.

--- a/.claude/plans/catio-conversion.md
+++ b/.claude/plans/catio-conversion.md
@@ -1,0 +1,405 @@
+# Plan: `builder2ibek catio` — EtherCAT → fastcs-catio conversion
+
+Status: **designed, not implemented**. Design settled 2026-08-07 in a grilling
+session. Everything below was verified against real files — file:line citations
+are load-bearing, but re-verify before asserting (repos move).
+
+## Goal
+
+DLS is replacing the custom EtherCAT scanner (`ethercat` support module) with
+**fastcs-catio**, which auto-discovers the EtherCAT chain over ADS and generates
+its own PV names. Those names differ from the legacy ones.
+
+`builder2ibek catio <BLxxI-BUILDER-path> --services-repo <path>` must:
+
+1. **Discover every EtherCAT chain** in the BUILDER tree — one per IOC XML
+   containing an `ethercat.EthercatMaster` (the "scanner IOCs").
+2. Model each chain and **predict** the PV names fastcs-catio will generate.
+3. **Drop** the EtherCAT entities from the converted IOCs — a generated
+   fastcs-catio IOC replaces them.
+4. Find every IOC XML that references PVs produced by any chain and
+   **substitute** the predicted names in.
+5. Write the affected IOCs into a services repo as new IOC folders.
+6. **Generate one fastcs-catio IOC per chain**, complete except for the ADS
+   server IP address.
+
+The scanner XMLs are **input-only** as far as their EtherCAT entities go:
+consumed for the mapping, never emitted. Their non-EtherCAT entities are
+converted as normal.
+
+---
+
+## Domain facts (verified)
+
+### How fastcs-catio names things
+
+`node_prefix`/`module_prefix`/`device_prefix` are `str.format` templates in
+`CATioNameMappings` (`fastcs-catio/src/fastcs_catio/catio_controller.py:400-430`).
+The DLS site config in `src/fastcs_catio/fastcs.yaml` is:
+
+```yaml
+name_mappings:
+  device_prefix: "{id}:ETH{:02d}"
+  node_prefix:   "BL04I-EA-E1RIO-{:02d}"
+  module_prefix: "{node_prefix}:{group_alias}{:02d}"
+```
+
+* **node index** — `loc_in_chain.node`, incremented on every `EK1100` or box
+  (`client.py:1420-1453`). 1-based ordinal of the coupler in chain order.
+* **module index** — `loc_in_chain.position`, reset to 0 at each coupler then
+  incremented, so the first terminal after a coupler is position 1. **But** when
+  `module_prefix` contains `{group_alias}`, the positional index becomes a
+  per-`(coupler, alias)` sequence number instead
+  (`catio_controller.py:695-713`, `:772-802`).
+* **group_alias** — from `terminal_types.yaml`, looked up by
+  `(vendor_id, product_code, revision_number)` with **fallback to
+  vendor+product** when the revision differs (`terminal_config.py:197-218`).
+  This matters: the I21 XMLs declare `EL3104 rev 0x00120000`/`0x00130000` while
+  the YAML holds `0x00100000`. Without the fallback the alias would silently
+  degrade to `MOD`.
+* **leaf** — `snake_to_pascal(fastcs_name)` (`fastcs/src/fastcs/util.py:14`,
+  `fastcs/src/fastcs/transports/epics/util.py:18`). `fastcs_name` comes from the
+  terminal YAML row, possibly shortened by `shorten_fastcs_name`
+  (`catio_terminals/utils.py:301`) against a budget that **depends on the length
+  of the PV prefix** (`fastcs_catio/utils.py:229-254`, 60-char EPICS limit).
+
+Chain order in the XML is asserted to be true chain order, so all of this is
+statically inferable — **no live ADS scan required**.
+
+### Terminal map for I21 (verified both sides)
+
+Legacy record names come from `/dls_sw/prod/R3.14.12.7/support/ethercat/7-5-3/db/*.template`.
+
+| Terminal | `group_alias` | legacy leaf | fastcs-catio leaf |
+|---|---|---|---|
+| EL3104 | `10VAI` | `INPUT{n}:VALUE` | `AiStandardChannel{n}Value` |
+| EL1014 | `24VDI` | `CHANNEL{n}:INPUT` | `Channel{n}` |
+| EL2024-0010 | `12VDO` | `CHANNEL{n}:OUTPUT` | `Channel{n}` |
+| EL3356-0010 | `AI` | `RMB:VALUE` | `RmbValueInt32Value` |
+
+These four are the **only** leaves referenced anywhere in the I21 XMLs. No
+consumer references `AL_STATE`, `ERROR_FLAG`, `SLIMIT*`, `SERROR`,
+`SOVERRANGE`, `SSYNCERROR` or `STXPDO*`.
+
+Worked example (`BL21I-VA-IOC-01`, `node_prefix: BL21I-VA-E1RIO-{:02d}`):
+
+```
+BL21I-VA-ERIO-01:MOD1:INPUT1:VALUE   -> BL21I-VA-E1RIO-05:10VAI01:AiStandardChannel1Value
+BL21I-VA-ERIO-01:MOD5:CHANNEL1:INPUT -> BL21I-VA-E1RIO-05:24VDI01:Channel1
+BL21I-VA-ERIO-04:MOD1:INPUT1:VALUE   -> BL21I-VA-E1RIO-01:10VAI01:AiStandardChannel1Value
+```
+
+Note `ERIO-01` becomes `E1RIO-**05**`. The legacy `ERIO-NN` numbers carry **no
+ordering information** — VA-IOC-01's chain order is ERIO-04, -12, -03, -02, -01.
+
+### Bugs found in the legacy I21 XMLs
+
+These are real and must be fixed in the source XML before conversion (the tool
+reports them and fails; it does not repair them).
+
+1. **`DEVICE=` attributes disagree with chain position.** In ERIO-03 and
+   ERIO-04 the `auto_EL1014` entities restart numbering at `MOD1` instead of
+   continuing the coupler's position sequence:
+
+   | Coupler | pos | type | chain-derived | declared `DEVICE=` |
+   |---|---|---|---|---|
+   | ERIO-03 | 3,4 | EL1014 | `MOD3,4` | `MOD1,2` ❌ |
+   | ERIO-04 | 5,6 | EL1014 | `MOD5,6` | `MOD1,2` ❌ |
+
+   This makes `ERIO-03:MOD1` ambiguous (an EL3104 *and* an EL1014 claim it).
+
+2. **Three live references to undeclared names** — `ERIO-03:MOD3`,
+   `ERIO-04:MOD5`, `ERIO-04:MOD6`, all from `rackFan_rio.rio_dinput`. These have
+   been pointing at non-existent PVs for years. Under chain ordering they
+   resolve correctly, i.e. the *consumers* were right and the `DEVICE=`
+   attributes are wrong.
+
+3. **`BL21I-VA-IOC-06`**: comment says `<!--Start of BL21I-VA-ERIO-05-->` but the
+   `auto_EL3104` declares `DEVICE="BL21I-VA-ERIO-99:MOD1"`. Comments are
+   unreliable.
+
+4. **`BL21I-VA-IOC-05`**: a third coupler (`EK1100` + `EL2024`) has no comment
+   and no `auto_*` entity — an unlabelled coupler that still consumes a node
+   index.
+
+### Consumer map for I21 (via builder2ibek's own `Builder`, comments excluded)
+
+| IOC | refs to VA-IOC-01's chain | refs to other chains | attributes |
+|---|---|---|---|
+| `BL21I-VA-IOC-01` | 22 | — | `rackFan_rio.rio_dinput` |
+| `BL21I-VA-IOC-02` | 29 | — | `mks937bGauge.plog_adc_pv`, `mks9xxGauge.plog_adc_pv` |
+| `BL21I-VA-IOC-04` | 3 | 3 (ERIO-05/-06) | `mks937bGauge.plog_adc_pv` |
+| `BL21I-VA-IOC-05` | 0 | 4 | `rackFan_rio.rio_dinput` |
+| `BL21I-DI-IOC-01` | 0 | 96 | `records.ai.INP`, `femto200.*`, `DewarScales.*` |
+
+`BL21I-VA-IOC-03` has **no** EtherCAT references (RGA only) — it is not a
+dependent.
+
+I21 has **four** independent chains: `VA-IOC-01`, `VA-IOC-05`, `VA-IOC-06`,
+`DI-IOC-01`.
+
+Two reference forms exist in attribute values:
+
+```
+rio_dinput="BL21I-VA-ERIO-01:MOD5:CHANNEL1:INPUT"    # bare PV
+INP="BL21I-DI-ERIO-10:MOD1:INPUT1:VALUE CP"          # PV + CA link flag
+```
+
+---
+
+## Decisions
+
+**D1 — Chain order in the XML is authoritative.** Node index = 1-based coupler
+ordinal; position = 1-based offset after its coupler. No live ADS scan.
+
+**D2 — Legacy canonical names are derived from chain ordering, not from
+`DEVICE=`.** The declared `DEVICE=` is used only to derive each coupler's label
+(from the *prefix* of its terminals' `DEVICE=` values, which must be unanimous)
+and as a cross-check. `<!--Start of ...-->` comments are ignored entirely —
+they are unvalidatable free text, they are wrong in VA-IOC-06, and
+`Builder._parse` (`src/builder2ibek/builder.py:44-56`) already discards comment
+nodes.
+
+**D3 — Substitution is keyed on the full legacy PV** (prefix *and* leaf), applied
+token-wise within attribute values, bounded by start/whitespace/end, preserving
+anything that follows (`CP`, `CPP`, `MS`, …). Prefix-only substitution is unsafe
+because `DEVICE=` names are ambiguous (bug 1); the leaf is what disambiguates the
+terminal, and it doubles as a type check.
+
+**D4 — Fail loudly, never guess.** Hard-fail with per-entity pointers when:
+1. a referenced `MODn` exceeds the coupler's terminal count;
+2. the leaf does not exist on the terminal type at that position;
+3. two couplers in one chain resolve to the same label;
+4. a coupler's `auto_*` entities disagree about its label;
+5. an IOC references a label that **no chain in the BUILDER tree** declares —
+   under D7 every chain is discovered, so this is a genuine error (typo, or a
+   cross-beamline reference), not a scoping artefact;
+6. a terminal type is absent from `terminal_types.yaml` — its `group_alias`
+   would silently degrade to `MOD` and its leaf map is unknown.
+
+The report must name the IOC, the entity, and the attribute — e.g.
+`BL21I-VA-IOC-01, entity VAFAN4, arg rio_dinput`. Rationale: chain ordering
+would silently "repair" bug 2 as a side effect of a name migration. That repair
+should be a reviewed XML fix, not a conversion artefact.
+
+**D5 — Do not reimplement the naming rule.** Add a public, hardware-free naming
+API to fastcs-catio and depend on it. The needed pieces are currently private
+(`_resolve_controller_name_and_path`, `_module_alias_indices`) and entangled with
+live ADS discovery. Proposed shape:
+
+```python
+def predict_names(
+    chain: list[tuple[str, int]],          # [(type_name, revision), ...] in chain order
+    mappings: CATioNameMappings,
+    root_id: str,
+) -> dict[tuple[int, int], str]:           # (node, position) -> PV prefix
+```
+
+It must accept terminal **type names** (`"EL3104"`), because that is all the
+builder XML has — `type_rev="EL3104 rev 0x00120000"` — whereas the runtime
+lookup keys on `(vendor_id, product_code)`. Lock it with a test in fastcs-catio
+so drift breaks the repo that caused it.
+
+**D6 — Substitute on parsed entity values, as a finalizer.** Not on XML text.
+`make_entity` (`convert.py:174-208`) leaves PV strings as strings, so there is
+nothing to corrupt, and entity-level access gives the provenance D4 needs.
+
+**D7 — Auto-discover every chain in the beamline; one invocation does the lot.**
+The input is the BUILDER root (e.g. `.../BL21I-BUILDER/5-19`); the tool globs
+`etc/makeIocs/*.xml`, treats every XML containing an `ethercat.EthercatMaster`
+as a scanner, and builds one merged substitution map across all chains. This is
+what makes `BL21I-VA-IOC-04` — which straddles two chains — convertible at all:
+it is written once, complete. D4.5 therefore fires only for a reference to a
+label no chain in the tree declares, which is a genuine error.
+
+*(Supersedes the earlier one-chain-per-invocation design with `--also-chain`.)*
+
+**D8 — Output is a services repo, not a single YAML.** `--services-repo <path>`
+replaces `xml2yaml`'s `--yaml`. Scaffold each affected IOC from `.ioc_template`.
+Per CLAUDE.md, an existing folder with `dev-c7:` in its `values.yaml` is legacy —
+delete the whole folder and recreate.
+
+**D10 — Generate the fastcs-catio IOC for each chain.** One services-repo folder
+per chain, named after its scanner IOC with `IOC` → `CATIO`, so provenance is
+obvious and adding a chain never renumbers an existing one:
+
+| Scanner IOC | fastcs-catio IOC | services folder |
+|---|---|---|
+| `BL21I-VA-IOC-01` | `BL21I-VA-CATIO-01` | `bl21i-va-catio-01` |
+| `BL21I-VA-IOC-05` | `BL21I-VA-CATIO-05` | `bl21i-va-catio-05` |
+| `BL21I-VA-IOC-06` | `BL21I-VA-CATIO-06` | `bl21i-va-catio-06` |
+| `BL21I-DI-IOC-01` | `BL21I-DI-CATIO-01` | `bl21i-di-catio-01` |
+
+Two files, matching the deployed-fastcs-IOC shape in
+`/workspaces/b01-1-services/services/bl01c-ea-align-01/`:
+
+`config/fastcs.yaml` — modelled on fastcs-catio's own
+`src/fastcs_catio/fastcs.yaml`, **not** on the older
+`transport: - ioc: pv_prefix:` form some services repos still use:
+
+```yaml
+controllers:
+  - id: BL21I-VA-CATIO-01
+    type: fastcs_catio.CATioServerController
+    tcp_settings:
+      target_ip: "REPLACE_WITH_ADS_SERVER_IP"   # only unknown value
+      target_port: 27905
+    route:
+      route_name: ""
+      user_name: "Administrator"
+      password: "1"
+    scan_timings:
+      poll_period: 1.0
+      notification_period: 0.2
+    name_mappings:
+      device_prefix: "{id}:ETH{:02d}"
+      node_prefix: "BL21I-VA-E1RIO-{:02d}"       # E{n}RIO per chain, see D11
+      module_prefix: "{node_prefix}:{group_alias}{:02d}"
+transport:
+  - epicsca: {}
+    gui:
+      output_dir: ./screens
+      title: "BL21I VA EtherCAT chain (from BL21I-VA-IOC-01)"
+```
+
+`values.yaml`:
+
+```yaml
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+ioc-instance:
+  image: ghcr.io/diamondlightsource/fastcs-catio:REPLACE_WITH_PINNED_TAG
+  args:
+    - stdio-expose --ptty --stdin --ctrl-d 'fastcs-catio run /epics/ioc/config/fastcs.yaml'
+```
+
+`fastcs-catio run <yaml>` is the yaml-driven entry point from FastCS `_launch`
+(`fastcs_catio/__main__.py:38`); the bespoke `fastcs-catio ioc <pv_prefix>
+<tcp_server>` command bypasses the config file and must not be used here.
+
+The `name_mappings` written here and the templates builder2ibek used to predict
+names are **the same values by construction** — the tool must emit both from one
+source, since a divergence points every rewritten PV at nothing.
+
+**D11 — Chains are distinguished by the `E{n}RIO` ordinal, not by a node
+offset.** `loc_in_chain.node` restarts at 1 for every chain
+(`client.py:1433-1444`), so on I21 three separate VA chains would each claim
+`BL21I-VA-E1RIO-01`. Resolve it by giving each chain in a domain its own
+`node_prefix` literal, incrementing the digit after `E`:
+
+| Scanner IOC | Domain | Chain ordinal | Couplers | `node_prefix` | Allocated |
+|---|---|---|---|---|---|
+| `BL21I-VA-IOC-01` | `BL21I-VA` | 1 | 5 | `BL21I-VA-E1RIO-{:02d}` | `E1RIO-01..05` |
+| `BL21I-VA-IOC-05` | `BL21I-VA` | 2 | 3 | `BL21I-VA-E2RIO-{:02d}` | `E2RIO-01..03` |
+| `BL21I-VA-IOC-06` | `BL21I-VA` | 3 | 1 | `BL21I-VA-E3RIO-{:02d}` | `E3RIO-01` |
+| `BL21I-DI-IOC-01` | `BL21I-DI` | 1 | 10 | `BL21I-DI-E1RIO-{:02d}` | `E1RIO-01..10` |
+
+This needs **no change to fastcs-catio** — `node_prefix` is already a per-IOC
+literal, and each generated `fastcs.yaml` simply carries a different one. It is
+also the intended reading of the name: the library default is
+`{device_prefix}:E1RIO{:02d}` (`catio_controller.py:429`), where the `1` is the
+EtherCAT device ordinal. Chain *n* → `E{n}RIO` matches that semantics rather
+than fighting it.
+
+Chain ordinals are allocated per `(beamline, domain)` — `BL21I-VA` and
+`BL21I-DI` number independently — in ascending scanner-IOC-name order.
+**Ordinals must be sticky**: on re-run the tool reads back the `node_prefix` of
+any already-generated `config/fastcs.yaml` and keeps it, allocating only for
+chains it has not seen. Otherwise inserting a chain (say a future
+`BL21I-VA-IOC-03`) would renumber every downstream PV.
+
+This restores the property the legacy naming had — `ERIO-NN` was unique across
+the whole `BL21I-VA-` domain — without preserving the actual numbers.
+
+*(Supersedes an earlier proposal to add `node_index_offset` to
+`CATioNameMappings`. No longer needed; do not implement it.)*
+
+**D9 — `/beamline-convert` must learn about this.** EtherCAT IOCs must be
+excluded from the per-IOC `xml2yaml` fan-out and handled by one `catio` call per
+chain instead.
+
+---
+
+## Implementation steps
+
+1. **fastcs-catio PR** — extract the naming rule into `predict_names()` (D5),
+   hardware-free, keyed on type names, with a locking test. This is the *only*
+   fastcs-catio change required. Blocks step 4 but can proceed in parallel
+   behind a thin shim.
+
+2. **`src/builder2ibek/catio.py`** — pure chain modelling:
+   * glob `etc/makeIocs/*.xml`, identify scanners by `EthercatMaster` (D7);
+   * parse each scanner XML into an ordered slave list;
+   * assign `(node, position)` per D1;
+   * allocate sticky per-domain `E{n}RIO` chain ordinals per D11;
+   * derive coupler labels per D2;
+   * build the canonical legacy PV set (prefix × leaves valid for that terminal
+     type);
+   * return `dict[legacy_pv, new_pv]` plus a list of diagnostics.
+
+   No I/O, no services repo, no fastcs runtime → unit-testable directly against
+   `tests/samples/BL21I-VA-IOC-01.xml`.
+
+3. **Leaf translation table** — legacy `.template` leaf → fastcs `fastcs_name`,
+   per terminal type. Start with the four I21 types; **fail on unknown types**
+   rather than passing them through.
+
+4. **Wire in `predict_names()`** from step 1.
+
+5. **Extend `src/builder2ibek/converters/ethercat.py`.** It already drops all
+   EtherCAT entities and replaces `EthercatMaster` with a TODO
+   `epics.PostStartupCommand`. Add a `finalize(ioc)` (picked up automatically by
+   `moduleinfos.py:22-24`) that applies the substitution map carried on
+   `Generic_IOC`.
+   * **Bug to fix while there**: the module-level `_dummy_inserted` global is set
+     but never read or reset — it will leak across IOCs in a multi-IOC process.
+
+6. **CLI** — `builder2ibek catio` in `src/builder2ibek/__main__.py`:
+
+   ```
+   builder2ibek catio BUILDER_PATH
+       --services-repo PATH
+       [--node-prefix TEXT] [--module-prefix TEXT] [--device-prefix TEXT]
+       [--dry-run]
+   ```
+
+   `BUILDER_PATH` is the BUILDER root (`.../BL21I-BUILDER/5-19`); the tool globs
+   `etc/makeIocs/*.xml` itself — same convention as the existing
+   `beamline2yaml` stub. The name-mapping templates default to the DLS
+   convention derived from each scanner IOC's domain
+   (`BL21I-VA-IOC-01` → `BL21I-VA-E1RIO-{:02d}`) and are written verbatim into
+   the generated `fastcs.yaml`, so prediction and deployment cannot diverge
+   (D10).
+
+7. **Services repo output** (D8) — scaffold from `.ioc_template`, honour the
+   `dev-c7:` legacy rule.
+
+8. **fastcs-catio IOC generation** (D10) — emit `config/fastcs.yaml` +
+   `values.yaml` per chain, with `target_ip` and the image tag left as explicit
+   `REPLACE_WITH_*` placeholders. The final report must list every placeholder
+   so none ships unfilled.
+
+9. **`/beamline-convert` update** (D9).
+
+10. **Tests** — add `BL21I-VA-IOC-01/-02/-04` to `tests/samples/`; assert the
+    generated map against a checked-in expected table; assert `E{n}RIO` ordinal
+    allocation and its stickiness across re-runs; assert each D4 failure mode
+    fires. Run as CI does: `env -u EPICS_ROOT uv run pytest`.
+
+## Open items
+
+* fastcs-catio inconsistency worth reporting upstream: attribute creation filters
+  on `selected` alone (`catio_dynamic_controller.py:61`) while symbol expansion
+  additionally drops rows where `bit_offset % 8 != 0` (`symbols.py:164`). So
+  EL3104's `AiStdCh1StsLim1`/`StsLim2` PVs are created but can never update.
+  Harmless here (nothing references them) but it means "PV exists" ≠ "PV works" —
+  do not use the naming API as an existence oracle.
+* Chain-ordinal stickiness has an unhandled edge: if a chain is *removed* from
+  the BUILDER tree its `E{n}RIO` ordinal stays reserved (correct — reusing it
+  would renumber live PVs), but nothing reclaims it. Acceptable; note it in the
+  report.
+* `E{n}RIO` assumes fewer than 10 chains per domain, beyond which `E10RIO`
+  widens the segment. No beamline is near this.
+* Only I21 has been examined. Other beamlines may use terminal types absent from
+  `terminal_types.yaml` (37 types present), which would degrade `group_alias` to
+  `MOD`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ bumping a submodule.
 - `/beamline-convert <beamline> [services-repo]` — convert all builder XML IOCs for a beamline
 - `/beamline-reconvert <beamline> [services-repo]` — re-run xml2yaml on all IOCs and validate schema
 - `/beamline-check <beamline> [services-repo]` — run ioc-check on all IOCs in a beamline
+- `/catio-convert <BLxxI-BUILDER> [services-repo]` — migrate a beamline's EtherCAT chains off the legacy `ethercat` scanner onto fastcs-catio, rewriting every consumer's PV references
 - `/ibek-concepts` — ibek entity model patterns (type: id/object, databases.args, Jinja2, auto_* entities, port references)
 - `/vdct-conversion` — VDCT `.vdb` → msi `.template` conversion and `auto_*` derivation
 - `/streamdevice-sweep` — **(work in progress)** sweep `/dls_sw/prod` for

--- a/src/builder2ibek/__main__.py
+++ b/src/builder2ibek/__main__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import typer
 
 from builder2ibek import __version__
+from builder2ibek.catio.cli import catio_cli
 from builder2ibek.convert import convert_file
 from builder2ibek.db2autosave import parse_templates
 from builder2ibek.dbcompare import compare_dbs
@@ -204,6 +205,58 @@ def reconvert(
         descriptions_json=descriptions_json,
         only=list(only) or None,
         json_out=json_out,
+    )
+
+
+@cli.command()
+def catio(
+    builder_path: Path = typer.Argument(
+        ...,
+        help="Path to a BLXXY-BUILDER support module (its etc/makeIocs is used) "
+        "or directly to a folder of builder IOC XMLs",
+    ),
+    services_repo: Path = typer.Option(
+        ..., "--services-repo", help="Path to the beamline services repo"
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict/--no-strict",
+        help="Promote device-mod-mismatch to an error, so a chain whose "
+        "declared DEVICE names disagree with the bus positions is not converted",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Do the full analysis and report, but write nothing"
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON on stdout"
+    ),
+    node_prefix: str | None = typer.Option(
+        None,
+        "--node-prefix",
+        help="Override the fastcs-catio node_prefix template. {domain} and {n} "
+        "are replaced per chain; {:02d} is left for fastcs-catio",
+    ),
+    module_prefix: str | None = typer.Option(
+        None, "--module-prefix", help="Override the fastcs-catio module_prefix template"
+    ),
+    device_prefix: str | None = typer.Option(
+        None, "--device-prefix", help="Override the fastcs-catio device_prefix template"
+    ),
+):
+    """
+    Migrate a beamline's EtherCAT IOCs from the legacy ethercat support module
+    onto fastcs-catio: predict the new PV names, rewrite every consumer IOC's
+    references, and write one fastcs-catio IOC per chain.
+    """
+    catio_cli(
+        builder_path,
+        services_repo,
+        strict=strict,
+        dry_run=dry_run,
+        json_out=json_out,
+        node_prefix=node_prefix,
+        module_prefix=module_prefix,
+        device_prefix=device_prefix,
     )
 
 

--- a/src/builder2ibek/catio/__init__.py
+++ b/src/builder2ibek/catio/__init__.py
@@ -1,0 +1,110 @@
+"""Migration of DLS EtherCAT IOCs from the legacy `ethercat` support module onto
+`fastcs-catio`.
+
+fastcs-catio auto-generates its PV names from the bus topology, so they differ
+from the ones the legacy `ethercat` templates created. This package predicts the
+new names *statically* -- before any hardware is reconfigured -- and rewrites
+every consumer IOC's PV references to match.
+
+The modules split by responsibility:
+
+* :mod:`~builder2ibek.catio.leaves` -- legacy record suffix to fastcs attribute
+  name, per builder entity type. Pure tables.
+* :mod:`~builder2ibek.catio.diagnostics` -- severity-carrying problem reports.
+  ``ERROR`` skips the owning chain; ``WARNING`` is reported and conversion
+  proceeds.
+* :mod:`~builder2ibek.catio.substitute` -- token-wise rewriting of parsed
+  builder entity values, including the read/write link-direction rule.
+* :mod:`~builder2ibek.catio.chains` -- builder XML to chain topology, PV-name
+  prediction, and the substitution map that ties the three together.
+* :mod:`~builder2ibek.catio.services` -- services-repo scaffolding: the
+  fastcs-catio IOC folder per chain and the rewritten consumer IOCs.
+* :mod:`~builder2ibek.catio.cli` -- the ``builder2ibek catio`` command body and
+  its report. Not re-exported here, so that importing this package does not drag
+  in typer and the converter machinery; ``builder2ibek.__main__`` imports it
+  directly.
+
+Only :mod:`~builder2ibek.catio.chains` touches `fastcs_catio`, and it imports it
+lazily inside :func:`~builder2ibek.catio.chains.predict_prefixes`: pytest
+collects `src` with ``--doctest-modules``, so a top-level import would fail the
+whole suite in builder2ibek's own environment, which deliberately does not have
+it installed.
+"""
+
+from builder2ibek.catio.chains import (
+    Chain,
+    Slave,
+    UnresolvedMap,
+    build_substituter,
+    catio_ioc_name,
+    discover_chains,
+    is_scanner,
+    parse_chain,
+    predict_prefixes,
+    report_unused_ambiguities,
+)
+from builder2ibek.catio.diagnostics import (
+    CODES,
+    STRICT_PROMOTIONS,
+    Diagnostic,
+    DiagnosticLog,
+    Severity,
+)
+from builder2ibek.catio.leaves import (
+    KNOWN_ENTITY_TYPES,
+    TERMINALS,
+    Leaf,
+    leaf_translations,
+    pv_leaf,
+    snake_to_pascal,
+    unmapped_suffixes,
+)
+from builder2ibek.catio.services import (
+    IBEK_PLACEHOLDERS,
+    is_legacy,
+    read_sticky_ordinals,
+    scaffold,
+    write_catio_ioc,
+    write_ioc,
+)
+from builder2ibek.catio.substitute import (
+    NewPv,
+    Substituter,
+    SubstitutionMap,
+    link_is_reading,
+)
+
+__all__ = [
+    "CODES",
+    "IBEK_PLACEHOLDERS",
+    "KNOWN_ENTITY_TYPES",
+    "STRICT_PROMOTIONS",
+    "TERMINALS",
+    "Chain",
+    "Diagnostic",
+    "DiagnosticLog",
+    "Leaf",
+    "NewPv",
+    "Severity",
+    "Slave",
+    "SubstitutionMap",
+    "Substituter",
+    "UnresolvedMap",
+    "build_substituter",
+    "catio_ioc_name",
+    "discover_chains",
+    "is_legacy",
+    "is_scanner",
+    "leaf_translations",
+    "link_is_reading",
+    "parse_chain",
+    "predict_prefixes",
+    "pv_leaf",
+    "read_sticky_ordinals",
+    "report_unused_ambiguities",
+    "scaffold",
+    "snake_to_pascal",
+    "unmapped_suffixes",
+    "write_catio_ioc",
+    "write_ioc",
+]

--- a/src/builder2ibek/catio/chains.py
+++ b/src/builder2ibek/catio/chains.py
@@ -1,0 +1,1063 @@
+"""EtherCAT chain modelling: builder XML in, fastcs-catio PV names out.
+
+A DLS *scanner* IOC declares one EtherCAT master and its bus in builder XML::
+
+    <ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>
+    <ethercat.EthercatSlave name="DCS00025070" type_rev="EK1100 rev 0x00120000"/>
+    <ethercat.EthercatSlave name="DCS00024908" type_rev="EL3104 rev 0x00120000"/>
+    <ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-04:MOD1" PORT="DCS00024908"/>
+
+`EthercatSlave` elements are in true bus order; each `auto_*` entity binds to one
+of them through ``PORT=`` and declares the PV prefix the legacy IOC gave that
+terminal in ``DEVICE=``. This module turns that into a :class:`Chain`, predicts
+the prefix fastcs-catio will use for every terminal, and assembles the
+:class:`~builder2ibek.catio.substitute.Substituter` that rewrites consumers.
+
+Node indexing follows fastcs-catio, **not** the fixtures
+-------------------------------------------------------
+
+:data:`Slave.node` is 1-based: node 0 is reserved for slaves that appear ahead
+of the first coupler, exactly as ``fastcs_catio.naming._locate`` numbers them.
+That is what makes ``predict_prefixes()[(slave.node, slave.position)]`` a direct
+lookup. ``tests/samples/catio/expected_chains.json`` and
+``.catio-spec/spec_ground.json`` instead number couplers from 0, so a fixture's
+``node`` is this module's ``node`` minus one.
+
+The dual-key substitution map
+-----------------------------
+
+Each terminal contributes **two** families of legacy PV name:
+
+1. **declared** -- ``{DEVICE}:{suffix}``. Authoritative: this is literally the
+   name the legacy IOC's records were created with.
+2. **chain-derived** -- ``{coupler label}:MOD{position}:{suffix}``. A best-effort
+   alias for consumers that followed bus position rather than the declaration.
+
+Where the two disagree the **declared name wins and the derived alias is
+dropped**. This matters: ``BL21I-DI-ERIO-01`` has a terminal declaring ``MOD10``
+at bus position 14 *and* a different terminal at bus position 10. Only the
+declared name ever existed as a record, so a consumer writing
+``BL21I-DI-ERIO-01:MOD10:CHANNEL1:OUTPUT`` provably meant position 14. Treating
+that as an unresolvable ambiguity would fail the whole `BL21I-DI-IOC-01` chain
+for no reason; 78 keys are in this position on I21 alone.
+
+Genuine ambiguity -- two *declared* names, or two *derived* names, resolving to
+different terminals -- still drops the key into ``unresolved`` under
+``ambiguous-legacy-pv``. Because whether anything references it is not known
+until substitution has run, the CLI calls :func:`report_unused_ambiguities`
+afterwards to downgrade the untouched ones to ``ambiguous-legacy-pv-unused``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from builder2ibek.builder import Builder
+from builder2ibek.catio.diagnostics import DiagnosticLog
+from builder2ibek.catio.leaves import (
+    KNOWN_ENTITY_TYPES,
+    TERMINALS,
+    leaf_translations,
+    pv_leaf,
+    unmapped_suffixes,
+)
+from builder2ibek.catio.substitute import NewPv, Substituter, SubstitutionMap
+
+__all__ = [
+    "BOX",
+    "BOX_TYPE_RE",
+    "COUPLER",
+    "COUPLER_TYPE",
+    "EXTENSION_TYPE",
+    "MAKE_IOCS",
+    "SLAVE",
+    "Chain",
+    "Slave",
+    "UnresolvedMap",
+    "build_substituter",
+    "catio_ioc_name",
+    "chain_by_ioc",
+    "discover_chains",
+    "domain_of",
+    "is_scanner",
+    "parse_chain",
+    "predict_prefixes",
+    "report_unused_ambiguities",
+]
+
+#: Exact type string that opens a new coupler node. Mirrors
+#: ``fastcs_catio.naming.COUPLER_TYPE``.
+COUPLER_TYPE = "EK1100"
+
+#: Bus extension; ahead of the first coupler it burns one position to reserve
+#: the slot of an EK1200 that TwinCAT does not report. Mirrors
+#: ``fastcs_catio.naming.EXTENSION_TYPE``.
+EXTENSION_TYPE = "EK1110"
+
+#: A box is a coupler-and-terminals in one housing. Anchored, and deliberately
+#: *not* matching ``EK1122`` junctions, which take an ordinary position. Mirrors
+#: ``fastcs_catio.naming.BOX_TYPE_RE``.
+BOX_TYPE_RE = re.compile(r"(E[PQR]P?\d{4})")
+
+COUPLER = "coupler"
+BOX = "box"
+SLAVE = "slave"
+
+#: Where an XMLbuilder support module keeps its IOC definitions.
+MAKE_IOCS = Path("etc/makeIocs")
+
+#: ``type_rev`` looks like ``"EL3104 rev 0x00120000"``; the revision is optional.
+_TYPE_REV_RE = re.compile(r"^(?P<type>\S+)(?:\s+rev\s+(?P<rev>\S+))?\s*$")
+
+#: A declared ``DEVICE=`` split into its coupler label and its ``MOD`` part.
+#: Greedy, so the *last* ``:MOD`` separates them. ``mod`` may be non-numeric
+#: (``MODSAM3``), in which case it is an opaque label and no position check
+#: applies.
+_DEVICE_MOD_RE = re.compile(r"^(?P<label>.+):MOD(?P<mod>.+)$")
+
+
+@dataclass(frozen=True)
+class Slave:
+    """One EtherCAT slave, located on the bus and bound to its builder entity.
+
+    :param node: 1-based coupler/box ordinal; 0 for slaves ahead of the first.
+    :param position: 0 on the coupler itself, then 1, 2, ... along its terminals.
+    :param type_name: CANopen type, e.g. ``"EL3104"`` or ``"EL2024-0010"``.
+    :param revision: EtherCAT revision as an int, or None when ``type_rev``
+        carried no ``rev`` part.
+    :param slave_name: the ``EthercatSlave`` ``name=``, which is also the asyn
+        port an ``auto_*`` entity names in ``PORT=``.
+    :param category: :data:`COUPLER`, :data:`BOX` or :data:`SLAVE`.
+    :param entity_type: the bound ``auto_*`` element name, e.g. ``auto_EL3104``.
+    :param entity_name: that entity's ``name=``.
+    :param declared_device: that entity's ``DEVICE=`` -- the legacy PV prefix.
+    """
+
+    node: int
+    position: int
+    type_name: str
+    revision: int | None
+    slave_name: str
+    category: str
+    entity_type: str | None = None
+    entity_name: str | None = None
+    declared_device: str | None = None
+
+    @property
+    def is_known(self) -> bool:
+        """True when a bound entity has a leaf translation table.
+
+        >>> Slave(1, 1, "EL3104", None, "P", SLAVE, "auto_EL3104").is_known
+        True
+        >>> Slave(1, 1, "EL2595", None, "P", SLAVE, "auto_EL2595").is_known
+        False
+        >>> Slave(1, 0, "EK1100", None, "P", COUPLER).is_known
+        False
+        """
+        return self.entity_type in KNOWN_ENTITY_TYPES
+
+
+@dataclass
+class Chain:
+    """One scanner IOC's EtherCAT bus, and the fastcs-catio IOC replacing it."""
+
+    scanner_ioc: str
+    domain: str
+    ordinal: int
+    slaves: list[Slave] = field(default_factory=list)
+    labels: dict[int, str | None] = field(default_factory=dict)
+
+    @property
+    def catio_ioc(self) -> str:
+        """The fastcs-catio IOC name.
+
+        >>> Chain("BL21I-VA-IOC-01", "BL21I-VA", 1).catio_ioc
+        'BL21I-VA-CATIO-01'
+        """
+        return catio_ioc_name(self.scanner_ioc)
+
+    @property
+    def services_folder(self) -> str:
+        """The services-repo folder holding that IOC.
+
+        >>> Chain("BL21I-VA-IOC-01", "BL21I-VA", 1).services_folder
+        'bl21i-va-catio-01'
+        """
+        return self.catio_ioc.lower()
+
+    @property
+    def node_prefix(self) -> str:
+        """``name_mappings.node_prefix`` for this chain.
+
+        Absolute on purpose. fastcs-catio's default,
+        ``"{device_prefix}:E1RIO{:02d}"``, would make a four-segment module path
+        and trip the shortening guard -- see :func:`predict_prefixes`.
+
+        >>> Chain("BL21I-VA-IOC-01", "BL21I-VA", 2).node_prefix
+        'BL21I-VA-E2RIO-{:02d}'
+        """
+        return f"{self.domain}-E{self.ordinal}RIO-{{:02d}}"
+
+    @property
+    def device_prefix(self) -> str:
+        """``name_mappings.device_prefix``; the fastcs-catio default."""
+        return "{id}:ETH{:02d}"
+
+    @property
+    def module_prefix(self) -> str:
+        """``name_mappings.module_prefix``, keyed on the terminal group alias."""
+        return "{node_prefix}:{group_alias}{:02d}"
+
+    def name_mappings(self) -> dict[str, str]:
+        """The three templates, ready for ``config/fastcs.yaml``.
+
+        The generated IOC and the names predicted here **must** come from this
+        one source: a divergence points every rewritten PV at nothing.
+
+        >>> Chain("BL21I-VA-IOC-01", "BL21I-VA", 1).name_mappings()["node_prefix"]
+        'BL21I-VA-E1RIO-{:02d}'
+        """
+        return {
+            "device_prefix": self.device_prefix,
+            "node_prefix": self.node_prefix,
+            "module_prefix": self.module_prefix,
+        }
+
+
+def catio_ioc_name(scanner_ioc: str) -> str:
+    """The fastcs-catio IOC name replacing *scanner_ioc*.
+
+    Only a whole ``IOC`` dash-segment is renamed, so a beamline that happens to
+    contain the letters elsewhere is left alone.
+
+    >>> catio_ioc_name("BL21I-DI-IOC-01")
+    'BL21I-DI-CATIO-01'
+    """
+    parts = ["CATIO" if part == "IOC" else part for part in scanner_ioc.split("-")]
+    return "-".join(parts)
+
+
+class UnresolvedMap(dict[str, tuple[str, str, str | None]]):
+    """``unresolved`` for :class:`~builder2ibek.catio.substitute.Substituter`.
+
+    A plain ``dict`` of full legacy PV -> ``(code, message, chain)``, extended
+    with *prefix* entries. A terminal whose ``auto_*`` entity type has no leaf
+    table has unknowable record suffixes, so it cannot be enumerated key by key;
+    registering its PV prefix makes every reference beneath it resolve to the
+    same diagnostic.
+
+    Only :meth:`get` consults the prefixes -- that is the sole method
+    ``Substituter`` calls -- so ``in``, ``[]`` and iteration stay exact.
+
+    >>> u = UnresolvedMap()
+    >>> u.add_prefix("BL21I-DI-LED-01", ("unknown-entity-type", "no table", "X"))
+    >>> u.get("BL21I-DI-LED-01:CHANNEL1:OUTPUT")[0]
+    'unknown-entity-type'
+    >>> u.get("BL21I-DI-LED-011:CHANNEL1:OUTPUT") is None
+    True
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        #: PV prefix -> the entry every PV beneath it resolves to.
+        self.prefixes: dict[str, tuple[str, str, str | None]] = {}
+
+    def add_prefix(self, prefix: str, entry: tuple[str, str, str | None]) -> None:
+        """Make every PV under *prefix* resolve to *entry*."""
+        self.prefixes[prefix] = entry
+
+    def get(  # type: ignore[override]
+        self, key: str, default: tuple[str, str, str | None] | None = None
+    ) -> tuple[str, str, str | None] | None:
+        """Exact match first, then the longest registered prefix."""
+        entry = super().get(key)
+        if entry is not None:
+            return entry
+        best: str | None = None
+        for prefix in self.prefixes:
+            if not key.startswith(prefix + ":"):
+                continue
+            if best is None or len(prefix) > len(best):
+                best = prefix
+        return self.prefixes[best] if best is not None else default
+
+
+# -- parsing -----------------------------------------------------------------
+
+
+def _locate(type_names: Sequence[str]) -> list[tuple[int, int, str]]:
+    """Assign ``(node, position, category)`` to each slave, in bus order.
+
+    A local copy of ``fastcs_catio.naming._locate``, duplicated because this
+    module must import cleanly without `fastcs_catio` (pytest collects `src`
+    with ``--doctest-modules``). ``test_catio_chains.py`` asserts the two agree
+    on every sample chain, which is what stops them drifting.
+
+    >>> _locate(["EK1100", "EL3104", "EK1122", "EL1014"])
+    [(1, 0, 'coupler'), (1, 1, 'slave'), (1, 2, 'slave'), (1, 3, 'slave')]
+    >>> _locate(["EK1100", "EL3104", "EK1100", "EL1014"])[2]
+    (2, 0, 'coupler')
+    """
+    located: list[tuple[int, int, str]] = []
+    node = 0
+    position = 0
+    for type_name in type_names:
+        category = SLAVE
+        if type_name == EXTENSION_TYPE and node == 0:
+            position += 1
+        if type_name == COUPLER_TYPE:
+            category = COUPLER
+            node += 1
+            position = 0
+        if BOX_TYPE_RE.match(type_name) is not None:
+            category = BOX
+            node += 1
+            position = 0
+        located.append((node, position, category))
+        position += 1
+    return located
+
+
+def _split_type_rev(type_rev: str) -> tuple[str, int | None]:
+    """Split an ``EthercatSlave`` ``type_rev`` into type name and revision.
+
+    >>> _split_type_rev("EL3104 rev 0x00120000")
+    ('EL3104', 1179648)
+    >>> _split_type_rev("EL2024-0010")
+    ('EL2024-0010', None)
+    """
+    match = _TYPE_REV_RE.match(type_rev.strip())
+    if match is None:  # pragma: no cover - type_rev is always non-empty in practice
+        return type_rev.strip(), None
+    revision = match.group("rev")
+    if revision is None:
+        return match.group("type"), None
+    try:
+        return match.group("type"), int(revision, 0)
+    except ValueError:
+        return match.group("type"), None
+
+
+def is_scanner(builder: Builder) -> bool:
+    """True when this IOC declares an EtherCAT master, and so owns a chain.
+
+    >>> from builder2ibek.builder import Builder
+    >>> b = Builder()
+    >>> b.load_string('<components arch="linux-x86_64">'
+    ...               '<ethercat.EthercatMaster name="ECATM"/></components>')
+    >>> is_scanner(b)
+    True
+    """
+    return any(
+        element.module == "ethercat" and element.name == "EthercatMaster"
+        for element in builder.elements
+    )
+
+
+def _bind_entities(builder: Builder) -> dict[str, list]:
+    """``EthercatSlave`` name -> the ``auto_*`` entities naming it in ``PORT=``."""
+    by_port: dict[str, list] = {}
+    for element in builder.elements:
+        if element.module == "ethercat" and element.name.startswith("auto_"):
+            by_port.setdefault(element.attributes.get("PORT", ""), []).append(element)
+    return by_port
+
+
+def _derive_labels(chain: Chain, log: DiagnosticLog) -> None:
+    """Fill ``chain.labels`` from the ``DEVICE=`` of each coupler's terminals.
+
+    The label is the unanimous part before ``:MOD``. Entities whose ``DEVICE``
+    has no ``:MOD`` part -- ``BL21I-OP-LED-01``, ``BL21I-MO-PIEZO-01`` -- name a
+    device rather than a bus slot and are ignored, with ``device-without-mod``.
+    ``<!--Start of ...-->`` comments are ignored entirely: they are unvalidatable
+    free text and are simply wrong in `BL21I-VA-IOC-06`.
+    """
+    candidates: dict[int, dict[str, list[Slave]]] = {}
+    for slave in chain.slaves:
+        candidates.setdefault(slave.node, {})
+        device = slave.declared_device
+        if not device:
+            continue
+        match = _DEVICE_MOD_RE.match(device)
+        if match is None:
+            log.add(
+                "device-without-mod",
+                f"{slave.entity_type} declares DEVICE={device!r}, which has no "
+                "':MOD' part, so it is ignored when deriving the coupler label",
+                chain=chain.scanner_ioc,
+                entity=slave.entity_name,
+                attribute="DEVICE",
+            )
+            continue
+        candidates[slave.node].setdefault(match.group("label"), []).append(slave)
+
+    for node, found in candidates.items():
+        if len(found) == 1:
+            chain.labels[node] = next(iter(found))
+        elif not found:
+            chain.labels[node] = None
+            if node == 0:
+                # Slaves ahead of the first coupler. There is no coupler to
+                # label, so nothing is missing.
+                continue
+            log.add(
+                "unlabelled-coupler",
+                f"node {node} has no entity declaring a 'LABEL:MODn' DEVICE, so "
+                "no coupler label can be derived; chain-derived aliases for its "
+                "terminals will not be registered",
+                chain=chain.scanner_ioc,
+            )
+        else:
+            chain.labels[node] = None
+            log.add(
+                "coupler-label-conflict",
+                f"node {node} carries entities declaring more than one coupler "
+                f"label: {', '.join(sorted(found))}",
+                chain=chain.scanner_ioc,
+            )
+
+    seen: dict[str, list[int]] = {}
+    for node, label in chain.labels.items():
+        if label:
+            seen.setdefault(label, []).append(node)
+    for label, nodes in seen.items():
+        if len(nodes) > 1:
+            log.add(
+                "duplicate-coupler-label",
+                f"label {label} is derived for nodes {nodes}; their declared PV "
+                "names stay distinct, but chain-derived aliases that collide "
+                "will be dropped",
+                chain=chain.scanner_ioc,
+            )
+
+
+def _check_declarations(chain: Chain, log: DiagnosticLog) -> None:
+    """Cross-check each bound entity against the slave it landed on."""
+    for slave in chain.slaves:
+        if slave.entity_type is None:
+            continue
+        if slave.entity_type in TERMINALS:
+            expected = TERMINALS[slave.entity_type].terminal_type
+            if expected != slave.type_name:
+                log.add(
+                    "slave-type-mismatch",
+                    f"slave {slave.slave_name} is a {slave.type_name} but is "
+                    f"bound to {slave.entity_type}, which describes a "
+                    f"{expected}; the {expected} leaf table is used anyway",
+                    chain=chain.scanner_ioc,
+                    entity=slave.entity_name,
+                    attribute="PORT",
+                )
+        match = _DEVICE_MOD_RE.match(slave.declared_device or "")
+        if match is None:
+            continue
+        mod = match.group("mod")
+        if mod.isdigit() and int(mod) != slave.position:
+            log.add(
+                "device-mod-mismatch",
+                f"{slave.entity_name or slave.entity_type} declares "
+                f"DEVICE={slave.declared_device!r} but sits at bus position "
+                f"{slave.position} of node {slave.node}; the declared name is "
+                "kept and the chain-derived alias is registered as well",
+                chain=chain.scanner_ioc,
+                entity=slave.entity_name,
+                attribute="DEVICE",
+            )
+
+
+def _chain_from_builder(
+    builder: Builder, log: DiagnosticLog, *, ordinal: int
+) -> Chain | None:
+    """Build a :class:`Chain` from an already-loaded scanner :class:`Builder`."""
+    if not is_scanner(builder):
+        return None
+    scanner_ioc = builder.name
+    chain = Chain(
+        scanner_ioc=scanner_ioc,
+        domain=domain_of(scanner_ioc),
+        ordinal=ordinal,
+    )
+    elements = [
+        e
+        for e in builder.elements
+        if e.module == "ethercat" and e.name == "EthercatSlave"
+    ]
+    by_port = _bind_entities(builder)
+    type_names = [
+        _split_type_rev(e.attributes.get("type_rev", ""))[0] for e in elements
+    ]
+    for element, (node, position, category) in zip(
+        elements, _locate(type_names), strict=True
+    ):
+        type_name, revision = _split_type_rev(element.attributes.get("type_rev", ""))
+        slave_name = element.attributes.get("name", "")
+        # Only the first binding is modelled: no slave in any DLS tree examined
+        # carries two auto_* entities, and Slave holds a single entity.
+        entities = by_port.get(slave_name, [])
+        entity = entities[0] if entities else None
+        chain.slaves.append(
+            Slave(
+                node=node,
+                position=position,
+                type_name=type_name,
+                revision=revision,
+                slave_name=slave_name,
+                category=category,
+                entity_type=entity.name if entity else None,
+                entity_name=entity.attributes.get("name") if entity else None,
+                declared_device=entity.attributes.get("DEVICE") if entity else None,
+            )
+        )
+    _derive_labels(chain, log)
+    _check_declarations(chain, log)
+    return chain
+
+
+def parse_chain(xml: Path, log: DiagnosticLog, *, ordinal: int) -> Chain | None:
+    """Parse one builder XML into a :class:`Chain`.
+
+    :param xml: the IOC's builder XML. Its stem is taken as the IOC name.
+    :param log: diagnostics are appended here; parsing never raises for a
+        malformed chain.
+    :param ordinal: this chain's ``E{n}RIO`` number within its domain -- see
+        :func:`discover_chains`, which allocates them.
+    :returns: the chain, or None when the IOC declares no EtherCAT master.
+    """
+    builder = Builder()
+    builder.load(xml)
+    return _chain_from_builder(builder, log, ordinal=ordinal)
+
+
+def domain_of(ioc_name: str) -> str:
+    """The first two dash-segments of an IOC name.
+
+    >>> domain_of("BL21I-VA-IOC-01")
+    'BL21I-VA'
+    """
+    return "-".join(ioc_name.split("-")[:2])
+
+
+def discover_chains(
+    builder_root: Path,
+    log: DiagnosticLog,
+    *,
+    sticky: dict[str, int] | None = None,
+) -> list[Chain]:
+    """Find and parse every scanner chain under *builder_root*.
+
+    :param builder_root: either a BUILDER support module root (its XMLs are then
+        read from ``etc/makeIocs``) or a directory that already *is* an
+        ``etc/makeIocs``. Which it is, is detected: the ``etc/makeIocs``
+        subdirectory is used when present, else *builder_root* itself.
+    :param log: diagnostics from parsing every chain.
+    :param sticky: ``catio_ioc -> ordinal`` read back from a services repo by
+        :func:`builder2ibek.catio.services.read_sticky_ordinals`. Honoured
+        exactly; only chains absent from it get a freshly allocated ordinal.
+        Renumbering an already-generated chain would repoint every PV that a
+        previous run rewrote at a name nothing creates. A pin whose scanner XML
+        is *gone* still reserves its ordinal: that IOC is deployed and answering
+        on those PVs whether or not its builder XML survives.
+    :returns: the chains, sorted by domain then scanner IOC name.
+    :raises ValueError: when *sticky* gives two IOCs of one domain the same
+        ordinal. That is a corrupt services repo, not a defect in any chain, so
+        it is not a diagnostic.
+
+    Ordinals are allocated per domain (``BL21I-VA``), in ascending scanner-IOC
+    name order, from the lowest positive integers left free by *sticky*.
+    """
+    search = builder_root / MAKE_IOCS
+    if not search.is_dir():
+        search = builder_root
+
+    builders: dict[str, Builder] = {}
+    for xml in sorted(search.glob("*.xml")):
+        builder = Builder()
+        builder.load(xml)
+        if is_scanner(builder):
+            builders[builder.name] = builder
+
+    sticky = sticky or {}
+    ordinals: dict[str, int] = {}
+    by_domain: dict[str, list[str]] = {}
+    for scanner_ioc in sorted(builders):
+        by_domain.setdefault(domain_of(scanner_ioc), []).append(scanner_ioc)
+
+    for domain, scanners in by_domain.items():
+        taken: dict[int, str] = {}
+        by_catio_ioc = {catio_ioc_name(scanner): scanner for scanner in scanners}
+        # Every pin in this domain reserves its ordinal, including *orphans* --
+        # a services folder whose scanner XML has since been renamed or retired
+        # is still deployed and still owns its E{n}RIO names. Handing a live
+        # chain an orphan's ordinal would put two IOCs on identical PVs.
+        for catio_ioc, pinned in sorted(sticky.items()):
+            if domain_of(catio_ioc) != domain:
+                continue
+            if pinned in taken:
+                raise ValueError(
+                    f"services repo pins ordinal {pinned} to both "
+                    f"{taken[pinned]} and {catio_ioc} in "
+                    f"domain {domain}; fix the duplicate node_prefix in their "
+                    "config/fastcs.yaml before re-running"
+                )
+            taken[pinned] = catio_ioc
+            if catio_ioc in by_catio_ioc:
+                ordinals[by_catio_ioc[catio_ioc]] = pinned
+        next_free = 1
+        for scanner_ioc in scanners:
+            if scanner_ioc in ordinals:
+                continue
+            while next_free in taken:
+                next_free += 1
+            taken[next_free] = catio_ioc_name(scanner_ioc)
+            ordinals[scanner_ioc] = next_free
+            next_free += 1
+
+    chains: list[Chain] = []
+    for domain in sorted(by_domain):
+        for scanner_ioc in by_domain[domain]:
+            chain = _chain_from_builder(
+                builders[scanner_ioc], log, ordinal=ordinals[scanner_ioc]
+            )
+            if chain is not None:
+                chains.append(chain)
+    return chains
+
+
+# -- name prediction ---------------------------------------------------------
+
+_NO_FASTCS = (
+    "fastcs_catio is required to predict fastcs-catio PV names. It is "
+    "deliberately absent from builder2ibek's own environment -- its release "
+    "pins a fastcs version that no longer exists on PyPI, so adding it breaks "
+    "`uv lock`. Run this command with the side venv instead, e.g.\n"
+    "    .venv-catio/bin/python -m builder2ibek catio ...\n"
+    "(see .catio-spec/HANDOFF.md)"
+)
+
+
+def _is_writable(access: str | None) -> bool:
+    """FastCS's own read/write test, from ``AdsItemBase.readonly``.
+
+    Duplicated rather than imported because it is a property of an instantiated
+    ADS item, which needs a live controller.
+
+    >>> _is_writable("Read/Write"), _is_writable("Read-only"), _is_writable(None)
+    (True, False, False)
+    """
+    if access is None:
+        return False
+    lowered = access.lower()
+    return "write" in lowered or lowered in ("rw", "wo")
+
+
+def _fastcs_attributes(type_name: str) -> dict[str, bool]:
+    """The PDO attributes fastcs-catio gives *type_name* -> whether each is R/W.
+
+    Read straight from ``terminal_types.yaml`` via fastcs-catio's own loader, so
+    :mod:`builder2ibek.catio.leaves` is checked against the library rather than
+    against a second hand-maintained copy of it. Only *selected* symbol nodes
+    appear, matching ``catio_dynamic_controller.create_terminal_controller``;
+    CoE and runtime attributes are deliberately excluded, as no leaf table maps
+    to one.
+
+    :raises ImportError: when `fastcs_catio` is not installed.
+    """
+    try:
+        from fastcs_catio.terminal_config import (
+            get_terminal_type,
+            symbol_to_fastcs_name,
+        )
+    except ImportError as err:  # pragma: no cover - depends on the environment
+        raise ImportError(_NO_FASTCS) from err
+
+    attributes: dict[str, bool] = {}
+    for symbol in get_terminal_type(type_name).symbol_nodes:
+        if not symbol.selected:
+            continue
+        channels = symbol.channel_indices if symbol.channels > 1 else [None]
+        for channel in channels:
+            attributes[symbol_to_fastcs_name(symbol, channel)] = _is_writable(
+                symbol.access
+            )
+    return attributes
+
+
+def predict_prefixes(chain: Chain, log: DiagnosticLog) -> dict[tuple[int, int], str]:
+    """``(node, position)`` -> the PV prefix fastcs-catio will give that slave.
+
+    Delegates the naming rule entirely to ``fastcs_catio.naming``: reproducing
+    it here would let the two drift, and a drift points every rewritten PV at a
+    name nothing creates. ``predict_chain`` is used rather than
+    ``predict_names`` -- it returns the same prefixes plus the ``path``
+    segments the shortening guard needs.
+
+    The **shortening guard**: FastCS truncates an attribute name that will not
+    fit the 60-character EPICS PV limit at its controller's prefix. With
+    fastcs-catio's default four-segment ``node_prefix`` the budget drops far
+    enough to truncate ``ai_standard_channel_1_value``, collapsing all twelve
+    EL3104 attributes onto one name and crashing the IOC at startup. Every leaf
+    this chain will emit is therefore checked against fastcs-catio's own
+    ``max_attribute_name_length`` / ``shorten_fastcs_name`` at the prefix
+    actually emitted; any that shortens raises ``shortened-leaf``.
+
+    The **leaf check**: every leaf is looked up in the attribute set
+    fastcs-catio will actually build for the slave's *own* type
+    (:func:`_fastcs_attributes`), not for the type its ``auto_*`` entity claims.
+    A leaf that is absent, or whose writability disagrees (which decides the
+    ``_RBV`` suffix), would be rewritten to a PV the new IOC never creates, so
+    it raises ``leaf-type-mismatch``. This is what keeps
+    :mod:`builder2ibek.catio.leaves` honest against ``terminal_types.yaml``, and
+    what catches an entity bound to the wrong terminal -- the case
+    ``slave-type-mismatch`` only warns about.
+
+    :returns: the prefixes, or ``{}`` when the chain names a terminal type
+        fastcs-catio does not know (``unknown-terminal-type``).
+    :raises ImportError: when `fastcs_catio` is not installed.
+    """
+    try:
+        from catio_terminals.utils import shorten_fastcs_name
+        from fastcs_catio.catio_controller import CATioNameMappings
+        from fastcs_catio.naming import (
+            ChainEntry,
+            UnknownTerminalTypeError,
+            predict_chain,
+        )
+        from fastcs_catio.utils import max_attribute_name_length
+    except ImportError as err:  # pragma: no cover - depends on the environment
+        raise ImportError(_NO_FASTCS) from err
+
+    mappings = CATioNameMappings(
+        device_prefix=chain.device_prefix,
+        node_prefix=chain.node_prefix,
+        module_prefix=chain.module_prefix,
+    )
+    entries = [ChainEntry(s.type_name, s.revision) for s in chain.slaves]
+    try:
+        predicted = predict_chain(
+            entries, mappings, root_id=chain.catio_ioc, strict=True
+        )
+    except UnknownTerminalTypeError as err:
+        log.add(
+            "unknown-terminal-type",
+            f"{err.args[0] if err.args else err}",
+            chain=chain.scanner_ioc,
+        )
+        return {}
+
+    for slave in chain.slaves:
+        if not slave.is_known:
+            continue
+        path = predicted[(slave.node, slave.position)].path
+        actual = _fastcs_attributes(slave.type_name)
+        for leaf in leaf_translations(slave.entity_type or "").values():
+            if leaf.fastcs_name not in actual:
+                log.add(
+                    "leaf-type-mismatch",
+                    f"{slave.entity_type} translates a legacy record to "
+                    f"{leaf.fastcs_name!r}, but the {slave.type_name} on port "
+                    f"{slave.slave_name} has no such fastcs-catio attribute, so "
+                    "the rewritten PV would not exist",
+                    chain=chain.scanner_ioc,
+                    entity=slave.entity_name,
+                )
+                continue
+            if actual[leaf.fastcs_name] != leaf.writable:
+                direction = "read-only" if leaf.writable else "read/write"
+                log.add(
+                    "leaf-type-mismatch",
+                    f"{slave.entity_type} treats {leaf.fastcs_name!r} as "
+                    f"{'read/write' if leaf.writable else 'read-only'}, but on "
+                    f"the {slave.type_name} at port {slave.slave_name} it is "
+                    f"{direction}, so the '_RBV' rule would pick a PV that does "
+                    "not exist",
+                    chain=chain.scanner_ioc,
+                    entity=slave.entity_name,
+                )
+                continue
+            budget = max_attribute_name_length(path, is_rw=leaf.writable)
+            shortened = shorten_fastcs_name(leaf.fastcs_name, budget)
+            if shortened != leaf.fastcs_name:
+                log.add(
+                    "shortened-leaf",
+                    f"at prefix {':'.join(path)} FastCS shortens "
+                    f"{leaf.fastcs_name!r} to {shortened!r} (budget {budget}); "
+                    "the emitted PV would not exist and colliding leaves crash "
+                    "the IOC at startup -- shorten node_prefix",
+                    chain=chain.scanner_ioc,
+                    entity=slave.entity_name,
+                )
+
+    return {key: slave.prefix for key, slave in predicted.items()}
+
+
+# -- substitution map --------------------------------------------------------
+
+#: A pending map entry: either a resolved replacement or a reason it is not one.
+_Entry = tuple[str, object]
+_SUB = "sub"
+_BAD = "bad"
+
+
+def _register(
+    table: dict[str, tuple[_Entry, str]],
+    ambiguous: dict[str, str],
+    key: str,
+    entry: _Entry,
+    chain: str,
+) -> None:
+    """Add *key* -> *entry*, recording a genuine clash instead of overwriting.
+
+    Two entries agree when they are the same replacement, or when both are
+    unresolved for the same reason -- ``AL_STATE`` has no fastcs equivalent
+    whichever terminal declared it, so a duplicate is not an ambiguity.
+    """
+    existing = table.get(key)
+    if existing is None:
+        table[key] = (entry, chain)
+        return
+    (kind, value), owner = existing
+    if kind == entry[0] and value == entry[1]:
+        return
+    ambiguous[key] = chain if owner == chain else f"{owner} and {chain}"
+
+
+def _dead_prefixes(chain: Chain, *, skip: set[str]) -> list[str]:
+    """Every PV prefix a *failed* chain owns, so references to it can be caught.
+
+    Both families a live chain would have registered: the coupler labels a
+    chain-derived alias is built from, and each terminal's declared ``DEVICE=``.
+    Labels already claimed by a converted chain are skipped -- that chain's own
+    keys are authoritative and must not be shadowed.
+
+    >>> chain = Chain("BL21I-DI-IOC-01", "BL21I-DI", 1)
+    >>> chain.labels = {1: "BL21I-DI-ERIO-01"}
+    >>> chain.slaves = [Slave(1, 1, "EL2595", None, "P", SLAVE,
+    ...                       "auto_EL2595", "LED", "BL21I-DI-LED-01")]
+    >>> _dead_prefixes(chain, skip=set())
+    ['BL21I-DI-ERIO-01', 'BL21I-DI-LED-01']
+    """
+    prefixes = {label for label in chain.labels.values() if label}
+    prefixes |= {s.declared_device for s in chain.slaves if s.declared_device}
+    return sorted(prefixes - skip)
+
+
+def build_substituter(chains: list[Chain], log: DiagnosticLog) -> Substituter:
+    """Assemble the substitution map for every clean chain.
+
+    Chains that already recorded an ERROR (``log.failed_chains()``) contribute
+    nothing: no substitutions, and later no fastcs-catio IOC. Under ``--strict``
+    that includes chains whose only problem was ``device-mod-mismatch``.
+
+    Two passes, so that a declared name is never displaced by a chain-derived
+    alias -- see the module docstring for why that matters.
+
+    :returns: a :class:`~builder2ibek.catio.substitute.Substituter` whose
+        ``unresolved`` is an :class:`UnresolvedMap`. After running it over every
+        consumer IOC, call :func:`report_unused_ambiguities`.
+    """
+    failed = log.failed_chains()
+    live = [chain for chain in chains if chain.scanner_ioc not in failed]
+
+    prefixes: dict[str, dict[tuple[int, int], str]] = {}
+    for chain in live:
+        prefixes[chain.scanner_ioc] = predict_prefixes(chain, log)
+    failed = log.failed_chains()
+    live = [c for c in live if c.scanner_ioc not in failed and prefixes[c.scanner_ioc]]
+    live_names = {chain.scanner_ioc for chain in live}
+    dead = [chain for chain in chains if chain.scanner_ioc not in live_names]
+
+    known_labels: dict[str, str] = {}
+    for chain in live:
+        for label in chain.labels.values():
+            if not label:
+                continue
+            owner = known_labels.setdefault(label, chain.scanner_ioc)
+            if owner != chain.scanner_ioc:
+                for claimant in (owner, chain.scanner_ioc):
+                    log.add(
+                        "unknown-chain-label",
+                        f"coupler label {label} is declared by both {owner} and "
+                        f"{chain.scanner_ioc}; a reference to it cannot be "
+                        "resolved to one terminal",
+                        chain=claimant,
+                    )
+
+    declared: dict[str, tuple[_Entry, str]] = {}
+    derived: dict[str, tuple[_Entry, str]] = {}
+    # Kept apart so that an ambiguity among the positional aliases can never
+    # discard the declared name of the same PV.
+    amb_declared: dict[str, str] = {}
+    amb_derived: dict[str, str] = {}
+    # device prefix -> (scanner IOC, entity type, terminal type, entity name)
+    unknown_prefixes: dict[str, tuple[str, str, str, str | None]] = {}
+
+    for chain in live:
+        chain_prefixes = prefixes[chain.scanner_ioc]
+        for slave in chain.slaves:
+            if slave.category == COUPLER or slave.entity_type is None:
+                continue
+            device = slave.declared_device or ""
+            entity_type = slave.entity_type
+            if entity_type not in KNOWN_ENTITY_TYPES:
+                # Suffixes unknowable, so only the authoritative declared prefix
+                # is registered -- a chain-derived alias could not be enumerated
+                # and would risk shadowing a real neighbour's declared name.
+                if device:
+                    unknown_prefixes[device] = (
+                        chain.scanner_ioc,
+                        entity_type,
+                        slave.type_name,
+                        slave.entity_name,
+                    )
+                continue
+            new_prefix = chain_prefixes[(slave.node, slave.position)]
+            label = chain.labels.get(slave.node)
+            forms: list[tuple[dict, dict, str]] = []
+            if device:
+                # Any non-empty DEVICE= is registered, `:MOD`-shaped or not.
+                # The `LABEL:MODn` shape is only needed to *derive* a coupler
+                # label and to cross-check bus position; the declared name is
+                # the record the legacy IOC created either way, so gating on the
+                # shape silently dropped the real PVs of terminals named after
+                # the device they drive (`BL21I-OP-LED-01:CHANNEL1:OUTPUT`).
+                forms.append((declared, amb_declared, device))
+            if label:
+                forms.append((derived, amb_derived, f"{label}:MOD{slave.position}"))
+            for table, ambiguous, prefix in forms:
+                for suffix, leaf in leaf_translations(entity_type).items():
+                    value = NewPv(
+                        read=f"{new_prefix}:{pv_leaf(leaf, reading=True)}",
+                        write=f"{new_prefix}:{pv_leaf(leaf, reading=False)}",
+                    )
+                    _register(
+                        table,
+                        ambiguous,
+                        f"{prefix}:{suffix}",
+                        (_SUB, value),
+                        chain.scanner_ioc,
+                    )
+                for suffix in unmapped_suffixes(entity_type):
+                    _register(
+                        table,
+                        ambiguous,
+                        f"{prefix}:{suffix}",
+                        (_BAD, "unmapped-suffix"),
+                        chain.scanner_ioc,
+                    )
+
+    subs: SubstitutionMap = {}
+    owners: dict[str, str] = {}
+    unresolved = UnresolvedMap()
+
+    def emit(key: str, entry: _Entry, chain: str) -> None:
+        owners[key] = chain
+        if entry[0] == _SUB:
+            subs[key] = entry[1]  # type: ignore[assignment]
+        else:
+            unresolved[key] = (
+                "unmapped-suffix",
+                f"{key} is a legacy record with no fastcs-catio equivalent, so "
+                "the new IOC will not create it; the reference must be removed "
+                "or repointed by hand",
+                chain,
+            )
+
+    for key, (entry, chain_name) in declared.items():
+        if key not in amb_declared:
+            emit(key, entry, chain_name)
+    for key, (entry, chain_name) in derived.items():
+        # Declared names win outright: they are the records the legacy IOC
+        # really created, so a colliding positional alias is provably a guess.
+        if key in declared or key in amb_declared or key in amb_derived:
+            continue
+        emit(key, entry, chain_name)
+
+    ambiguities = dict(amb_declared)
+    for key, chain_name in amb_derived.items():
+        if key not in declared and key not in amb_declared:
+            ambiguities[key] = chain_name
+    for key, chain_name in ambiguities.items():
+        owners.setdefault(key, chain_name.split(" and ")[0])
+        unresolved[key] = (
+            "ambiguous-legacy-pv",
+            f"{key} maps to more than one fastcs-catio PV (declared on "
+            f"{chain_name}), so it was dropped rather than rewritten to the "
+            "wrong terminal",
+            chain_name.split(" and ")[0],
+        )
+
+    # A chain that failed *before* substitution contributes no keys at all, so
+    # without this its consumers would sail through: `LEGACY_PV_RE` only
+    # recognises names carrying an `-ERIO-` segment, and a declared `DEVICE=`
+    # need not have one (`BL21I-DI-LED-01`). The consumer would then be written
+    # with a dangling legacy PV and no diagnostic. Registering the failed
+    # chain's own prefixes makes every such reference fail loudly, attributed to
+    # the chain that has to be fixed. Registered before the live entries below,
+    # so a live chain always wins a prefix they somehow share.
+    for chain in dead:
+        for prefix in _dead_prefixes(chain, skip=set(known_labels)):
+            unresolved.add_prefix(
+                prefix,
+                (
+                    "unknown-chain-label",
+                    f"{prefix} belongs to chain {chain.scanner_ioc}, which failed "
+                    "to convert, so no fastcs-catio name can be predicted for it; "
+                    "fix that chain's errors and re-run",
+                    chain.scanner_ioc,
+                ),
+            )
+
+    for prefix, (chain_name, entity_type, type_name, entity_name) in sorted(
+        unknown_prefixes.items()
+    ):
+        where = f" (entity {entity_name})" if entity_name else ""
+        unresolved.add_prefix(
+            prefix,
+            (
+                "unknown-entity-type",
+                f"{prefix} is declared by {entity_type}{where}, a {type_name} "
+                "terminal that builder2ibek.catio.leaves has no translation "
+                "table for, so its legacy record suffixes are unknown and no "
+                f"fastcs-catio name can be predicted; add {type_name} to "
+                "leaves.TERMINALS to convert this chain",
+                chain_name,
+            ),
+        )
+
+    return Substituter(subs, owners, unresolved, known_labels)
+
+
+def report_unused_ambiguities(
+    substituter: Substituter, log: DiagnosticLog
+) -> list[str]:
+    """Downgrade ambiguities that nothing referenced, after substitution.
+
+    ``build_substituter`` cannot know whether a dropped key matters, so it
+    registers every ambiguity at ``ambiguous-legacy-pv`` (ERROR) and
+    ``Substituter`` raises it only when a consumer actually names one. Call this
+    once at the end of the run: every ambiguity whose diagnostic never fired is
+    re-reported at ``ambiguous-legacy-pv-unused`` (WARNING), so the report is
+    complete without failing a chain over a name nobody uses.
+
+    :returns: the legacy PVs downgraded, sorted.
+    """
+    fired = {d.message for d in log if d.code == "ambiguous-legacy-pv"}
+    downgraded: list[str] = []
+    for key, (code, message, chain) in sorted(substituter.unresolved.items()):
+        if code != "ambiguous-legacy-pv" or message in fired:
+            continue
+        log.add("ambiguous-legacy-pv-unused", message, chain=chain)
+        downgraded.append(key)
+    return downgraded
+
+
+def chain_by_ioc(chains: Iterable[Chain]) -> dict[str, Chain]:
+    """Index chains by their scanner IOC name.
+
+    >>> sorted(chain_by_ioc([Chain("BL21I-VA-IOC-01", "BL21I-VA", 1)]))
+    ['BL21I-VA-IOC-01']
+    """
+    return {chain.scanner_ioc: chain for chain in chains}

--- a/src/builder2ibek/catio/chains.py
+++ b/src/builder2ibek/catio/chains.py
@@ -152,7 +152,7 @@ class Slave:
 
         >>> Slave(1, 1, "EL3104", None, "P", SLAVE, "auto_EL3104").is_known
         True
-        >>> Slave(1, 1, "EL2595", None, "P", SLAVE, "auto_EL2595").is_known
+        >>> Slave(1, 1, "EL3602", None, "P", SLAVE, "auto_EL3602").is_known
         False
         >>> Slave(1, 0, "EK1100", None, "P", COUPLER).is_known
         False

--- a/src/builder2ibek/catio/cli.py
+++ b/src/builder2ibek/catio/cli.py
@@ -1,0 +1,557 @@
+"""The body of the ``builder2ibek catio`` command.
+
+One invocation migrates a whole beamline off the legacy `ethercat` support
+module: it discovers every EtherCAT chain in a BUILDER tree, predicts the PV
+names fastcs-catio will generate, rewrites every consumer IOC's references to
+match, and writes both the rewritten consumer IOCs and one fastcs-catio IOC per
+chain into a services repo.
+
+Failure is **per chain**, never all-or-nothing. A chain that records an ERROR
+contributes no substitutions and gets no fastcs-catio IOC; any consumer IOC
+referencing it is skipped whole, even where its other chains are clean, because
+a half-rewritten IOC is worse than an unconverted one. The report names the
+chain that blocked each skipped IOC.
+
+Ordering matters and is not arbitrary: *every* candidate IOC is converted before
+*any* is written. Reference-time diagnostics -- a MOD number off the end of a
+chain, a record with no fastcs equivalent -- are what populate
+:meth:`~builder2ibek.catio.diagnostics.DiagnosticLog.failed_chains`, so the
+write decision cannot be made until the last IOC has been converted. Converting
+has no side effects until :func:`builder2ibek.catio.services.write_ioc` is
+called, so the two-pass shape costs nothing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, NoReturn
+
+import typer
+from ruamel.yaml import YAML
+
+from builder2ibek.catio.chains import (
+    MAKE_IOCS,
+    Chain,
+    build_substituter,
+    discover_chains,
+    report_unused_ambiguities,
+)
+from builder2ibek.catio.diagnostics import DiagnosticLog
+from builder2ibek.catio.substitute import Substituter
+from builder2ibek.convert import convert_to_ioc
+from builder2ibek.converters.ethercat import CatioContext
+from builder2ibek.types import Generic_IOC
+
+__all__ = [
+    "PLACEHOLDER_RE",
+    "CatioReport",
+    "apply_prefix_overrides",
+    "catio_cli",
+]
+
+#: A scaffold value a human must replace before the IOC can be deployed.
+PLACEHOLDER_RE = re.compile(r"REPLACE_WITH_[A-Z0-9_]*")
+
+#: Sticky ordinals mean a chain deleted from the BUILDER tree keeps its
+#: ``E{n}RIO`` number reserved by its leftover services folder, and nothing
+#: reclaims it. Reclaiming would renumber a live chain and repoint every PV a
+#: previous run rewrote at a name nothing creates. Open item, plan D11.
+ORDINAL_NOTE = (
+    "note: chain ordinals are sticky -- a chain removed from the BUILDER tree "
+    "keeps its E{n}RIO ordinal reserved by its leftover services folder and "
+    "nothing reclaims it (D11, open)"
+)
+
+
+def _load_services() -> Any:
+    """Import :mod:`builder2ibek.catio.services` on demand.
+
+    Deferred rather than imported at module scope for the same reason
+    :mod:`~builder2ibek.catio.chains` defers `fastcs_catio`: nothing outside the
+    ``catio`` command should pay for the services-repo writer, and tests can
+    replace this function to drive the whole flow without touching a real repo.
+    """
+    from builder2ibek.catio import services
+
+    return services
+
+
+# -- input discovery ---------------------------------------------------------
+
+
+def _xml_dir(builder_path: Path) -> Path:
+    """The directory holding the IOC XMLs, given a BUILDER root or a leaf dir.
+
+    Mirrors :func:`builder2ibek.catio.chains.discover_chains` exactly, so the
+    chains and the consumer IOCs are always read from the same place.
+    """
+    search = builder_path / MAKE_IOCS
+    return search if search.is_dir() else builder_path
+
+
+def _is_template_xml(xml: Path) -> bool:
+    """True for a macro template rather than a real IOC definition.
+
+    >>> _is_template_xml(Path("GIGE-FIT-TEMPLATE.xml"))
+    True
+    >>> _is_template_xml(Path("BL21I-VA-IOC-02.xml"))
+    False
+    """
+    name = xml.name
+    return "$(" in name or "template" in name.lower()
+
+
+def _existing_description(services_repo: Path, ioc_name: str) -> str:
+    """The ``description`` of an already-deployed IOC, or ``""``.
+
+    Carried across so that re-running ``catio`` over a converted beamline does
+    not replace a curated description with the generic auto-generated one.
+    """
+    ioc_yaml = services_repo / "services" / ioc_name.lower() / "config" / "ioc.yaml"
+    if not ioc_yaml.is_file():
+        return ""
+    try:
+        data = YAML(typ="safe").load(ioc_yaml)
+    except Exception:  # noqa: BLE001 - a corrupt file just means no description
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    description = data.get("description") or ""
+    return "" if str(description).startswith("REPLACE_WITH") else str(description)
+
+
+# -- name-mapping overrides --------------------------------------------------
+
+
+def _expand_template(template: str | None, chain: Chain) -> str | None:
+    """Substitute ``{domain}`` and ``{n}`` in a CLI-supplied prefix template.
+
+    Plain text replacement, **not** :meth:`str.format`: the templates also carry
+    the positional ``{:02d}`` and the named ``{id}`` / ``{group_alias}`` /
+    ``{node_prefix}`` that fastcs-catio itself expands later, and ``format``
+    would either consume or reject those.
+
+    >>> chain = Chain("BL21I-VA-IOC-01", "BL21I-VA", 3)
+    >>> _expand_template("{domain}-E{n}RIO-{:02d}", chain)
+    'BL21I-VA-E3RIO-{:02d}'
+    >>> _expand_template(None, chain) is None
+    True
+    """
+    if template is None:
+        return None
+    return template.replace("{domain}", chain.domain).replace("{n}", str(chain.ordinal))
+
+
+class _OverriddenChain(Chain):
+    """A :class:`Chain` whose name-mapping templates come from the CLI.
+
+    A plain subclass rather than extra :class:`Chain` fields: the three
+    templates are properties on ``Chain``, and overriding a property is the only
+    way to keep ``Chain.name_mappings()`` -- the single source the generated
+    ``config/fastcs.yaml`` and the predicted names must both come from -- in
+    agreement with the override.
+
+    >>> base = Chain("BL21I-VA-IOC-01", "BL21I-VA", 2)
+    >>> chain = _OverriddenChain(base, node_prefix="{domain}-RIO{n}-{:02d}")
+    >>> chain.node_prefix, chain.name_mappings()["node_prefix"]
+    ('BL21I-VA-RIO2-{:02d}', 'BL21I-VA-RIO2-{:02d}')
+    >>> chain.device_prefix == base.device_prefix
+    True
+    """
+
+    def __init__(
+        self,
+        chain: Chain,
+        *,
+        node_prefix: str | None = None,
+        module_prefix: str | None = None,
+        device_prefix: str | None = None,
+    ) -> None:
+        super().__init__(
+            scanner_ioc=chain.scanner_ioc,
+            domain=chain.domain,
+            ordinal=chain.ordinal,
+            slaves=chain.slaves,
+            labels=chain.labels,
+        )
+        self._node_prefix = _expand_template(node_prefix, chain)
+        self._module_prefix = _expand_template(module_prefix, chain)
+        self._device_prefix = _expand_template(device_prefix, chain)
+
+    @property
+    def node_prefix(self) -> str:
+        return self._node_prefix or super().node_prefix
+
+    @property
+    def module_prefix(self) -> str:
+        return self._module_prefix or super().module_prefix
+
+    @property
+    def device_prefix(self) -> str:
+        return self._device_prefix or super().device_prefix
+
+
+def apply_prefix_overrides(
+    chains: list[Chain],
+    *,
+    node_prefix: str | None = None,
+    module_prefix: str | None = None,
+    device_prefix: str | None = None,
+) -> list[Chain]:
+    """Re-wrap *chains* so their name mappings use the CLI overrides.
+
+    Returns *chains* unchanged when nothing is overridden, so the common case
+    keeps the exact objects :func:`discover_chains` produced.
+
+    >>> chains = [Chain("BL21I-VA-IOC-01", "BL21I-VA", 1)]
+    >>> apply_prefix_overrides(chains) is chains
+    True
+    """
+    if node_prefix is None and module_prefix is None and device_prefix is None:
+        return chains
+    return [
+        _OverriddenChain(
+            chain,
+            node_prefix=node_prefix,
+            module_prefix=module_prefix,
+            device_prefix=device_prefix,
+        )
+        for chain in chains
+    ]
+
+
+# -- placeholder reporting ---------------------------------------------------
+
+
+def _placeholder_line(folder: Path, item: str) -> str:
+    """One report line for a placeholder reported by ``services.py``.
+
+    ``write_catio_ioc`` returns the placeholder tokens it left behind; a bare
+    token is qualified with the folder it lives in, while anything that already
+    carries its own location is passed through untouched.
+
+    >>> _placeholder_line(Path("services/bl21i-va-catio-01"), "REPLACE_WITH_IMAGE")
+    'services/bl21i-va-catio-01: REPLACE_WITH_IMAGE'
+    >>> _placeholder_line(Path("x"), "values.yaml: REPLACE_WITH_IMAGE")
+    'values.yaml: REPLACE_WITH_IMAGE'
+    """
+    return f"{folder}: {item}" if item.startswith("REPLACE_WITH") else item
+
+
+def _dedupe_placeholders(lines: Iterable[str]) -> list[str]:
+    """Collapse ``location: TOKEN`` lines onto the most specific location.
+
+    ``write_catio_ioc`` reports a placeholder against the IOC *folder* while the
+    post-write sweep finds the same token in a named *file* underneath it. Both
+    are true, so a plain set keeps both and the report lists every placeholder
+    twice. Keep the file, which is the one a human has to open.
+
+    A folder is only collapsed away for the token that was found beneath it, so
+    a placeholder unique to the folder itself still survives.
+
+    >>> _dedupe_placeholders(["a: T", "a/values.yaml: T", "b: U"])
+    ['a/values.yaml: T', 'b: U']
+    >>> _dedupe_placeholders(["a: T", "a/values.yaml: V"])
+    ['a/values.yaml: V', 'a: T']
+    """
+    seen = dict.fromkeys(lines)
+    split = [(line, *line.split(": ", 1)) for line in seen if ": " in line]
+    specific = {(loc, token) for _, loc, token in split}
+    kept = [
+        line
+        for line, loc, token in split
+        if not any(
+            other.startswith(f"{loc}/")
+            for other, other_token in specific
+            if other_token == token
+        )
+    ]
+    return sorted(kept + [line for line in seen if ": " not in line])
+
+
+def _scan_placeholders(folder: Path) -> list[str]:
+    """Every ``REPLACE_WITH_*`` token under *folder*, as ``path: TOKEN`` lines.
+
+    A belt-and-braces sweep of what was actually written, so a placeholder that
+    ``services.py`` did not report still reaches the human. Symlinked
+    directories are not descended into -- in a services repo ``templates`` is a
+    symlink to the shared chart, which is not this IOC's to fill in.
+    """
+    lines: list[str] = []
+    if not folder.is_dir():
+        return lines
+    stack = [folder]
+    while stack:
+        current = stack.pop()
+        for child in sorted(current.iterdir()):
+            if child.is_symlink():
+                continue
+            if child.is_dir():
+                stack.append(child)
+                continue
+            try:
+                text = child.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for token in dict.fromkeys(PLACEHOLDER_RE.findall(text)):
+                lines.append(f"{child}: {token}")
+    return sorted(lines)
+
+
+# -- the report --------------------------------------------------------------
+
+
+@dataclass
+class CatioReport:
+    """Everything one ``catio`` run did, ready to render or serialise."""
+
+    builder_path: str
+    services_repo: str
+    strict: bool
+    dry_run: bool
+    chains: list[dict] = field(default_factory=list)
+    iocs_written: list[str] = field(default_factory=list)
+    iocs_skipped: list[dict] = field(default_factory=list)
+    placeholders: list[str] = field(default_factory=list)
+    conversion_errors: list[dict] = field(default_factory=list)
+    #: consumer IOC -> the services path written, for the human report only.
+    ioc_paths: dict[str, str] = field(default_factory=dict)
+
+
+def _render_report(report: CatioReport, log: DiagnosticLog) -> str:
+    """The human report: diagnostics, then what was done, then what is left."""
+    converted = [c for c in report.chains if c["converted"]]
+    failed = [c for c in report.chains if not c["converted"]]
+    lines = [
+        log.render(),
+        "",
+        f"Builder XMLs:      {report.builder_path}",
+        f"Services repo:     {report.services_repo}",
+        f"Chains discovered: {len(report.chains)}",
+        f"Chains converted:  {len(converted)}",
+        f"Chains failed:     {len(failed)}",
+        f"IOCs written:      {len(report.iocs_written)}",
+        f"IOCs skipped:      {len(report.iocs_skipped)}",
+    ]
+    if report.dry_run:
+        lines.append("DRY RUN -- nothing was written")
+
+    if report.chains:
+        lines += ["", "Chains:"]
+        for chain in report.chains:
+            state = "converted" if chain["converted"] else "FAILED (skipped)"
+            lines.append(
+                f"  {chain['scanner_ioc']} -> {chain['catio_ioc']} "
+                f"[{state}] node_prefix {chain['node_prefix']}"
+            )
+
+    if report.iocs_written:
+        lines += ["", "IOCs written:"]
+        for ioc in report.iocs_written:
+            path = report.ioc_paths.get(ioc, "")
+            lines.append(f"  {ioc}{f' -> {path}' if path else ''}")
+
+    if report.iocs_skipped:
+        lines += ["", "IOCs skipped:"]
+        for item in report.iocs_skipped:
+            blocked = ", ".join(item["blocked_by"]) or "-"
+            reason = "own errors; " if item["own_errors"] else ""
+            lines.append(f"  {item['ioc']} ({reason}blocked by chain {blocked})")
+
+    if report.conversion_errors:
+        lines += ["", "Conversion errors (IOC left untouched):"]
+        for item in report.conversion_errors:
+            lines.append(f"  {item['ioc']}: {item['error']}")
+
+    lines += ["", "Placeholders to fill in:"]
+    if report.placeholders:
+        lines += [f"  {line}" for line in report.placeholders]
+    else:
+        lines.append("  (none)")
+
+    lines += ["", ORDINAL_NOTE]
+    return "\n".join(lines)
+
+
+def _to_json(report: CatioReport, log: DiagnosticLog) -> str:
+    data = asdict(report)
+    data["diagnostics"] = log.to_json()
+    return json.dumps(data, indent=2)
+
+
+# -- the command -------------------------------------------------------------
+
+
+def _convert_all(
+    xml_dir: Path,
+    services_repo: Path,
+    substituter: Substituter,
+    log: DiagnosticLog,
+    report: CatioReport,
+) -> dict[str, Generic_IOC]:
+    """Convert every candidate IOC XML, rewriting its EtherCAT references.
+
+    Every XML is converted, because whether an IOC references a chain is only
+    known once its values have been walked. Nothing is written here.
+
+    A conversion that raises is recorded and that IOC is dropped from the run.
+    Only a *scanner* failing this way is fatal: an unrelated converter defect in
+    some other IOC is `/beamline-convert`'s problem, not this command's, and
+    must not block the whole beamline's EtherCAT migration.
+    """
+    converted: dict[str, Generic_IOC] = {}
+    for xml in sorted(xml_dir.glob("*.xml")):
+        if _is_template_xml(xml):
+            continue
+        ioc_name = xml.stem
+        try:
+            converted[ioc_name] = convert_to_ioc(
+                xml,
+                description=_existing_description(services_repo, ioc_name),
+                catio=CatioContext(substituter=substituter, log=log, ioc_name=ioc_name),
+            )
+        except Exception as exc:  # noqa: BLE001 - report any converter failure
+            report.conversion_errors.append(
+                {"ioc": ioc_name, "error": f"{type(exc).__name__}: {exc}"}
+            )
+    return converted
+
+
+def _fail(message: str, *, json_out: bool) -> NoReturn:
+    """Report a run that could not start at all, and exit non-zero."""
+    if json_out:
+        print(json.dumps({"error": message}))
+    else:
+        print(f"error: {message}", file=sys.stderr)
+    raise typer.Exit(1)
+
+
+def catio_cli(
+    builder_path: Path,
+    services_repo: Path,
+    *,
+    strict: bool = False,
+    dry_run: bool = False,
+    json_out: bool = False,
+    node_prefix: str | None = None,
+    module_prefix: str | None = None,
+    device_prefix: str | None = None,
+) -> None:
+    """Run the whole migration and print the report.
+
+    :raises typer.Exit: with code 1 when any ERROR was recorded, a scanner IOC
+        failed to convert, or the run could not start at all.
+    """
+    services = _load_services()
+
+    try:
+        if not builder_path.is_dir():
+            raise FileNotFoundError(f"builder path not found: {builder_path}")
+        if not services_repo.is_dir():
+            raise FileNotFoundError(f"services repo not found: {services_repo}")
+
+        sticky = services.read_sticky_ordinals(services_repo)
+        log = DiagnosticLog(strict=strict)
+        chains = discover_chains(builder_path, log, sticky=sticky)
+        chains = apply_prefix_overrides(
+            chains,
+            node_prefix=node_prefix,
+            module_prefix=module_prefix,
+            device_prefix=device_prefix,
+        )
+        substituter = build_substituter(chains, log)
+    except (FileNotFoundError, ValueError, ImportError) as exc:
+        _fail(f"{type(exc).__name__}: {exc}", json_out=json_out)
+
+    # Converter chatter must not pollute a `--json` stdout, and is noise in the
+    # human report too.
+    with contextlib.redirect_stdout(sys.stderr):
+        report = CatioReport(
+            builder_path=str(builder_path),
+            services_repo=str(services_repo),
+            strict=strict,
+            dry_run=dry_run,
+        )
+        xml_dir = _xml_dir(builder_path)
+        iocs = _convert_all(xml_dir, services_repo, substituter, log, report)
+
+        scanners = {chain.scanner_ioc for chain in chains}
+        failed_chains = log.failed_chains()
+        failed_iocs = log.failed_iocs()
+
+        for ioc_name, ioc in iocs.items():
+            references = substituter.references(ioc_name)
+            own_errors = ioc_name in failed_iocs
+            if ioc_name in scanners:
+                # A scanner's own chain counts as a reference even when its
+                # entities name no PV from it: writing the scanner with its
+                # EtherCAT entities stripped, while its replacement catio IOC
+                # was skipped, would leave the beamline without that hardware.
+                references = references | {ioc_name}
+            elif not references and not own_errors:
+                # No EtherCAT references at all -- not this command's business.
+                continue
+            # An IOC whose every reference was to a skipped chain has no
+            # *resolved* references at all, only errors of its own; it must
+            # still be reported rather than silently passed over.
+            blocked = sorted(references & failed_chains)
+            if blocked or own_errors:
+                report.iocs_skipped.append(
+                    {
+                        "ioc": ioc_name,
+                        "blocked_by": blocked,
+                        "own_errors": own_errors,
+                    }
+                )
+                continue
+            path = services.write_ioc(services_repo, ioc_name, ioc, dry_run=dry_run)
+            report.iocs_written.append(ioc_name)
+            report.ioc_paths[ioc_name] = str(path)
+
+        placeholders: list[str] = []
+        for chain in chains:
+            folder = services_repo / "services" / chain.services_folder
+            converted = chain.scanner_ioc not in failed_chains
+            report.chains.append(
+                {
+                    "scanner_ioc": chain.scanner_ioc,
+                    "catio_ioc": chain.catio_ioc,
+                    "services_folder": chain.services_folder,
+                    "domain": chain.domain,
+                    "ordinal": chain.ordinal,
+                    "slaves": len(chain.slaves),
+                    "converted": converted,
+                    "path": str(folder),
+                    **chain.name_mappings(),
+                }
+            )
+            if not converted:
+                continue
+            for item in services.write_catio_ioc(services_repo, chain, dry_run=dry_run):
+                placeholders.append(_placeholder_line(folder, item))
+
+        if not dry_run:
+            folders = [c["services_folder"] for c in report.chains if c["converted"]]
+            folders += [name.lower() for name in report.iocs_written]
+            for folder_name in folders:
+                placeholders += _scan_placeholders(
+                    services_repo / "services" / folder_name
+                )
+        report.placeholders = _dedupe_placeholders(placeholders)
+
+        report_unused_ambiguities(substituter, log)
+
+        scanner_failures = [
+            item for item in report.conversion_errors if item["ioc"] in scanners
+        ]
+
+    print(_to_json(report, log) if json_out else _render_report(report, log))
+
+    if log.has_errors() or scanner_failures:
+        raise typer.Exit(1)

--- a/src/builder2ibek/catio/diagnostics.py
+++ b/src/builder2ibek/catio/diagnostics.py
@@ -1,0 +1,336 @@
+"""Structured diagnostics for the `catio` conversion.
+
+A chain-by-chain migration cannot be all-or-nothing: one malformed EtherCAT
+chain must not block the other three on the same beamline. Every problem the
+converter finds is therefore recorded as a :class:`Diagnostic` carrying enough
+location to act on it -- the scanner IOC that owns the affected chain, the
+consumer IOC the reference was found in, and the builder entity and attribute
+that held it.
+
+Severity drives control flow, not just presentation:
+
+* ``ERROR`` -- the owning chain is skipped: no substitutions come from it and no
+  fastcs-catio IOC is written. Any consumer IOC referencing that chain is
+  skipped whole, even if its other chains are clean.
+* ``WARNING`` -- reported, conversion proceeds.
+
+Codes are a closed set (:data:`CODES`). Passing an unlisted code to
+:meth:`DiagnosticLog.add` raises :class:`KeyError` rather than inventing a
+severity, so a typo cannot silently downgrade an error to nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Severity(StrEnum):
+    """How badly a diagnostic hurts.
+
+    >>> Severity.ERROR < Severity.WARNING  # errors sort first
+    True
+    >>> str(Severity.WARNING)
+    'warning'
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One problem found while converting a chain or a consumer IOC.
+
+    :param code: canonical code, a key of :data:`CODES`.
+    :param severity: the severity actually recorded, after any ``--strict``
+        promotion -- not necessarily ``CODES[code]``.
+    :param message: human-readable detail, no location (the location fields
+        supply that).
+    :param chain: scanner IOC name owning the affected chain, e.g.
+        ``"BL21I-VA-IOC-01"``. `None` for problems not tied to a chain.
+    :param ioc: the consumer IOC the diagnostic was raised from.
+    :param entity: builder entity name within *ioc*.
+    :param attribute: builder attribute (argument) name within *entity*.
+    """
+
+    code: str
+    severity: Severity
+    message: str
+    chain: str | None = None
+    ioc: str | None = None
+    entity: str | None = None
+    attribute: str | None = None
+
+    def location(self) -> str:
+        """The location prefix used by :meth:`__str__`, possibly empty.
+
+        The consumer IOC is preferred over the chain because that is where a
+        human must go to fix a bad reference; the chain is only shown when no
+        consumer is known.
+
+        >>> Diagnostic("unmapped-suffix", Severity.ERROR, "x",
+        ...            ioc="BL21I-VA-IOC-05", entity="VAFAN4",
+        ...            attribute="rio_dinput").location()
+        'BL21I-VA-IOC-05, entity VAFAN4, arg rio_dinput'
+        >>> Diagnostic("unlabelled-coupler", Severity.WARNING, "x",
+        ...            chain="BL21I-DI-IOC-01").location()
+        'chain BL21I-DI-IOC-01'
+        """
+        parts: list[str] = []
+        if self.ioc:
+            parts.append(self.ioc)
+        elif self.chain:
+            parts.append(f"chain {self.chain}")
+        if self.entity:
+            parts.append(f"entity {self.entity}")
+        if self.attribute:
+            parts.append(f"arg {self.attribute}")
+        return ", ".join(parts)
+
+    def __str__(self) -> str:
+        """One-line report form naming severity, code, location and message.
+
+        >>> print(Diagnostic("mod-out-of-range", Severity.ERROR,
+        ...                  "MOD9 exceeds 8 terminals",
+        ...                  chain="BL21I-VA-IOC-01", ioc="BL21I-VA-IOC-01",
+        ...                  entity="VAFAN4", attribute="rio_dinput"))
+        error [mod-out-of-range] BL21I-VA-IOC-01, entity VAFAN4, arg rio_dinput: MOD9 exceeds 8 terminals
+        >>> print(Diagnostic("unknown-chain-label", Severity.ERROR, "no such label"))
+        error [unknown-chain-label]: no such label
+        """  # noqa: E501
+        where = self.location()
+        head = f"{self.severity} [{self.code}]"
+        return f"{head} {where}: {self.message}" if where else f"{head}: {self.message}"
+
+    def to_dict(self) -> dict[str, str | None]:
+        """This diagnostic as a plain JSON-serialisable dict.
+
+        >>> Diagnostic("unlabelled-coupler", Severity.WARNING, "no DEVICE",
+        ...            chain="BL21I-DI-IOC-01").to_dict()["severity"]
+        'warning'
+        """
+        return {
+            "code": self.code,
+            "severity": str(self.severity),
+            "message": self.message,
+            "chain": self.chain,
+            "ioc": self.ioc,
+            "entity": self.entity,
+            "attribute": self.attribute,
+        }
+
+
+#: Canonical diagnostic code -> its default severity.
+CODES: dict[str, Severity] = {
+    # -- errors: the owning chain cannot be converted --------------------------
+    "mod-out-of-range": Severity.ERROR,
+    "leaf-type-mismatch": Severity.ERROR,
+    "coupler-label-conflict": Severity.ERROR,
+    "unknown-chain-label": Severity.ERROR,
+    "unknown-terminal-type": Severity.ERROR,
+    "unknown-entity-type": Severity.ERROR,
+    "unmapped-suffix": Severity.ERROR,
+    "ambiguous-legacy-pv": Severity.ERROR,
+    "shortened-leaf": Severity.ERROR,
+    # -- warnings: reported, conversion proceeds -------------------------------
+    "duplicate-coupler-label": Severity.WARNING,
+    "ambiguous-legacy-pv-unused": Severity.WARNING,
+    "device-mod-mismatch": Severity.WARNING,
+    "unlabelled-coupler": Severity.WARNING,
+    "device-without-mod": Severity.WARNING,
+    "slave-type-mismatch": Severity.WARNING,
+    "link-direction-guess": Severity.WARNING,
+    "dropped-reference": Severity.WARNING,
+}
+
+#: Codes that ``--strict`` promotes from WARNING to ERROR.
+STRICT_PROMOTIONS: frozenset[str] = frozenset({"device-mod-mismatch"})
+
+#: Group heading shown for diagnostics with no owning chain.
+_NO_CHAIN = "(no chain)"
+
+
+def _sort_key(diagnostic: Diagnostic) -> tuple[str, ...]:
+    """Total order within a render group, independent of insertion order."""
+    return (
+        diagnostic.code,
+        diagnostic.ioc or "",
+        diagnostic.entity or "",
+        diagnostic.attribute or "",
+        diagnostic.message,
+    )
+
+
+class DiagnosticLog:
+    """An ordered, queryable collection of :class:`Diagnostic`.
+
+    >>> log = DiagnosticLog()
+    >>> _ = log.add("unlabelled-coupler", "no DEVICE with :MOD",
+    ...             chain="BL21I-DI-IOC-01")
+    >>> _ = log.add("unmapped-suffix", "AL_STATE has no fastcs equivalent",
+    ...             chain="BL21I-VA-IOC-01", ioc="BL21I-VA-IOC-05")
+    >>> len(log), log.has_errors()
+    (2, True)
+    >>> sorted(log.failed_chains()), sorted(log.failed_iocs())
+    (['BL21I-VA-IOC-01'], ['BL21I-VA-IOC-05'])
+    """
+
+    def __init__(self, strict: bool = False) -> None:
+        """Create an empty log.
+
+        :param strict: when True, codes in :data:`STRICT_PROMOTIONS` are
+            recorded at ``ERROR`` instead of their default severity.
+        """
+        self.strict = strict
+        self._diagnostics: list[Diagnostic] = []
+
+    def add(
+        self,
+        code: str,
+        message: str,
+        *,
+        chain: str | None = None,
+        ioc: str | None = None,
+        entity: str | None = None,
+        attribute: str | None = None,
+    ) -> Diagnostic:
+        """Record a diagnostic and return it.
+
+        :param code: must be a key of :data:`CODES`.
+        :param message: detail, without location.
+        :param chain: scanner IOC owning the affected chain.
+        :param ioc: consumer IOC the diagnostic was raised from.
+        :param entity: builder entity name.
+        :param attribute: builder attribute name.
+        :returns: the stored :class:`Diagnostic`.
+        :raises KeyError: if *code* is not a known code -- a typo must not
+            silently produce an unclassified, and therefore ignored, problem.
+
+        >>> log = DiagnosticLog(strict=True)
+        >>> log.add("device-mod-mismatch", "MOD3 but position 4").severity
+        <Severity.ERROR: 'error'>
+        >>> DiagnosticLog().add("nonsuch", "boom")
+        Traceback (most recent call last):
+            ...
+        KeyError: "unknown diagnostic code 'nonsuch'"
+        """
+        try:
+            severity = CODES[code]
+        except KeyError:
+            raise KeyError(f"unknown diagnostic code {code!r}") from None
+        if self.strict and code in STRICT_PROMOTIONS:
+            severity = Severity.ERROR
+        diagnostic = Diagnostic(
+            code=code,
+            severity=severity,
+            message=message,
+            chain=chain,
+            ioc=ioc,
+            entity=entity,
+            attribute=attribute,
+        )
+        self._diagnostics.append(diagnostic)
+        return diagnostic
+
+    def __iter__(self) -> Iterator[Diagnostic]:
+        """Iterate the diagnostics in the order they were added."""
+        return iter(self._diagnostics)
+
+    def __len__(self) -> int:
+        """The number of diagnostics recorded."""
+        return len(self._diagnostics)
+
+    @property
+    def errors(self) -> list[Diagnostic]:
+        """Every diagnostic recorded at ``ERROR``, in insertion order."""
+        return [d for d in self._diagnostics if d.severity is Severity.ERROR]
+
+    @property
+    def warnings(self) -> list[Diagnostic]:
+        """Every diagnostic recorded at ``WARNING``, in insertion order."""
+        return [d for d in self._diagnostics if d.severity is Severity.WARNING]
+
+    def has_errors(self) -> bool:
+        """True when at least one ``ERROR`` was recorded.
+
+        >>> log = DiagnosticLog()
+        >>> log.has_errors()
+        False
+        >>> _ = log.add("device-without-mod", "no :MOD in DEVICE")
+        >>> log.has_errors()
+        False
+        """
+        return any(d.severity is Severity.ERROR for d in self._diagnostics)
+
+    def failed_chains(self) -> set[str]:
+        """Scanner IOCs whose chain hit at least one error.
+
+        Such a chain is skipped entirely: no substitutions and no
+        fastcs-catio IOC.
+        """
+        return {d.chain for d in self.errors if d.chain}
+
+    def failed_iocs(self) -> set[str]:
+        """Consumer IOCs that hit at least one error of their own.
+
+        This is *not* the full skip list -- an IOC referencing a chain in
+        :meth:`failed_chains` is skipped too, even with a clean record here.
+        """
+        return {d.ioc for d in self.errors if d.ioc}
+
+    def render(self) -> str:
+        """A human report: errors first, then warnings, grouped by chain.
+
+        Ordering is fully sorted rather than insertion-ordered, so two runs
+        over the same beamline produce byte-identical reports.
+
+        :returns: the report, ending in a ``N errors, M warnings`` summary.
+
+        >>> log = DiagnosticLog()
+        >>> _ = log.add("device-without-mod", "BL21I-OP-LED-01 has no :MOD",
+        ...             chain="BL21I-VA-IOC-06")
+        >>> _ = log.add("unmapped-suffix", "AL_STATE has no fastcs equivalent",
+        ...             chain="BL21I-VA-IOC-01", ioc="BL21I-VA-IOC-05",
+        ...             entity="vacFan", attribute="rio_dinput")
+        >>> print(log.render())
+        ERRORS
+          chain BL21I-VA-IOC-01
+            error [unmapped-suffix] BL21I-VA-IOC-05, entity vacFan, arg rio_dinput: AL_STATE has no fastcs equivalent
+        <BLANKLINE>
+        WARNINGS
+          chain BL21I-VA-IOC-06
+            warning [device-without-mod] chain BL21I-VA-IOC-06: BL21I-OP-LED-01 has no :MOD
+        <BLANKLINE>
+        1 errors, 1 warnings
+        """  # noqa: E501
+        blocks: list[str] = []
+        for heading, group in (("ERRORS", self.errors), ("WARNINGS", self.warnings)):
+            if not group:
+                continue
+            lines = [heading]
+            by_chain: dict[str, list[Diagnostic]] = {}
+            for diag in group:
+                by_chain.setdefault(diag.chain or _NO_CHAIN, []).append(diag)
+            for chain in sorted(by_chain, key=lambda c: (c == _NO_CHAIN, c)):
+                lines.append(
+                    f"  {_NO_CHAIN}" if chain == _NO_CHAIN else f"  chain {chain}"
+                )
+                lines += [f"    {d}" for d in sorted(by_chain[chain], key=_sort_key)]
+            blocks.append("\n".join(lines))
+        blocks.append(f"{len(self.errors)} errors, {len(self.warnings)} warnings")
+        return "\n\n".join(blocks)
+
+    def to_json(self) -> list[dict]:
+        """Every diagnostic as plain dicts, ready for :func:`json.dumps`.
+
+        Insertion order is preserved so a machine consumer can reconstruct the
+        sequence of events.
+
+        >>> log = DiagnosticLog()
+        >>> _ = log.add("link-direction-guess", "assumed read", ioc="BL21I-DI-IOC-02")
+        >>> log.to_json()
+        [{'code': 'link-direction-guess', 'severity': 'warning', 'message': 'assumed read', 'chain': None, 'ioc': 'BL21I-DI-IOC-02', 'entity': None, 'attribute': None}]
+        """  # noqa: E501
+        return [d.to_dict() for d in self._diagnostics]

--- a/src/builder2ibek/catio/leaves.py
+++ b/src/builder2ibek/catio/leaves.py
@@ -1,0 +1,226 @@
+"""Legacy EtherCAT record suffixes and their fastcs-catio equivalents.
+
+The DLS `ethercat` support module names a record `$(DEVICE):<suffix>`, where
+`<suffix>` comes from `db/<terminal>.template` and `DEVICE` is set by the
+`auto_<terminal>` entity in the builder XML. fastcs-catio instead names its
+attributes from `terminal_types.yaml`, so migrating a consumer's PV reference
+means translating the suffix as well as the prefix.
+
+The tables are keyed on the **builder entity type** (`auto_EL3104`), not the
+terminal type, because `auto_EL3104` and `auto_EL3104adc` produce byte-identical
+suffix sets from different templates -- a consumer's PV string alone cannot
+distinguish them.
+
+Suffix inventories were taken from
+`/dls_sw/prod/R3.14.12.7/support/ethercat/7-5-3/db/*.template` and proved
+exhaustive (every `record(...)` name starts with `$(DEVICE):` and no suffix
+contains a further macro). They are byte-identical across ethercat 7-4-3
+through 7-5-3.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: `{n}` in a suffix or fastcs name stands for a 1-based channel number.
+_CHANNEL = "{n}"
+
+
+@dataclass(frozen=True)
+class Leaf:
+    """One translatable record suffix.
+
+    :param suffix: legacy suffix template, e.g. ``"INPUT{n}:VALUE"``.
+    :param fastcs_name: the matching `fastcs_name` from `terminal_types.yaml`,
+        e.g. ``"ai_standard_channel_{n}_value"``. fastcs-catio PascalCases this
+        to form the PV leaf.
+    :param writable: True when the fastcs attribute is `AttrRW`, so FastCS
+        creates both a write PV and a `_RBV` readback. Readers of such a signal
+        must be pointed at the `_RBV`.
+    """
+
+    suffix: str
+    fastcs_name: str
+    writable: bool = False
+
+
+# Suffixes a terminal really produces but which fastcs-catio has no equivalent
+# for. Referencing one is a migration error, not a silent pass-through: the new
+# IOC simply will not have that PV.
+#
+# The EL3104 status bits below exist as PDO entries but are not selected in
+# terminal_types.yaml. The EL3356 RMBSTATUS/RMBCONTROL bits are worse -- their
+# fastcs counterparts (`rmb_status`, `rmb_control`) are single packed bitfield
+# attributes, so there is no per-bit PV to point at.
+_EL3104_UNMAPPED = tuple(
+    f"INPUT{{n}}:{s}"
+    for s in (
+        "SUNDERRANGE",
+        "SOVERRANGE",
+        "SERROR",
+        "SSYNCERROR",
+        "STXPDOSTATE",
+        "STXPDOTOGGLE",
+    )
+)
+
+_EL3356_UNMAPPED = (
+    "RMBSTATUS:SOVERRANGE",
+    "RMBSTATUS:ST_DATAINVALID",
+    "RMBSTATUS:SERROR",
+    "RMBSTATUS:ST_CIP",
+    "RMBSTATUS:ST__STEADYSTATE",
+    "RMBSTATUS:SSYNCERROR",
+    "RMBSTATUS:STXPDOTOGGLE",
+    "RMBCONTROL:CTRL_STARTCLB",
+    "RMBCONTROL:CTRL__DISABLECALIBRATION",
+    "RMBCONTROL:CTRL_INPUTFREEZE",
+    "RMBCONTROL:CTRL_SAMPLEMODE",
+    "RMBCONTROL:CTRL_TARA",
+)
+
+# Every terminal template also declares these two. `AL_STATE` is the EtherCAT
+# state machine and `ERROR_FLAG` the slave error latch; fastcs-catio's nearest
+# equivalent, `wcstate`, is a working-counter status and is not the same signal.
+_COMMON_UNMAPPED = ("AL_STATE", "ERROR_FLAG")
+
+
+@dataclass(frozen=True)
+class TerminalLeaves:
+    """The translation table for one builder entity type."""
+
+    entity_type: str
+    terminal_type: str
+    leaves: tuple[Leaf, ...]
+    unmapped: tuple[str, ...] = ()
+    channels: int = 4
+
+
+TERMINALS: dict[str, TerminalLeaves] = {
+    t.entity_type: t
+    for t in (
+        TerminalLeaves(
+            entity_type="auto_EL3104",
+            terminal_type="EL3104",
+            leaves=(
+                Leaf("INPUT{n}:VALUE", "ai_standard_channel_{n}_value"),
+                Leaf("INPUT{n}:SLIMIT1", "ai_std_ch_{n}_sts_lim_1"),
+                Leaf("INPUT{n}:SLIMIT2", "ai_std_ch_{n}_sts_lim_2"),
+            ),
+            unmapped=_COMMON_UNMAPPED + _EL3104_UNMAPPED,
+        ),
+        # Same template shape, `ai` records with EGU scaling instead of `longin`.
+        TerminalLeaves(
+            entity_type="auto_EL3104adc",
+            terminal_type="EL3104",
+            leaves=(
+                Leaf("INPUT{n}:VALUE", "ai_standard_channel_{n}_value"),
+                Leaf("INPUT{n}:SLIMIT1", "ai_std_ch_{n}_sts_lim_1"),
+                Leaf("INPUT{n}:SLIMIT2", "ai_std_ch_{n}_sts_lim_2"),
+            ),
+            unmapped=_COMMON_UNMAPPED + _EL3104_UNMAPPED,
+        ),
+        TerminalLeaves(
+            entity_type="auto_EL1014",
+            terminal_type="EL1014",
+            leaves=(Leaf("CHANNEL{n}:INPUT", "channel_{n}"),),
+            unmapped=_COMMON_UNMAPPED,
+        ),
+        TerminalLeaves(
+            entity_type="auto_EL2024_0010",
+            terminal_type="EL2024-0010",
+            leaves=(Leaf("CHANNEL{n}:OUTPUT", "channel_{n}", writable=True),),
+            unmapped=_COMMON_UNMAPPED,
+        ),
+        TerminalLeaves(
+            entity_type="auto_EL3356_0010",
+            terminal_type="EL3356-0010",
+            leaves=(Leaf("RMB:VALUE", "rmb_value_int32_value"),),
+            unmapped=_COMMON_UNMAPPED + _EL3356_UNMAPPED,
+            channels=1,
+        ),
+    )
+}
+
+#: Entity types whose terminal has a translation table.
+KNOWN_ENTITY_TYPES = frozenset(TERMINALS)
+
+
+def snake_to_pascal(name: str) -> str:
+    """PascalCase a fastcs snake_case name, as `fastcs.util.snake_to_pascal` does.
+
+    Only strings that are wholly lower-case snake_case are transformed; anything
+    else is returned unchanged, which is what keeps PV segments such as
+    ``10VAI01`` intact.
+
+    >>> snake_to_pascal("ai_standard_channel_1_value")
+    'AiStandardChannel1Value'
+    >>> snake_to_pascal("channel_2")
+    'Channel2'
+    >>> snake_to_pascal("10VAI01")
+    '10VAI01'
+    """
+    if not re.fullmatch(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)*", name):
+        return name
+    return "".join(part.title() for part in name.split("_"))
+
+
+def _expand(template: str, channel: int | None) -> str:
+    return template.replace(_CHANNEL, str(channel)) if channel else template
+
+
+def leaf_translations(entity_type: str) -> dict[str, Leaf]:
+    """Every legacy suffix of *entity_type*, channel numbers expanded.
+
+    :returns: legacy suffix -> the :class:`Leaf` describing its replacement,
+        with `{n}` already substituted in both.
+
+    >>> leaf_translations("auto_EL1014")["CHANNEL3:INPUT"].fastcs_name
+    'channel_3'
+    """
+    terminal = TERMINALS[entity_type]
+    out: dict[str, Leaf] = {}
+    for leaf in terminal.leaves:
+        numbered = _CHANNEL in leaf.suffix
+        channels = range(1, terminal.channels + 1) if numbered else [None]
+        for channel in channels:
+            suffix = _expand(leaf.suffix, channel)
+            out[suffix] = Leaf(
+                suffix=suffix,
+                fastcs_name=_expand(leaf.fastcs_name, channel),
+                writable=leaf.writable,
+            )
+    return out
+
+
+def unmapped_suffixes(entity_type: str) -> set[str]:
+    """Legacy suffixes of *entity_type* that fastcs-catio has no PV for.
+
+    >>> "AL_STATE" in unmapped_suffixes("auto_EL1014")
+    True
+    """
+    terminal = TERMINALS[entity_type]
+    out: set[str] = set()
+    for suffix in terminal.unmapped:
+        channels = range(1, terminal.channels + 1) if _CHANNEL in suffix else [None]
+        out.update(_expand(suffix, channel) for channel in channels)
+    return out
+
+
+def pv_leaf(leaf: Leaf, *, reading: bool) -> str:
+    """The PV leaf a consumer should point at.
+
+    FastCS gives a read/write attribute two PVs: the setpoint under its own
+    name, and a readback suffixed ``_RBV``. A link that *reads* the signal must
+    use the readback.
+
+    >>> pv_leaf(Leaf("CHANNEL1:OUTPUT", "channel_1", writable=True), reading=True)
+    'Channel1_RBV'
+    >>> pv_leaf(Leaf("CHANNEL1:OUTPUT", "channel_1", writable=True), reading=False)
+    'Channel1'
+    >>> pv_leaf(Leaf("INPUT1:VALUE", "ai_standard_channel_1_value"), reading=True)
+    'AiStandardChannel1Value'
+    """
+    name = snake_to_pascal(leaf.fastcs_name)
+    return f"{name}_RBV" if leaf.writable and reading else name

--- a/src/builder2ibek/catio/leaves.py
+++ b/src/builder2ibek/catio/leaves.py
@@ -160,10 +160,17 @@ def snake_to_pascal(name: str) -> str:
     'Channel2'
     >>> snake_to_pascal("10VAI01")
     '10VAI01'
+
+    Only the first character of a part is raised, never one following a digit --
+    ``str.title()`` would give ``'Ch1A'`` here and diverge from the PV fastcs
+    actually creates:
+
+    >>> snake_to_pascal("ch1a")
+    'Ch1a'
     """
     if not re.fullmatch(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)*", name):
         return name
-    return "".join(part.title() for part in name.split("_"))
+    return re.sub(r"(?:^|_)([a-z0-9])", lambda m: m.group(1).upper(), name)
 
 
 def _expand(template: str, channel: int | None) -> str:

--- a/src/builder2ibek/catio/leaves.py
+++ b/src/builder2ibek/catio/leaves.py
@@ -80,6 +80,37 @@ _EL3356_UNMAPPED = (
     "RMBCONTROL:CTRL_TARA",
 )
 
+# The EL2595's status and control words are packed bitfields on the fastcs side
+# (`dox_status`, `dox_control`), exactly as the EL3356's are, so the legacy
+# per-bit records -- which asyn-address individual bits of `DOXStatus.*` and
+# `DOXControl.*` -- have no PV to point at.
+#
+# The four `OUTPUT_VOLTAGE*` records are a different thing again: they go
+# through `@asyn($(PORT)_SDO)`, so they are CoE/SDO parameter access rather than
+# cyclic PDO data, and `terminal_types.yaml` models CoE under `coe_objects`, not
+# `symbol_nodes`. Mapping them belongs to whatever handles `SdoEntryTemplate`
+# (cf. `HOLDCURR`), not here. Nothing in any DLS BUILDER tree references them.
+#
+# For the record, since it is easy to assume otherwise: these are integers, not
+# floats. `OUTPUT_VOLTAGE` and `DOXCURRENT:OUTPUTCURRENT` are `longout`,
+# `OUTPUT_VOLTAGE:RBV`/`:STAT` are `longin`, all `asynInt32`; only
+# `OUTPUT_VOLTAGE_READ` is a bit, and it is a `bo` that triggers an SDO read.
+_EL2595_UNMAPPED = (
+    "DOXSTATUS:SERROR",
+    "DOXSTATUS:STATUS__DIGITALINPUT",
+    "DOXSTATUS:STATUS__OUTPUTACTIVE",
+    "DOXSTATUS:STATUS__READYTOACTIVATE",
+    "DOXSTATUS:STATUS__WARNING",
+    "DOXSTATUS:STXPDOTOGGLE",
+    "DOXCONTROL:CONTROL__INPUTTRIGGERENABLE",
+    "DOXCONTROL:CONTROL__OUTPUT",
+    "DOXCONTROL:CONTROL__RESET",
+    "OUTPUT_VOLTAGE",
+    "OUTPUT_VOLTAGE:RBV",
+    "OUTPUT_VOLTAGE:STAT",
+    "OUTPUT_VOLTAGE_READ",
+)
+
 # Every terminal template also declares these two. `AL_STATE` is the EtherCAT
 # state machine and `ERROR_FLAG` the slave error latch; fastcs-catio's nearest
 # equivalent, `wcstate`, is a working-counter status and is not the same signal.
@@ -138,6 +169,32 @@ TERMINALS: dict[str, TerminalLeaves] = {
             terminal_type="EL3356-0010",
             leaves=(Leaf("RMB:VALUE", "rmb_value_int32_value"),),
             unmapped=_COMMON_UNMAPPED + _EL3356_UNMAPPED,
+            channels=1,
+        ),
+        TerminalLeaves(
+            entity_type="auto_EL4134",
+            terminal_type="EL4134",
+            leaves=(
+                Leaf("OUTPUT{n}:ANALOG", "ao_out_ch_{n}_analog_out", writable=True),
+            ),
+            unmapped=_COMMON_UNMAPPED,
+        ),
+        # `dox_current_output_current` is only selected in `terminal_types.yaml`
+        # from fastcs-catio#65 onwards. Against an older release fastcs-catio
+        # creates no PV for it and the `leaf-type-mismatch` check fires, which is
+        # the intended outcome: better a named error than a rewritten reference
+        # pointing at a record that will never exist.
+        TerminalLeaves(
+            entity_type="auto_EL2595",
+            terminal_type="EL2595",
+            leaves=(
+                Leaf(
+                    "DOXCURRENT:OUTPUTCURRENT",
+                    "dox_current_output_current",
+                    writable=True,
+                ),
+            ),
+            unmapped=_COMMON_UNMAPPED + _EL2595_UNMAPPED,
             channels=1,
         ),
     )

--- a/src/builder2ibek/catio/services.py
+++ b/src/builder2ibek/catio/services.py
@@ -1,0 +1,426 @@
+"""Writing a converted beamline back into an epics-containers services repo.
+
+A services repo looks like this (paths relative to the repo root)::
+
+    .helm-shared/Chart.yaml
+    .helm-shared/LegacyChart.yaml
+    .helm-shared/values.schema.json
+    .helm-shared/templates/ioc_instance.yaml
+    services/.ioc_template/          scaffold for an ibek IOC
+    services/.fastcs_ioc_template/   scaffold for a FastCS IOC
+    services/<instance>/             one folder per deployed IOC
+
+Every IOC folder -- template or real -- carries ``Chart.yaml`` and ``templates``
+as **relative symlinks** into ``../../.helm-shared/``, never as copies. Git
+tracks ``services/<instance>/templates`` as a single mode-120000 entry, so a
+generator that copied the directory would produce a diff nobody wants. All the
+scaffolding here goes through :func:`_link_like`, which reads the link target
+off the template with :func:`os.readlink` and reproduces it verbatim.
+
+Three functions do the work:
+
+* :func:`scaffold` materialises (or repairs) one IOC folder from a template.
+* :func:`write_catio_ioc` fills a scaffold in with the generated fastcs-catio
+  IOC for one :class:`~builder2ibek.catio.chains.Chain`.
+* :func:`write_ioc` fills a scaffold in with a converted ibek IOC.
+
+:func:`read_sticky_ordinals` closes the loop: it reads the ``E{n}RIO`` ordinal
+back out of every ``config/fastcs.yaml`` a previous run wrote, so re-running the
+conversion never renumbers a chain. Renumbering would repoint every rewritten PV
+at nothing.
+
+This module never imports ``fastcs_catio``, and imports the rest of
+``builder2ibek`` lazily, so it stays cheap under ``--doctest-modules``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, keeps this module import-light
+    from builder2ibek.catio.chains import Chain
+    from builder2ibek.types import Generic_IOC
+
+__all__ = [
+    "CATIO_CONTROLLER_TYPE",
+    "CATIO_IMAGE",
+    "FASTCS_IOC_TEMPLATE",
+    "IBEK_PLACEHOLDERS",
+    "IOC_SCHEMA",
+    "IOC_TEMPLATE",
+    "PLACEHOLDER_RE",
+    "is_legacy",
+    "read_sticky_ordinals",
+    "scaffold",
+    "write_catio_ioc",
+    "write_ioc",
+]
+
+#: The ``type:`` discriminator of a fastcs-catio controller entry. Verified
+#: against ``fastcs_catio/schema.json`` (``CATioServerControllerEntry.type`` is
+#: a ``const``).
+CATIO_CONTROLLER_TYPE = "fastcs_catio.CATioServerController"
+
+#: The container image holding fastcs-catio. The tag is deliberately left as a
+#: placeholder -- pinning it is a human decision, not a conversion output.
+CATIO_IMAGE = "ghcr.io/diamondlightsource/fastcs-catio"
+
+#: The fastcs-catio console script, from its ``[project.scripts]``.
+CATIO_ENTRYPOINT = "fastcs-catio"
+
+#: Scaffold folder for an ibek IOC, relative to ``services/``.
+IOC_TEMPLATE = ".ioc_template"
+
+#: Scaffold folder for a FastCS IOC, relative to ``services/``.
+FASTCS_IOC_TEMPLATE = ".fastcs_ioc_template"
+
+#: ``$schema`` written into a converted ``config/ioc.yaml``. Matches
+#: ``.ioc_template/config/ioc.yaml`` and every real IOC in i21-services.
+IOC_SCHEMA = "../ioc.schema.json"
+
+#: The FastCS config filename. fastcs-catio's own reference config is called
+#: ``fastcs.yaml`` and so are 4 of the 6 deployed FastCS IOCs; the i21 scaffold
+#: ships a ``controller.yaml`` example that :func:`write_catio_ioc` removes.
+FASTCS_CONFIG = "fastcs.yaml"
+
+#: The example config shipped in ``.fastcs_ioc_template/config/``.
+FASTCS_EXAMPLE_CONFIG = "controller.yaml"
+
+#: Anything a human still has to fill in.
+PLACEHOLDER_RE = re.compile(r"REPLACE_WITH_[A-Z0-9_]+")
+
+#: Placeholders :func:`write_ioc` leaves behind. It never touches ``values.yaml``,
+#: so a freshly scaffolded ibek IOC keeps the template's image placeholder.
+IBEK_PLACEHOLDERS = ("REPLACE_WITH_IMAGE_URI",)
+
+#: Pulls the chain ordinal out of a ``node_prefix`` such as
+#: ``"BL21I-VA-E1RIO-{:02d}"``.
+_ORDINAL_RE = re.compile(r"E(\d+)RIO")
+
+#: A top-level ``dev-c7:`` key -- column 0, so an indented ``dev-c7`` inside an
+#: image tag does not match. See :func:`is_legacy`.
+_DEV_C7_RE = re.compile(r"^dev-c7:", re.MULTILINE)
+
+_LEGACY_CHART = "LegacyChart.yaml"
+
+
+def _services(services_repo: Path) -> Path:
+    """The ``services/`` directory of *services_repo*."""
+    return Path(services_repo) / "services"
+
+
+def is_legacy(folder: Path) -> bool:
+    """Is *folder* a DLS legacy (``dev-c7``) IOC that must be recreated?
+
+    Two independent signals, either of which is conclusive:
+
+    1. ``Chart.yaml`` is a symlink to ``LegacyChart.yaml``.
+    2. ``values.yaml`` has a ``dev-c7:`` key at **column 0**.
+
+    The column-0 anchor matters. ``bl21i-ea-ioc-01-debug`` is a perfectly good
+    ibek IOC whose ``values.yaml`` contains
+    ``image: ghcr.io/diamondlightsource/dev-c7:2025.11.1-beta.1``; a substring
+    match would delete it.
+
+    A folder that does not exist is not legacy.
+    """
+    folder = Path(folder)
+    if not folder.is_dir():
+        return False
+
+    chart = folder / "Chart.yaml"
+    if chart.is_symlink() and Path(os.readlink(chart)).name == _LEGACY_CHART:
+        return True
+
+    values = folder / "values.yaml"
+    if values.is_file():
+        return bool(_DEV_C7_RE.search(values.read_text()))
+    return False
+
+
+def _link_like(template_entry: Path, target_entry: Path) -> None:
+    """Reproduce the symlink *template_entry* at *target_entry*.
+
+    The link **text** is copied verbatim (``../../.helm-shared/Chart.yaml``), so
+    the result is relative and survives moving the repo. An existing entry at
+    *target_entry* is replaced only when it is wrong, and is unlinked rather
+    than removed recursively -- a ``templates`` symlink must never be followed
+    into ``.helm-shared``.
+    """
+    link = os.readlink(template_entry)
+    if target_entry.is_symlink():
+        if os.readlink(target_entry) == link:
+            return
+        target_entry.unlink()
+    elif target_entry.exists():
+        # a real file or directory squatting where a symlink belongs
+        if target_entry.is_dir():
+            shutil.rmtree(target_entry)
+        else:
+            target_entry.unlink()
+    os.symlink(link, target_entry)
+
+
+def _copy_missing(template_dir: Path, target_dir: Path) -> None:
+    """Copy *template_dir* into *target_dir*, preserving symlinks.
+
+    Existing regular files are **kept** -- a hand-edited ``values.yaml`` with a
+    real image reference must survive a re-run. Symlinks are always repaired,
+    because a wrong ``Chart.yaml`` is never a deliberate local edit.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for entry in sorted(template_dir.iterdir()):
+        target = target_dir / entry.name
+        if entry.is_symlink():
+            _link_like(entry, target)
+        elif entry.is_dir():
+            _copy_missing(entry, target)
+        elif not target.exists():
+            shutil.copyfile(entry, target)
+
+
+def scaffold(services_repo: Path, folder: str, *, fastcs: bool, dry_run: bool) -> Path:
+    """Materialise ``services/<folder>`` from the appropriate template.
+
+    :param services_repo: the repo **root** (the folder holding ``services/``).
+    :param folder: the instance folder name, e.g. ``"bl21i-va-catio-01"``.
+    :param fastcs: scaffold from ``.fastcs_ioc_template`` rather than
+        ``.ioc_template``.
+    :param dry_run: check everything, write nothing.
+    :returns: the instance folder, whether or not it was written.
+    :raises FileNotFoundError: the repo has no ``services/`` directory, or no
+        template of the requested kind.
+    :raises ValueError: *folder* is not a plain instance folder name.
+
+    An existing **legacy** folder is deleted whole and recreated (CLAUDE.md's
+    services-repo rule); an existing non-legacy folder is repaired in place,
+    keeping every real file it already has.
+    """
+    # The legacy rule deletes folders, and `.legacy_ioc_template` is itself a
+    # `dev-c7:` folder -- so never let a dotted or nested name through.
+    if not folder or folder.startswith(".") or "/" in folder or folder == "..":
+        raise ValueError(f"not an IOC instance folder name: {folder!r}")
+
+    services = _services(services_repo)
+    if not services.is_dir():
+        raise FileNotFoundError(f"no services directory in {services_repo}")
+
+    name = FASTCS_IOC_TEMPLATE if fastcs else IOC_TEMPLATE
+    template = services / name
+    if not template.is_dir():
+        raise FileNotFoundError(f"no {name} in {services}")
+
+    target = services / folder
+    if dry_run:
+        return target
+
+    if is_legacy(target):
+        # rmtree unlinks symlinks rather than descending them, so the
+        # `templates` link is removed without touching .helm-shared/templates.
+        shutil.rmtree(target)
+
+    _copy_missing(template, target)
+    return target
+
+
+def _fastcs_yaml(chain: Chain) -> str:
+    """The ``config/fastcs.yaml`` text for *chain*.
+
+    The three ``name_mappings`` come straight from
+    :meth:`~builder2ibek.catio.chains.Chain.name_mappings`, which is also what
+    predicted the new PV names. That single source is the whole point: if the
+    templates written here ever diverged from the ones used for prediction,
+    every rewritten reference would point at a PV that does not exist.
+    """
+    mappings = chain.name_mappings()
+    title = f"{chain.domain.replace('-', ' ')} EtherCAT chain"
+    return f"""\
+# Generated by `builder2ibek catio` from {chain.scanner_ioc}.
+#
+# The name_mappings below are the templates builder2ibek used to predict the new
+# PV names when it rewrote every consumer's references. Editing them here
+# without re-running the conversion will point those references at nothing.
+
+controllers:
+  - id: {chain.catio_ioc}
+    type: {CATIO_CONTROLLER_TYPE}
+    tcp_settings:
+      target_ip: "REPLACE_WITH_ADS_SERVER_IP"
+      target_port: 27905
+    route:
+      route_name: ""
+      user_name: "Administrator"
+      password: "1"
+    scan_timings:
+      poll_period: 1.0
+      notification_period: 0.2
+    name_mappings:
+      device_prefix: "{mappings["device_prefix"]}"
+      node_prefix: "{mappings["node_prefix"]}"
+      module_prefix: "{mappings["module_prefix"]}"
+
+transport:
+  - epicsca: {{}}
+    gui:
+      output_dir: ./screens
+      title: "{title} (from {chain.scanner_ioc})"
+"""
+
+
+def _fastcs_values_yaml(chain: Chain) -> str:
+    """The ``values.yaml`` text for *chain*'s fastcs-catio IOC.
+
+    ``stdio-expose`` rather than the scaffold's ``stdio-socket``: every FastCS
+    IOC actually deployed uses the former (see the module report). The empty
+    ``livenessExecutable``/``preStopExecutable`` come from the scaffold's own
+    warning -- the FastCS image has none of ibek's probe executables.
+    """
+    del chain  # nothing instance-specific yet; kept for symmetry and future use
+    run = f"{CATIO_ENTRYPOINT} run /epics/ioc/config/{FASTCS_CONFIG}"
+    args = f"stdio-expose --ptty --stdin --ctrl-d '{run}'"
+    return f"""\
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+ioc-instance:
+  image: {CATIO_IMAGE}:REPLACE_WITH_PINNED_TAG
+  args:
+    - {args}
+
+  # the fastcs image has no ibek liveness/preStop executables
+  livenessExecutable: ""
+  preStopExecutable: ""
+"""
+
+
+def _placeholders(*texts: str) -> list[str]:
+    """Every distinct ``REPLACE_WITH_*`` in *texts*, in order of first sighting.
+
+    >>> _placeholders("a REPLACE_WITH_B c", "REPLACE_WITH_A, REPLACE_WITH_B")
+    ['REPLACE_WITH_B', 'REPLACE_WITH_A']
+    """
+    found: dict[str, None] = {}
+    for text in texts:
+        for match in PLACEHOLDER_RE.findall(text):
+            found[match] = None
+    return list(found)
+
+
+def write_catio_ioc(services_repo: Path, chain: Chain, *, dry_run: bool) -> list[str]:
+    """Write the fastcs-catio IOC replacing *chain*'s legacy scanner.
+
+    Scaffolds ``services/<chain.services_folder>`` from
+    ``.fastcs_ioc_template``, writes ``config/fastcs.yaml`` and ``values.yaml``,
+    and removes the scaffold's ``config/controller.yaml`` example so the folder
+    holds exactly one FastCS config.
+
+    :returns: the ``REPLACE_WITH_*`` placeholders a human must still fill in, in
+        the order they appear in the generated files.
+    """
+    folder = scaffold(
+        services_repo, chain.services_folder, fastcs=True, dry_run=dry_run
+    )
+    config = _fastcs_yaml(chain)
+    values = _fastcs_values_yaml(chain)
+
+    if not dry_run:
+        config_dir = folder / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / FASTCS_CONFIG).write_text(config)
+        (config_dir / FASTCS_EXAMPLE_CONFIG).unlink(missing_ok=True)
+        (folder / "values.yaml").write_text(values)
+
+    return _placeholders(config, values)
+
+
+def write_ioc(
+    services_repo: Path, ioc_name: str, ioc: Generic_IOC, *, dry_run: bool
+) -> Path:
+    """Write a converted ibek IOC into the services repo.
+
+    Scaffolds ``services/<ioc_name.lower()>`` from ``.ioc_template`` and writes
+    ``config/ioc.yaml``. ``values.yaml`` is deliberately left alone: on a fresh
+    folder it keeps the template's ``REPLACE_WITH_IMAGE_URI`` (see
+    :data:`IBEK_PLACEHOLDERS`), and on an existing folder it keeps the real
+    image reference someone already pinned.
+
+    ``ioc.schema.json`` is **not** written -- ``ibek pattern schema`` generates
+    it from a pre-commit hook.
+
+    :returns: the instance folder.
+    """
+    from builder2ibek.convert import write_ioc_yaml
+
+    folder = scaffold(services_repo, ioc_name.lower(), fastcs=False, dry_run=dry_run)
+    if not ioc.description:
+        ioc.description = f"{ioc_name}, converted by builder2ibek catio"
+
+    if not dry_run:
+        # write_ioc_yaml mutates `ioc` (it drops the internal source_file
+        # attribute), so it is called only on the writing path.
+        write_ioc_yaml(ioc, folder / "config" / "ioc.yaml", IOC_SCHEMA)
+    return folder
+
+
+def read_sticky_ordinals(services_repo: Path) -> dict[str, int]:
+    """The ``E{n}RIO`` ordinal of every fastcs-catio IOC already in the repo.
+
+    Chain ordinals must be **sticky**: a second conversion run that renumbered
+    a chain would repoint every PV rewritten by the first run at nothing. So
+    the allocator in :func:`~builder2ibek.catio.chains.discover_chains` starts
+    from whatever is on disk.
+
+    Every ``services/*/config/fastcs.yaml`` is parsed; unrelated FastCS IOCs
+    (a different controller ``type``, or the singular ``controller:`` mapping
+    other FastCS projects use) and unparseable files are skipped silently --
+    a services repo is entitled to hold FastCS IOCs this tool knows nothing
+    about.
+
+    :returns: ``{catio IOC id: ordinal}``.
+    """
+    yaml = YAML(typ="safe")
+    ordinals: dict[str, int] = {}
+
+    services = _services(services_repo)
+    for path in sorted(services.glob(f"*/config/{FASTCS_CONFIG}")):
+        try:
+            doc = yaml.load(path)
+        except (YAMLError, OSError, UnicodeDecodeError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        controllers = doc.get("controllers")
+        if not isinstance(controllers, list):
+            continue
+        for controller in controllers:
+            entry = _ordinal_of(controller)
+            if entry is not None:
+                ordinals[entry[0]] = entry[1]
+    return ordinals
+
+
+def _ordinal_of(controller: object) -> tuple[str, int] | None:
+    """``(id, ordinal)`` for a fastcs-catio controller entry, else ``None``."""
+    if not isinstance(controller, dict):
+        return None
+    if controller.get("type") != CATIO_CONTROLLER_TYPE:
+        return None
+    catio_ioc = controller.get("id")
+    if not isinstance(catio_ioc, str) or not catio_ioc:
+        return None
+    mappings = controller.get("name_mappings")
+    if not isinstance(mappings, dict):
+        return None
+    node_prefix = mappings.get("node_prefix")
+    if not isinstance(node_prefix, str):
+        return None
+    match = _ORDINAL_RE.search(node_prefix)
+    if match is None:
+        return None
+    return catio_ioc, int(match.group(1))

--- a/src/builder2ibek/catio/services.py
+++ b/src/builder2ibek/catio/services.py
@@ -183,6 +183,11 @@ def _copy_missing(template_dir: Path, target_dir: Path) -> None:
         elif entry.is_dir():
             _copy_missing(entry, target)
         elif not target.exists():
+            # exists() follows symlinks, so a broken link reads as absent and
+            # copyfile would then write *through* it, landing the file wherever
+            # the link points -- possibly outside the instance folder.
+            if target.is_symlink():
+                target.unlink()
             shutil.copyfile(entry, target)
 
 

--- a/src/builder2ibek/catio/substitute.py
+++ b/src/builder2ibek/catio/substitute.py
@@ -206,12 +206,26 @@ class Substituter:
                 attribute=attribute,
             )
 
-    @staticmethod
-    def _trailing_flags(parts: list[str], index: int) -> str:
-        """The non-whitespace tokens of *parts* that follow position *index*."""
-        return " ".join(
-            token for token in parts[index + 1 :] if token and not token.isspace()
-        )
+    def _trailing_flags(self, parts: list[str], index: int) -> str:
+        """The EPICS link flags that belong to the PV at position *index*.
+
+        A value may carry more than one PV -- ``"PV1 PP PV2 CP"`` is a writer
+        followed by a reader -- so the scan stops at the next token that is
+        itself a PV. Running on past it would let ``PV2``'s ``CP`` decide
+        ``PV1``'s direction and quietly point a writer at a read-only readback.
+        """
+        flags: list[str] = []
+        for token in parts[index + 1 :]:
+            if not token or token.isspace():
+                continue
+            if (
+                token in self.subs
+                or token in self.unresolved
+                or LEGACY_PV_RE.match(token)
+            ):
+                break
+            flags.append(token)
+        return " ".join(flags)
 
     # -- public API --------------------------------------------------------
 

--- a/src/builder2ibek/catio/substitute.py
+++ b/src/builder2ibek/catio/substitute.py
@@ -1,0 +1,373 @@
+"""Rewriting legacy EtherCAT PV references onto their fastcs-catio names.
+
+This module is deliberately **pure**: it does no file I/O, never imports
+`fastcs_catio`, and knows nothing about EtherCAT chains beyond the four
+dictionaries its constructor is handed. :mod:`builder2ibek.catio.chains` builds
+those dictionaries; this module only applies them.
+
+Substitution is **token-wise on parsed entity values**, never on XML text. A
+value such as ``"BL21I-DI-ERIO-10:MOD1:INPUT1:VALUE CP"`` is split on
+whitespace runs, only whole tokens that are exact keys of the substitution map
+are replaced, and everything else -- including the trailing EPICS link flags --
+is preserved byte for byte. Keys are the *full* legacy PV including the record
+suffix, because a prefix-only substitution would be unsafe: `DEVICE=` names are
+ambiguous between terminals and only the leaf disambiguates them.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, keeps this module import-light
+    from builder2ibek.catio.diagnostics import DiagnosticLog
+
+__all__ = [
+    "INPUT_ATTR_RE",
+    "LEGACY_PV_RE",
+    "OUTPUT_ATTR_RE",
+    "READ_FLAGS",
+    "WRITE_FLAGS",
+    "NewPv",
+    "SubstitutionMap",
+    "Substituter",
+    "link_is_reading",
+]
+
+
+#: A token that looks like a legacy EtherCAT PV: a hyphenated device name
+#: containing an ``ERIO`` segment, followed by at least one ``:``-separated
+#: record suffix. The colon is required -- bare ``ERIO`` words in free text
+#: must not be mistaken for PV references.
+LEGACY_PV_RE = re.compile(r"^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*-ERIO-[A-Za-z0-9]+:\S+$")
+
+#: EPICS link flags that make the link *read* the target.
+READ_FLAGS = frozenset({"CP", "CPP", "MS", "MSS", "MSI"})
+
+#: EPICS link flags that make the link *write* to the target.
+WRITE_FLAGS = frozenset({"PP", "NPP"})
+
+#: Attribute names that name an output link.
+OUTPUT_ATTR_RE = re.compile(r"(?i)(^|_)(out|dol|output)(\d*)($|_)")
+
+#: Attribute names that name an input link.
+INPUT_ATTR_RE = re.compile(r"(?i)(^|_)(inp|input|in)(\d*)($|_)")
+
+
+@dataclass(frozen=True)
+class NewPv:
+    """The replacement PVs for one legacy PV.
+
+    FastCS gives a read/write attribute two PVs -- the setpoint under its own
+    name and a readback suffixed ``_RBV`` -- so which one a consumer should use
+    depends on the direction of the link that references it.
+
+    :param read: full new PV a reader should use.
+    :param write: full new PV a writer should use.
+    """
+
+    read: str
+    write: str
+
+    @classmethod
+    def same(cls, name: str) -> NewPv:
+        """A read-only signal, where both directions use the same PV.
+
+        >>> NewPv.same("BL21I-VA-E1RIO-01:24VDI01:Channel1")
+        NewPv(read='BL21I-VA-E1RIO-01:24VDI01:Channel1', write='BL21I-VA-E1RIO-01:24VDI01:Channel1')
+        """  # noqa: E501
+        return cls(read=name, write=name)
+
+    @property
+    def writable(self) -> bool:
+        """True when the underlying fastcs attribute is read/write.
+
+        >>> NewPv.same("X:Y").writable
+        False
+        >>> NewPv(read="X:Y_RBV", write="X:Y").writable
+        True
+        """
+        return self.read != self.write
+
+
+#: Full legacy PV (prefix *and* record suffix) -> its replacement.
+SubstitutionMap = dict[str, NewPv]
+
+
+def link_is_reading(attribute: str, flags: str) -> bool | None:
+    """Whether a link reads from, or writes to, the PV it names.
+
+    The rules are tried in order and the first that fires wins:
+
+    1. the trailing link flags contain ``CP``, ``CPP``, ``MS``, ``MSS`` or
+       ``MSI`` -- reading;
+    2. else the flags contain ``PP`` or ``NPP`` -- writing;
+    3. else the attribute name looks like an output link -- writing;
+    4. else the attribute name looks like an input link -- reading;
+    5. else undecidable.
+
+    :param attribute: the builder attribute the value came from, e.g. ``INP1``.
+    :param flags: the non-whitespace tokens following the PV in the same value.
+    :returns: True for reading, False for writing, None when nothing decided it
+        -- the caller then defaults to reading and, for a writable leaf, emits
+        ``link-direction-guess``.
+
+    >>> link_is_reading("VAL", "CP MS")
+    True
+    >>> link_is_reading("VAL", "PP")
+    False
+    >>> link_is_reading("OUTGB0", "")
+    >>> link_is_reading("DOL", "")
+    False
+    >>> link_is_reading("INP1", "")
+    True
+    """
+    tokens = {token.upper() for token in flags.split()}
+    if tokens & READ_FLAGS:
+        return True
+    if tokens & WRITE_FLAGS:
+        return False
+    if OUTPUT_ATTR_RE.search(attribute):
+        return False
+    if INPUT_ATTR_RE.search(attribute):
+        return True
+    return None
+
+
+class Substituter:
+    """Applies a prepared substitution map to builder entity values."""
+
+    def __init__(
+        self,
+        subs: SubstitutionMap,
+        owners: dict[str, str],
+        unresolved: dict[str, tuple[str, str, str | None]],
+        known_labels: dict[str, str],
+    ) -> None:
+        """
+        :param subs: full legacy PV -> replacement.
+        :param owners: full legacy PV -> the scanner IOC whose chain owns it.
+        :param unresolved: full legacy PV -> ``(code, message, chain)`` for PVs
+            that were deliberately dropped from *subs* (an ambiguous mapping,
+            say). Referencing one raises the recorded diagnostic and leaves the
+            token alone.
+        :param known_labels: coupler label -> the scanner IOC declaring it. Used
+            to tell a bad ``MOD`` number on a known chain (``mod-out-of-range``,
+            which fails that chain) from a reference to a label no chain
+            declares at all (``unknown-chain-label``, which fails only the
+            consumer IOC).
+        """
+        self.subs = subs
+        self.owners = owners
+        self.unresolved = unresolved
+        self.known_labels = known_labels
+        self._references: dict[str, set[str]] = {}
+        self._touched: set[str] = set()
+
+    # -- internals ---------------------------------------------------------
+
+    def _note_reference(self, ioc: str, chain: str | None) -> None:
+        if chain:
+            self._references.setdefault(ioc, set()).add(chain)
+
+    def _diagnose_unknown(
+        self,
+        token: str,
+        *,
+        log: DiagnosticLog,
+        ioc: str,
+        entity: str | None,
+        attribute: str,
+    ) -> None:
+        """Report a token that looks like a legacy PV but resolves to nothing."""
+        label, _, remainder = token.partition(":")
+        chain = self.known_labels.get(label)
+        if chain is not None:
+            log.add(
+                "mod-out-of-range",
+                f"{token} references coupler label {label}, which chain {chain} "
+                f"declares, but that chain has no terminal providing {remainder}",
+                chain=chain,
+                ioc=ioc,
+                entity=entity,
+                attribute=attribute,
+            )
+            self._note_reference(ioc, chain)
+        else:
+            log.add(
+                "unknown-chain-label",
+                f"{token} references coupler label {label}, "
+                "which no converted chain declares",
+                chain=None,
+                ioc=ioc,
+                entity=entity,
+                attribute=attribute,
+            )
+
+    @staticmethod
+    def _trailing_flags(parts: list[str], index: int) -> str:
+        """The non-whitespace tokens of *parts* that follow position *index*."""
+        return " ".join(
+            token for token in parts[index + 1 :] if token and not token.isspace()
+        )
+
+    # -- public API --------------------------------------------------------
+
+    def rewrite_value(
+        self,
+        value: str,
+        *,
+        attribute: str,
+        log: DiagnosticLog,
+        ioc: str,
+        entity: str | None,
+    ) -> str:
+        """Rewrite every legacy PV token in *value*, preserving everything else.
+
+        Whitespace runs and trailing EPICS link flags survive verbatim; only
+        whole tokens that are exact keys of the substitution map change.
+        """
+        parts = re.split(r"(\s+)", value)
+        changed = False
+        for index, token in enumerate(parts):
+            if not token or token.isspace():
+                continue
+            new_pv = self.subs.get(token)
+            if new_pv is not None:
+                flags = self._trailing_flags(parts, index)
+                reading = link_is_reading(attribute, flags)
+                if reading is None:
+                    reading = True
+                    if new_pv.writable:
+                        log.add(
+                            "link-direction-guess",
+                            f"cannot tell whether {token} is read or written "
+                            f"by {attribute}; assuming it is read and using "
+                            f"{new_pv.read}",
+                            chain=self.owners.get(token),
+                            ioc=ioc,
+                            entity=entity,
+                            attribute=attribute,
+                        )
+                replacement = new_pv.read if reading else new_pv.write
+                self._note_reference(ioc, self.owners.get(token))
+                if replacement != token:
+                    parts[index] = replacement
+                    changed = True
+                continue
+
+            dropped = self.unresolved.get(token)
+            if dropped is not None:
+                code, message, chain = dropped
+                log.add(
+                    code,
+                    message,
+                    chain=chain,
+                    ioc=ioc,
+                    entity=entity,
+                    attribute=attribute,
+                )
+                self._note_reference(ioc, chain)
+                continue
+
+            if LEGACY_PV_RE.match(token):
+                self._diagnose_unknown(
+                    token, log=log, ioc=ioc, entity=entity, attribute=attribute
+                )
+
+        if not changed:
+            return value
+        self._touched.add(ioc)
+        return "".join(parts)
+
+    def rewrite_entity(
+        self, entity: dict[str, Any], *, log: DiagnosticLog, ioc: str
+    ) -> bool:
+        """Rewrite every string value of a parsed builder entity in place.
+
+        The ``type`` key is never touched. Returns True when anything changed.
+        """
+        name = entity.get("name")
+        entity_name = name if isinstance(name, str) else None
+        changed = False
+        for key, value in list(entity.items()):
+            if key == "type" or not isinstance(value, str):
+                continue
+            new_value = self.rewrite_value(
+                value, attribute=key, log=log, ioc=ioc, entity=entity_name
+            )
+            if new_value != value:
+                entity[key] = new_value
+                changed = True
+        return changed
+
+    def _known_tokens(
+        self, entities: Iterable[dict[str, Any]]
+    ) -> dict[str, tuple[str | None, str]]:
+        """Legacy PVs *entities* name -> where the first sighting was.
+
+        Only tokens the substitution map actually knows are collected, so this
+        never has to guess what is and is not a PV.
+        """
+        found: dict[str, tuple[str | None, str]] = {}
+        for entity in entities:
+            name = entity.get("name")
+            entity_name = name if isinstance(name, str) else None
+            for key, value in entity.items():
+                if key == "type" or not isinstance(value, str):
+                    continue
+                for token in value.split():
+                    known = token in self.subs or self.unresolved.get(token) is not None
+                    if known:
+                        found.setdefault(token, (entity_name, key))
+        return found
+
+    def report_dropped(
+        self,
+        raw_entities: Iterable[dict[str, Any]],
+        kept_entities: Iterable[dict[str, Any]],
+        *,
+        log: DiagnosticLog,
+        ioc: str,
+    ) -> list[str]:
+        """Report legacy PVs that vanished with an entity the converter dropped.
+
+        Some builder elements have no ibek equivalent and are deleted outright
+        -- ``records.*`` most of all. A deleted entity cannot be rewritten, so
+        an EtherCAT reference inside one leaves no trace in the converted IOC
+        and no trace in the report either: the operator is never told that IOC
+        had an EtherCAT dependency to re-create by hand. This closes that gap.
+
+        A WARNING, not an error: nothing dangles, because the record itself is
+        gone. It is information the human needs, not a reason to stop.
+
+        :param raw_entities: every element of the source XML, before conversion.
+        :param kept_entities: the converted entities, taken *before* they were
+            rewritten -- afterwards they hold the new names, not the legacy ones.
+        :returns: the legacy PVs reported, sorted.
+        """
+        dropped = self._known_tokens(raw_entities)
+        for token in self._known_tokens(kept_entities):
+            dropped.pop(token, None)
+        for token, (entity, attribute) in sorted(dropped.items()):
+            log.add(
+                "dropped-reference",
+                f"{token} is referenced by an entity that has no ibek equivalent "
+                "and was dropped in conversion, so the reference was neither "
+                "rewritten nor kept; re-create it by hand if it is still needed",
+                chain=self.owners.get(token),
+                ioc=ioc,
+                entity=entity,
+                attribute=attribute,
+            )
+        return sorted(dropped)
+
+    def references(self, ioc: str) -> set[str]:
+        """The scanner IOCs *ioc* depends on, including via failed references."""
+        return set(self._references.get(ioc, ()))
+
+    def touched_iocs(self) -> set[str]:
+        """The consumer IOCs in which at least one value was actually rewritten."""
+        return set(self._touched)

--- a/src/builder2ibek/catio/substitute.py
+++ b/src/builder2ibek/catio/substitute.py
@@ -96,20 +96,35 @@ class NewPv:
 SubstitutionMap = dict[str, NewPv]
 
 
-def link_is_reading(attribute: str, flags: str) -> bool | None:
+#: ``(entity type, attribute)`` pairs whose direction is not a heuristic at all.
+#: ``epics.dbpf`` performs a caput at startup, so its ``pv`` is written to by
+#: definition -- and its attribute is named ``pv``, which no name heuristic can
+#: read anything into. Without this an EL2595's drive current is rewritten to
+#: ``...DoxCurrentOutputCurrent_RBV`` and the IOC tries to caput a read-only
+#: readback. Real occurrences: the four LED currents in ``BL21I-DI-IOC-01``.
+KNOWN_DIRECTIONS: dict[tuple[str, str], bool] = {
+    ("epics.dbpf", "pv"): False,
+}
+
+
+def link_is_reading(
+    attribute: str, flags: str, entity_type: str | None = None
+) -> bool | None:
     """Whether a link reads from, or writes to, the PV it names.
 
     The rules are tried in order and the first that fires wins:
 
-    1. the trailing link flags contain ``CP``, ``CPP``, ``MS``, ``MSS`` or
+    1. the entity type and attribute are a known, unambiguous pair;
+    2. else the trailing link flags contain ``CP``, ``CPP``, ``MS``, ``MSS`` or
        ``MSI`` -- reading;
-    2. else the flags contain ``PP`` or ``NPP`` -- writing;
-    3. else the attribute name looks like an output link -- writing;
-    4. else the attribute name looks like an input link -- reading;
-    5. else undecidable.
+    3. else the flags contain ``PP`` or ``NPP`` -- writing;
+    4. else the attribute name looks like an output link -- writing;
+    5. else the attribute name looks like an input link -- reading;
+    6. else undecidable.
 
     :param attribute: the builder attribute the value came from, e.g. ``INP1``.
     :param flags: the non-whitespace tokens following the PV in the same value.
+    :param entity_type: the converted entity's ``type``, e.g. ``epics.dbpf``.
     :returns: True for reading, False for writing, None when nothing decided it
         -- the caller then defaults to reading and, for a writable leaf, emits
         ``link-direction-guess``.
@@ -123,7 +138,13 @@ def link_is_reading(attribute: str, flags: str) -> bool | None:
     False
     >>> link_is_reading("INP1", "")
     True
+    >>> link_is_reading("pv", "", "epics.dbpf")
+    False
     """
+    if entity_type is not None:
+        known = KNOWN_DIRECTIONS.get((entity_type, attribute))
+        if known is not None:
+            return known
     tokens = {token.upper() for token in flags.split()}
     if tokens & READ_FLAGS:
         return True
@@ -237,6 +258,7 @@ class Substituter:
         log: DiagnosticLog,
         ioc: str,
         entity: str | None,
+        entity_type: str | None = None,
     ) -> str:
         """Rewrite every legacy PV token in *value*, preserving everything else.
 
@@ -251,7 +273,7 @@ class Substituter:
             new_pv = self.subs.get(token)
             if new_pv is not None:
                 flags = self._trailing_flags(parts, index)
-                reading = link_is_reading(attribute, flags)
+                reading = link_is_reading(attribute, flags, entity_type)
                 if reading is None:
                     reading = True
                     if new_pv.writable:
@@ -305,12 +327,19 @@ class Substituter:
         """
         name = entity.get("name")
         entity_name = name if isinstance(name, str) else None
+        kind = entity.get("type")
+        entity_type = kind if isinstance(kind, str) else None
         changed = False
         for key, value in list(entity.items()):
             if key == "type" or not isinstance(value, str):
                 continue
             new_value = self.rewrite_value(
-                value, attribute=key, log=log, ioc=ioc, entity=entity_name
+                value,
+                attribute=key,
+                log=log,
+                ioc=ioc,
+                entity=entity_name,
+                entity_type=entity_type,
             )
             if new_value != value:
                 entity[key] = new_value

--- a/src/builder2ibek/convert.py
+++ b/src/builder2ibek/convert.py
@@ -14,7 +14,23 @@ from builder2ibek.support_defaults import strip_defaults
 from builder2ibek.types import Entity, Generic_IOC
 
 
-def convert_file(xml: Path, yaml: Path, schema: str, description: str = ""):
+def convert_to_ioc(
+    xml: Path, *, description: str = "", catio: Any = None
+) -> Generic_IOC:
+    """Convert a single builder XML file into an in-memory Generic_IOC.
+
+    ``catio`` is an optional ``builder2ibek.converters.ethercat.CatioContext``
+    used by the ``catio`` command to rewrite EtherCAT PV references. It is
+    ``None`` for a plain ``xml2yaml`` conversion.
+    """
+    builder = Builder()
+    builder.load(xml)
+    return dispatch(builder, xml, description=description, catio=catio)
+
+
+def write_ioc_yaml(ioc: Generic_IOC, yaml: Path, schema: str) -> None:
+    """Serialise an already converted Generic_IOC to an ibek YAML file"""
+
     def tidy_up(yaml):
         # add blank lines between major fields
         for field in [
@@ -25,11 +41,6 @@ def convert_file(xml: Path, yaml: Path, schema: str, description: str = ""):
         ]:
             yaml = re.sub(rf"(\n{field})", "\n\\g<1>", yaml)
         return yaml
-
-    """Convert a single builder XML file into a single ibek YAML"""
-    builder = Builder()
-    builder.load(xml)
-    ioc = dispatch(builder, xml, description=description)
 
     ruamel = YAML()
 
@@ -49,7 +60,15 @@ def convert_file(xml: Path, yaml: Path, schema: str, description: str = ""):
         ruamel.dump(yaml_map, stream, transform=tidy_up)
 
 
-def dispatch(builder: Builder, filename, description: str = "") -> Generic_IOC:
+def convert_file(xml: Path, yaml: Path, schema: str, description: str = ""):
+    """Convert a single builder XML file into a single ibek YAML"""
+    ioc = convert_to_ioc(xml, description=description)
+    write_ioc_yaml(ioc, yaml, schema)
+
+
+def dispatch(
+    builder: Builder, filename, description: str = "", catio: Any = None
+) -> Generic_IOC:
     """
     Dispatch every element in the XML to the correct convertor
     and build a generic IOC from the converted Entities
@@ -77,6 +96,13 @@ def dispatch(builder: Builder, filename, description: str = "") -> Generic_IOC:
         ],
         source_file=filename,
     )
+
+    if catio is not None:
+        # picked up by builder2ibek.converters.ethercat.finalize
+        ioc.catio = catio
+        # ioc.raw_entities is overwritten by every nested do_dispatch, so the
+        # unconverted elements are captured here, once, instead.
+        catio.raw_entities = [make_entity(element) for element in builder.elements]
 
     do_dispatch(builder, ioc)
 

--- a/src/builder2ibek/converters/ethercat.py
+++ b/src/builder2ibek/converters/ethercat.py
@@ -99,6 +99,7 @@ def finalize(ioc: Generic_IOC) -> None:
         ]
         ctx.substituter.report_dropped(raw, kept, log=ctx.log, ioc=ctx.ioc_name)
     finally:
-        # Generic_IOC allows extra attributes and model_dump() would serialise
-        # this one into the output YAML, so it must not outlive the conversion.
-        delattr(ioc, "catio")
+        # The field is excluded from model_dump(), so this is not what keeps it
+        # out of the YAML -- it just stops a spent context outliving the
+        # conversion and being applied twice.
+        ioc.catio = None

--- a/src/builder2ibek/converters/ethercat.py
+++ b/src/builder2ibek/converters/ethercat.py
@@ -1,10 +1,46 @@
+"""
+Convertor for the legacy ``ethercat`` support module.
+
+Legacy ethercat entities have no ibek equivalent: the replacement is
+fastcs-catio, which is a separate IOC entirely (see ``builder2ibek catio``).
+So every ethercat entity is dropped and a single TODO placeholder is left
+behind in place of the ``EthercatMaster``.
+
+When the conversion is driven by the ``catio`` command the IOC additionally
+carries a :class:`CatioContext` in ``ioc.catio``; :func:`finalize` then rewrites
+every legacy EtherCAT PV reference in the whole IOC to its fastcs-catio name.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
 from builder2ibek.converters.globalHandler import globalHandler
 from builder2ibek.types import Entity, Generic_IOC
 
 xml_component = "ethercat"
 
-# Track whether we've already inserted the dummy for this IOC
-_dummy_inserted = False
+
+@dataclass
+class CatioContext:
+    """
+    The per-IOC context a ``builder2ibek catio`` run attaches to ``ioc.catio``.
+
+    Typed loosely on purpose: importing ``builder2ibek.catio`` at module scope
+    would make every converter import it, and pytest imports every module under
+    ``src`` for ``--doctest-modules``.
+
+    ``substituter`` is a ``builder2ibek.catio.substitute.Substituter``,
+    ``log`` a ``builder2ibek.catio.diagnostics.DiagnosticLog``.
+
+    ``raw_entities`` is filled in by ``builder2ibek.convert.dispatch`` with
+    every element of the source XML, so :func:`finalize` can tell which
+    references were lost with an entity the conversion dropped.
+    """
+
+    substituter: Any
+    log: Any
+    ioc_name: str
+    raw_entities: list[dict[str, Any]] = field(default_factory=list)
 
 
 @globalHandler
@@ -15,11 +51,8 @@ def handler(entity: Entity, entity_type: str, ioc: Generic_IOC):
     Ethercat entities are marked for major rewrite — the new approach uses
     fastcs-catio instead of the legacy ethercat support module.
     """
-    global _dummy_inserted
-
     if entity_type == "EthercatMaster":
         # Replace the first EthercatMaster with a placeholder comment
-        _dummy_inserted = True
         entity.clear()
         entity.type = "epics.PostStartupCommand"
         entity["command"] = (
@@ -29,3 +62,43 @@ def handler(entity: Entity, entity_type: str, ioc: Generic_IOC):
     else:
         # Drop all other ethercat entities
         entity.delete_me()
+
+
+def finalize(ioc: Generic_IOC) -> None:
+    """Apply the catio PV substitutions, if this conversion is a catio run.
+
+    A plain ``xml2yaml`` conversion never sets ``ioc.catio``, so this is a
+    no-op there:
+
+    >>> from pathlib import Path
+    >>> from builder2ibek.types import Generic_IOC
+    >>> ioc = Generic_IOC(
+    ...     ioc_name="x", description="", entities=[], source_file=Path("x.xml")
+    ... )
+    >>> finalize(ioc)
+    >>> "catio" in ioc.model_dump()
+    False
+    """
+    ctx = getattr(ioc, "catio", None)
+    if ctx is None:
+        return
+
+    try:
+        # Snapshot before rewriting: afterwards these hold the *new* names, and
+        # the comparison below needs the legacy ones.
+        kept = [dict(entity) for entity in ioc.entities]
+        for entity in ioc.entities:
+            ctx.substituter.rewrite_entity(entity, log=ctx.log, ioc=ctx.ioc_name)
+        # `ethercat.*` entities are dropped by design and their replacement is
+        # the generated fastcs-catio IOC, so their DEVICE= is not a reference
+        # anyone has to re-create by hand.
+        raw = [
+            entity
+            for entity in ctx.raw_entities
+            if not str(entity.get("type", "")).startswith(f"{xml_component}.")
+        ]
+        ctx.substituter.report_dropped(raw, kept, log=ctx.log, ioc=ctx.ioc_name)
+    finally:
+        # Generic_IOC allows extra attributes and model_dump() would serialise
+        # this one into the output YAML, so it must not outlive the conversion.
+        delattr(ioc, "catio")

--- a/src/builder2ibek/converters/ethercat.py
+++ b/src/builder2ibek/converters/ethercat.py
@@ -8,7 +8,8 @@ behind in place of the ``EthercatMaster``.
 
 When the conversion is driven by the ``catio`` command the IOC additionally
 carries a :class:`CatioContext` in ``ioc.catio``; :func:`finalize` then rewrites
-every legacy EtherCAT PV reference in the whole IOC to its fastcs-catio name.
+every legacy EtherCAT PV reference in the whole IOC to its fastcs-catio name,
+and drops the TODO placeholder -- that switch has just been made.
 """
 
 from dataclasses import dataclass, field
@@ -18,6 +19,12 @@ from builder2ibek.converters.globalHandler import globalHandler
 from builder2ibek.types import Entity, Generic_IOC
 
 xml_component = "ethercat"
+
+#: What an ``EthercatMaster`` becomes in a plain ``xml2yaml`` conversion.
+TODO_COMMAND = (
+    "# TODO: ethercat support requires major rewrite for "
+    "epics-containers — switch to fastcs-catio"
+)
 
 
 @dataclass
@@ -55,13 +62,18 @@ def handler(entity: Entity, entity_type: str, ioc: Generic_IOC):
         # Replace the first EthercatMaster with a placeholder comment
         entity.clear()
         entity.type = "epics.PostStartupCommand"
-        entity["command"] = (
-            "# TODO: ethercat support requires major rewrite for "
-            "epics-containers — switch to fastcs-catio"
-        )
+        entity["command"] = TODO_COMMAND
     else:
         # Drop all other ethercat entities
         entity.delete_me()
+
+
+def _is_todo_placeholder(entity: dict[str, Any]) -> bool:
+    """True for the placeholder :func:`handler` leaves behind for a master."""
+    return (
+        entity.get("type") == "epics.PostStartupCommand"
+        and entity.get("command") == TODO_COMMAND
+    )
 
 
 def finalize(ioc: Generic_IOC) -> None:
@@ -84,6 +96,12 @@ def finalize(ioc: Generic_IOC) -> None:
         return
 
     try:
+        # The placeholder tells a human to switch to fastcs-catio; in a catio
+        # run that has just happened, so leaving it behind would send whoever
+        # reads the IOC looking for work already done. Only a *written* IOC
+        # matters, and `catio` skips any scanner whose chain failed, so a
+        # placeholder that would reach a services repo is always stale.
+        ioc.entities[:] = [e for e in ioc.entities if not _is_todo_placeholder(e)]
         # Snapshot before rewriting: afterwards these hold the *new* names, and
         # the comparison below needs the legacy ones.
         kept = [dict(entity) for entity in ioc.entities]

--- a/src/builder2ibek/types.py
+++ b/src/builder2ibek/types.py
@@ -65,6 +65,10 @@ class Generic_IOC(BaseModel):
     raw_entities: list[dict[str, Any]] = Field(default_factory=list, exclude=True)
     source_file: Path
     already_converted: list[dict[str, Any]] = Field(default_factory=list, exclude=True)
+    # Set only by `builder2ibek catio`, and consumed by the ethercat converter's
+    # finalizer. Declared here rather than leaned on `extra="allow"` so that it
+    # type-checks, and excluded so it can never reach the output YAML.
+    catio: Any = Field(default=None, exclude=True)
 
 
 # Generic XML classes ##########################################################

--- a/tests/samples/catio/BL21I-DI-IOC-01.xml
+++ b/tests/samples/catio/BL21I-DI-IOC-01.xml
@@ -1,0 +1,542 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<EPICS_BASE.EpicsEnvSet key="EPICS_CA_MAX_ARRAY_BYTES" name="EPICS_CA_MAX_ARRAY_BYTES" value="500000"/>
+	<autosave.Autosave bl="True" iocName="BL21I-DI-IOC-01" name="BL21I-DI-IOC-01.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="DI1.PVLOGGING"/>
+	<BL21I.M4ADCSupport DESC="M4 Drain Current Synchronised Capture" GenADCPrefix="BL21I-MO-POD-01:FEMTO1:ADC101" PVTRIGGER="BL21I-OP-SHTR-01:STATUS" name="M4.DrainC1.Capture" prefix="BL21I-MO-POD-01:FEMTO1:ADC101_CAP"/>
+	<!--Selects which measurement mode to use, which will impact the fast shutter state (see i21 electrical drawing 1116266 page8 for detailed shutter driver configuration).
+
+If FSXAS is selected, the fast shutter is controlled directly through the ERIO signal (usually open), but the valve is shut to prevent the beam reaching the detector.
+If Primary (Andor Marana-X), Spare (iKon-L Andor1 or XCAM), Polarimeter-Pi (iKon-L Andor2) or Polarimeter-Sigma (iKon-L Andor3) is selected, the fast shutter is automatically shut to prevent light damaging the detector if not ready to receive it, but the valve is open to let the beam through when ready. Opening/closing of the fast shutter is then linked to the detector's own shutter control (defined by driver).
+The ERIO mode is used for continuous scanning of sensitive samples, where the fast shutter is controlled directly through the ERIO signal (usually open), but the valve is kept open to radiate the beam away from the sample.
+
+Fast shutter drive mode depends on the output values of BL21I-DI-ERIO-04, EL2124, Module.15, Outputs.1-4
+Fast shutter status comes from BL21I-DI-ERIO-05, EL1014 Module.7, Input.4-->
+	<BL21I.FS1Control ERIO_CTRL="@asyn(DCS00024867)Channel1.Output" POLPI_CTRL="BL21I-EA-DET-02:CAM:AndorShutterMode" POLSIGMA_CTRL="BL21I-EA-DET-04:CAM:AndorShutterMode" PRIMARY_CTRL="BL21I-EA-DET-01:CAM:AndorShutterMode" RL-AB_SWITCH="@asyn(DCS00024867)Channel3.Output" RL-C_SWITCH="@asyn(DCS00024867)Channel2.Output" RL-D_SWITCH="@asyn(DCS00024867)Channel4.Output" SPARE_CTRL="BL21I-EA-DET-05:CAM:ShutterMode" STATUS_IN="@asyn(DCS00026321)Channel4.Input" VALVE_CTRL="BL21I-VA-VALVE-17" name="FS1.Control" prefix="BL21I-OP-SHTR-01"/>
+	<BL21I.FeedbackAutoPv DESC="M1 and M2 Feedback Control" FEEDBACK_TIME="5" PULSE_DELAY="9" name="M1.FeedbackControl" prefix="BL21I-OP-MIRR-01:FBCTRL"/>
+	<BL21I.S2DiodeDifference FEMTO1="BL21I-AL-SLITS-02:FEMTO4" FEMTO2="BL21I-AL-SLITS-02:FEMTO3" MINVAL="0.0000000001" P="BL21I-AL-SLITS-02" PREC="6" R=":XDIFF"/>
+	<BL21I.DewarScales LH_CONV="8" LOAD_CELL_1="BL21I-DI-ERIO-04:MOD12:RMB:VALUE" LOAD_CELL_2="BL21I-DI-ERIO-04:MOD13:RMB:VALUE" LOAD_CELL_3="BL21I-DI-ERIO-04:MOD14:RMB:VALUE" LOAD_CELL_4="BL21I-DI-ERIO-04:MOD15:RMB:VALUE" SCALING="200" name="SMPL.SCALES" prefix="BL21I-EA-SMPL-01:SCALES"/>
+	<!--Synchronised capture of multiple PVs-->
+	<binPoints.BinPointAll DESCRIPTION="draincurent_i" P="BL21I-EA-SMPL-01:DC_S:" R="BPTS:" R1="DC:" R10LNK="" R10RSTLNK="" R11LNK="" R11RSTLNK="" R12LNK="" R12RSTLNK="" R2="DC_I:" R3="IDGAP:" R4="PGME:" R5="CUR_CAP:" R6="REQ_CAP:" R7LNK="" R7RSTLNK="" R8LNK="" R8RSTLNK="" R9LNK="" R9RSTLNK="" TRIGGER_PV_NAME="BL21I-EA-SMPL-01:FEMTO1:ADC_ACQ:MONITOR"/>
+	<!--DC_S: Draincurrent synchronised accumulation
+DF_S: Diff synchronised accumulation
+FYDx_S: FY Diode x synchronised accumulation
+
+Poor naming due to long PV lengths (need to modify binPoints template)-->
+	<binPoints.BinPointAll DESCRIPTION="diff_i" P="BL21I-EA-SMPL-01:DF_S:" R="BPTS:" R1="DFF:" R10LNK="" R10RSTLNK="" R11LNK="" R11RSTLNK="" R12LNK="" R12RSTLNK="" R2="DFF_I:" R3="IDGAP:" R4="PGME:" R5="CUR_CAP:" R6="REQ_CAP:" R7LNK="" R7RSTLNK="" R8LNK="" R8RSTLNK="" R9LNK="" R9RSTLNK="" TRIGGER_PV_NAME="BL21I-EA-SMPL-01:FEMTO6:ADC_ACQ:MONITOR"/>
+	<binPoints.BinPointAll DESCRIPTION="m4c1" P="BL21I-MO-POD-01:C1_S:" R="BPTS:" R1="M4C1:" R10LNK="" R10RSTLNK="" R11LNK="" R11RSTLNK="" R12LNK="" R12RSTLNK="" R2="M4C1_I:" R3="IDGAP:" R4="PGME:" R5="CUR_CAP:" R6="REQ_CAP:" R7LNK="" R7RSTLNK="" R8LNK="" R8RSTLNK="" R9LNK="" R9RSTLNK="" TRIGGER_PV_NAME="BL21I-MO-POD-01:FEMTO1:ADC_ACQ:MONITOR"/>
+	<binPoints.BinPointAll DESCRIPTION="fydiode2_i" P="BL21I-EA-SMPL-01:F2_S:" R="BPTS:" R1="FYD:" R10LNK="" R10RSTLNK="" R11LNK="" R11RSTLNK="" R12LNK="" R12RSTLNK="" R2="FYD_I:" R3="IDGAP:" R4="PGME:" R5="CUR_CAP:" R6="REQ_CAP:" R7LNK="" R7RSTLNK="" R8LNK="" R8RSTLNK="" R9LNK="" R9RSTLNK="" TRIGGER_PV_NAME="BL21I-EA-SMPL-01:FEMTO5:ADC_ACQ:MONITOR"/>
+	<!--Draincurrent capture-->
+	<binPoints.BinPoint DESCRIPTION="draincurrent" P="BL21I-EA-SMPL-01:DC_S:" R="DC:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO1:ADC2_VALUE"/>
+	<binPoints.BinPoint DESCRIPTION="draincurrent integral" P="BL21I-EA-SMPL-01:DC_S:" R="DC_I:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO1:ADC2_INTEGRAL"/>
+	<binPoints.BinPoint DESCRIPTION="ID gap" P="BL21I-EA-SMPL-01:DC_S:" R="IDGAP:" VALUE_PV_NAME="SR21I-MO-SERVC-01:CURRGAPD"/>
+	<binPoints.BinPoint DESCRIPTION="PGM energy" P="BL21I-EA-SMPL-01:DC_S:" R="PGME:" VALUE_PV_NAME="BL21I-OP-PGM-01:ENERGY.RBV"/>
+	<binPoints.BinPoint DESCRIPTION="Current capture count" P="BL21I-EA-SMPL-01:DC_S:" R="CUR_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO1:ADC_ACQ:CURR_CAPS"/>
+	<binPoints.BinPoint DESCRIPTION="Number to capture" P="BL21I-EA-SMPL-01:DC_S:" R="REQ_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO1:ADC_ACQ:REQ_CAPS"/>
+	<!--DFF Capture-->
+	<binPoints.BinPoint DESCRIPTION="diff" P="BL21I-EA-SMPL-01:DF_S:" R="DFF:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO6:ADC1_VALUE"/>
+	<binPoints.BinPoint DESCRIPTION="diff integral" P="BL21I-EA-SMPL-01:DF_S:" R="DFF_I:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO6:ADC1_INTEGRAL"/>
+	<binPoints.BinPoint DESCRIPTION="ID gap" P="BL21I-EA-SMPL-01:DF_S:" R="IDGAP:" VALUE_PV_NAME="SR21I-MO-SERVC-01:CURRGAPD"/>
+	<binPoints.BinPoint DESCRIPTION="PGM energy" P="BL21I-EA-SMPL-01:DF_S:" R="PGME:" VALUE_PV_NAME="BL21I-OP-PGM-01:ENERGY.RBV"/>
+	<binPoints.BinPoint DESCRIPTION="Current capture count" P="BL21I-EA-SMPL-01:DF_S:" R="CUR_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO6:ADC_ACQ:CURR_CAPS"/>
+	<binPoints.BinPoint DESCRIPTION="Number to capture" P="BL21I-EA-SMPL-01:DF_S:" R="REQ_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO6:ADC_ACQ:REQ_CAPS"/>
+	<!--M4C1 Capture
+i.e. M4 drain current femto 1-->
+	<binPoints.BinPoint DESCRIPTION="m4c1" P="BL21I-MO-POD-01:C1_S:" R="M4C1:" VALUE_PV_NAME="BL21I-MO-POD-01:FEMTO1:ADC101_VALUE"/>
+	<binPoints.BinPoint DESCRIPTION="m4c1 integral" P="BL21I-MO-POD-01:C1_S:" R="M4C1_I:" VALUE_PV_NAME="BL21I-MO-POD-01:FEMTO1:ADC101_INTEGRAL"/>
+	<binPoints.BinPoint DESCRIPTION="ID gap" P="BL21I-MO-POD-01:C1_S:" R="IDGAP:" VALUE_PV_NAME="SR21I-MO-SERVC-01:CURRGAPD"/>
+	<binPoints.BinPoint DESCRIPTION="PGM energy" P="BL21I-MO-POD-01:C1_S:" R="PGME:" VALUE_PV_NAME="BL21I-OP-PGM-01:ENERGY.RBV"/>
+	<binPoints.BinPoint DESCRIPTION="Current capture count" P="BL21I-MO-POD-01:C1_S:" R="CUR_CAP:" VALUE_PV_NAME="BL21I-MO-POD-01:FEMTO1:ADC_ACQ:CURR_CAPS"/>
+	<binPoints.BinPoint DESCRIPTION="Number to capture" P="BL21I-MO-POD-01:C1_S:" R="REQ_CAP:" VALUE_PV_NAME="BL21I-MO-POD-01:FEMTO1:ADC_ACQ:REQ_CAPS"/>
+	<!--FY Diode 2 capture-->
+	<binPoints.BinPoint DESCRIPTION="FY diode 2 current" P="BL21I-EA-SMPL-01:F2_S:" R="FYD:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO5:ADC2_VALUE"/>
+	<binPoints.BinPoint DESCRIPTION="FY diode 2 integral" P="BL21I-EA-SMPL-01:F2_S:" R="FYD_I:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO5:ADC2_INTEGRAL"/>
+	<binPoints.BinPoint DESCRIPTION="ID gap" P="BL21I-EA-SMPL-01:F2_S:" R="IDGAP:" VALUE_PV_NAME="SR21I-MO-SERVC-01:CURRGAPD"/>
+	<binPoints.BinPoint DESCRIPTION="PGM energy" P="BL21I-EA-SMPL-01:F2_S:" R="PGME:" VALUE_PV_NAME="BL21I-OP-PGM-01:ENERGY.RBV"/>
+	<binPoints.BinPoint DESCRIPTION="Current capture count" P="BL21I-EA-SMPL-01:F2_S:" R="CUR_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO5:ADC_ACQ:CURR_CAPS"/>
+	<binPoints.BinPoint DESCRIPTION="Number to capture" P="BL21I-EA-SMPL-01:F2_S:" R="REQ_CAP:" VALUE_PV_NAME="BL21I-EA-SMPL-01:FEMTO5:ADC_ACQ:REQ_CAPS"/>
+	<!--These loop triggers are used by GDA to accumulate a particular number of ADC samples.-->
+	<BL21I.ADCAcquisition ADC_PREFIX="BL21I-EA-SMPL-01:FEMTO1:ADC2" P="BL21I-EA-SMPL-01:FEMTO1:" R="ADC_ACQ:"/>
+	<BL21I.ADCAcquisition ADC_PREFIX="BL21I-EA-SMPL-01:FEMTO6:ADC1" P="BL21I-EA-SMPL-01:FEMTO6:" R="ADC_ACQ:"/>
+	<BL21I.ADCAcquisition ADC_PREFIX="BL21I-MO-POD-01:FEMTO1:ADC101" P="BL21I-MO-POD-01:FEMTO1:" R="ADC_ACQ:"/>
+	<BL21I.ADCAcquisition ADC_PREFIX="BL21I-EA-SMPL-01:FEMTO5:ADC2" P="BL21I-EA-SMPL-01:FEMTO5:" R="ADC_ACQ:"/>
+	<BL21I.ADCAcquisitionGroup ADCAcq_PREFIX1="BL21I-EA-SMPL-01:FEMTO1:ADC_ACQ:" ADCAcq_PREFIX2="BL21I-EA-SMPL-01:FEMTO6:ADC_ACQ:" ADCAcq_PREFIX3="BL21I-MO-POD-01:FEMTO1:ADC_ACQ:" ADCAcq_PREFIX4="BL21I-EA-SMPL-01:FEMTO5:ADC_ACQ:" ADC_PREFIX1="BL21I-EA-SMPL-01:FEMTO1:ADC2" ADC_PREFIX2="BL21I-EA-SMPL-01:FEMTO6:ADC1" ADC_PREFIX3="BL21I-MO-POD-01:FEMTO1:ADC101" ADC_PREFIX4="BL21I-EA-SMPL-01:FEMTO5:ADC2" BPT_PREFIX1="BL21I-EA-SMPL-01:DC_S:BPTS:BINPOINTALL:" BPT_PREFIX2="BL21I-EA-SMPL-01:DF_S:BPTS:BINPOINTALL:" BPT_PREFIX3="BL21I-MO-POD-01:C1_S:BPTS:BINPOINTALL:" BPT_PREFIX4="BL21I-EA-SMPL-01:F2_S:BPTS:BINPOINTALL:" P="BL21I-EA-SMPL-01:" R="ADC_ACQ_GRP:"/>
+	<devIocStats.devIocStatsHelper ioc="BL21I-DI-IOC-01" name="BL21I-DI-IOC-01.DEVIOCSTATS"/>
+	<ethercat.EthercatMaster max_message="200000" name="ECATM" socket="/tmp/socket0"/>
+	<!--Start of BL21I-DI-ERIO-05 Spetrometer hall rail 1-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026299" position="DCS00026299" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026199" position="DCS00026199" type_rev="EK1122 rev 0x00120000"/>
+	<!--Start of BL21I-DI-ERIO-05 Spetrometer hall rail 1
+See electrical drawing 1116266-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026293" position="DCS00026293" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026381" position="DCS00026381" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026382" position="DCS00026382" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026258" position="DCS00026258" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026259" position="DCS00026259" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023720" position="DCS00023720" type_rev="EL3602 rev 0x00100000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026320" position="DCS00026320" type_rev="EL1014 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026321" position="DCS00026321" type_rev="EL1014 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026210" position="DCS00026210" type_rev="EL2595 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026211" position="DCS00026211" type_rev="EL2595 rev 0x00130000"/>
+	<!--<ethercat.EthercatSlave master="ECATM" name="DCS00026212" position="DCS00026212" type_rev="EL2595 rev 0x00130000"/>-->
+	<!--<ethercat.EthercatSlave master="ECATM" name="DCS00026213" position="DCS00026213" type_rev="EL2595 rev 0x00130000"/>-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026672" position="DCS00026672" type_rev="EL9512 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026706" position="DCS00026706" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026707" position="DCS00026707" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026708" position="DCS00026708" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026709" position="DCS00026709" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026710" position="DCS00026710" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026711" position="DCS00026711" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<!--Start of BL21I-DI-ERIO-04 Spetrometer hall rail 2-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026292" position="DCS00026292" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026377" position="DCS00026377" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026380" position="DCS00026380" type_rev="EL3602 rev 0x00120000"/>
+	<!--<ethercat.EthercatSlave master="ECATM" name="DCS00024971" position="DCS00024971" type_rev="EL2595 rev 0x00120000"/>-->
+	<!--<ethercat.EthercatSlave master="ECATM" name="DCS00024972" position="DCS00024972" type_rev="EL2595 rev 0x00120000"/>-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024973" position="DCS00024973" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026214" position="DCS00026214" type_rev="EL2595 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026673" position="DCS00026673" type_rev="EL9512 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026712" position="DCS00026712" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026714" position="DCS00026714" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026713" position="DCS00026713" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026913" position="DCS00026913" type_rev="EL9510 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026910" position="DCS00026910" type_rev="EL3356-0010 rev 0x0018000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026911" position="DCS00026911" type_rev="EL3356-0010 rev 0x0018000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026977" position="DCS00026977" type_rev="EL3356-0010 rev 0x0019000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026971" position="DCS00026971" type_rev="EL3356-0010 rev 0x0019000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024957" position="DCS00024957" type_rev="EL9505 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024867" position="DCS00024867" type_rev="EL2124 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026627" position="DCS00026627" type_rev="EL2124 rev 0x00110000"/>
+	<!--Start of BL21I-DI-ERIO-09 Spectrometer hall 2 Rail 2-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026539" position="DCS00026539" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026674" position="DCS00026674" type_rev="EL9512 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026715" position="DCS00026715" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026716" position="DCS00026716" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026717" position="DCS00026717" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026718" position="DCS00026718" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026719" position="DCS00026719" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026720" position="DCS00026720" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<!--Start of BL21I-DI-ERIO-08 Spectrometer hall 2 Rail 1-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026540" position="DCS00026540" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026579" position="DCS00026579" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026580" position="DCS00026580" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026581" position="DCS00026581" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026582" position="DCS00026582" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026583" position="DCS00026583" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026584" position="DCS00026584" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026585" position="DCS00026585" type_rev="EL3602 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026441" position="DCS00026441" type_rev="EK1122 rev 0x00120000"/>
+	<!--Start of BL21I-DI-ERIO-01 OH1 Modules-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024927" position="DCS00024927" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023938" position="DCS00023938" type_rev="EK1122 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024933" position="DCS00024933" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024797" position="DCS00024797" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024798" position="DCS00024798" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024817" position="DCS00024817" type_rev="EL4134 rev 0x03fa0000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024652" position="DCS00024652" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024965" position="DCS00024965" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024966" position="DCS00024966" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023939" position="DCS00023939" type_rev="EK1122 rev 0x00110000"/>
+	<!--Start of BL21I-DI-ERIO-02 OH2 Modules-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024941" position="DCS00024941" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025131" position="DCS00025131" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025132" position="DCS00025132" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025133" position="DCS00025133" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025134" position="DCS00025134" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025135" position="DCS00025135" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026270" position="DCS00026270" type_rev="EL4134 rev 0x03fa0000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024967" position="DCS00024967" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024778" position="DCS00024778" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026671" position="DCS00026671" type_rev="EL9512 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026696" position="DCS00026696" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026697" position="DCS00026697" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026698" position="DCS00026698" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026699" position="DCS00026699" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026700" position="DCS00026700" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026701" position="DCS00026701" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026702" position="DCS00026702" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026703" position="DCS00026703" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026704" position="DCS00026704" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026705" position="DCS00026705" type_rev="EL2024-0010 rev 0x0012000a"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023940" position="DCS00023940" type_rev="EK1122 rev 0x00110000"/>
+	<!--Start of BL21I-DI-ERIO-03 OC1 Modules-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024940" position="DCS00024940" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024799" position="DCS00024799" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024800" position="DCS00024800" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024801" position="DCS00024801" type_rev="EL3602 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024549" position="DCS00024549" type_rev="EL3124 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024653" position="DCS00024653" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024654" position="DCS00024654" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024668" position="DCS00024668" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024669" position="DCS00024669" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024670" position="DCS00024670" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024782" position="DCS00024782" type_rev="EL2595 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023941" position="DCS00023941" type_rev="EK1122 rev 0x00110000"/>
+	<!--Trailing Coupler (probably from first module (dunno))-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023942" position="DCS00023942" type_rev="EK1122 rev 0x00110000"/>
+	<!--Start of BL21I-DI-ERIO-10 Lab 10 Area Modules-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026726" position="DCS00026726" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026416" position="DCS00026416" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026553" position="DCS00026553" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026554" position="DCS00026554" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026555" position="DCS00026555" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026556" position="DCS00026556" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026557" position="DCS00026557" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.SdoControl index="32768" name="SDO.LED1" slave="DCS00024966"/>
+	<ethercat.SdoControl index="32768" name="SDO.LED2" slave="DCS00024778"/>
+	<ethercat.SdoControl index="32768" name="SDO.LED3" slave="DCS00024967"/>
+	<ethercat.SdoControl index="32768" name="SDO.LED4" slave="DCS00024973"/>
+	<ethercat.SdoEntryControl asynparameter="voltage" bit_length="16" description="Output Voltage" name="SDO.LED1.1" parentsdo="SDO.LED1" subindex="4"/>
+	<ethercat.SdoEntryControl asynparameter="svoltage" bit_length="16" description="Supply Voltage" name="SDO.LED1.2" parentsdo="SDO.LED1" subindex="3"/>
+	<ethercat.SdoEntryControl asynparameter="holdcurrent" bit_length="16" description="Hold Current" name="SDO.LED1.3" parentsdo="SDO.LED1" subindex="2"/>
+	<ethercat.SdoEntryControl asynparameter="swarnlevel" bit_length="8" description="Warning Level (supply)" name="SDO.LED1.4" parentsdo="SDO.LED1" subindex="17"/>
+	<ethercat.SdoEntryControl asynparameter="serrorlevel" bit_length="8" description="Error Level (supply)" name="SDO.LED1.5" parentsdo="SDO.LED1" subindex="18"/>
+	<ethercat.SdoEntryControl asynparameter="outwarnlevel" bit_length="8" description="Warning Level (output)" name="SDO.LED1.6" parentsdo="SDO.LED1" subindex="19"/>
+	<ethercat.SdoEntryControl asynparameter="outerrorlevel" bit_length="8" description="Error Level (output)" name="SDO.LED1.7" parentsdo="SDO.LED1" subindex="20"/>
+	<ethercat.SdoEntryControl asynparameter="voltage" bit_length="16" description="Output Voltage" name="SDO.LED2.1" parentsdo="SDO.LED2" subindex="4"/>
+	<ethercat.SdoEntryControl asynparameter="svoltage" bit_length="16" description="Supply Voltage" name="SDO.LED2.2" parentsdo="SDO.LED2" subindex="3"/>
+	<ethercat.SdoEntryControl asynparameter="holdcurrent" bit_length="16" description="Hold Current" name="SDO.LED2.3" parentsdo="SDO.LED2" subindex="2"/>
+	<ethercat.SdoEntryControl asynparameter="swarnlevel" bit_length="8" description="Warning Level (supply)" name="SDO.LED2.4" parentsdo="SDO.LED2" subindex="17"/>
+	<ethercat.SdoEntryControl asynparameter="serrorlevel" bit_length="8" description="Error Level (supply)" name="SDO.LED2.5" parentsdo="SDO.LED2" subindex="18"/>
+	<ethercat.SdoEntryControl asynparameter="outwarnlevel" bit_length="8" description="Warning Level (output)" name="SDO.LED2.6" parentsdo="SDO.LED2" subindex="19"/>
+	<ethercat.SdoEntryControl asynparameter="outerrorlevel" bit_length="8" description="Error Level (output)" name="SDO.LED2.7" parentsdo="SDO.LED2" subindex="20"/>
+	<ethercat.SdoEntryControl asynparameter="voltage" bit_length="16" description="Output Voltage" name="SDO.LED3.1" parentsdo="SDO.LED3" subindex="4"/>
+	<ethercat.SdoEntryControl asynparameter="svoltage" bit_length="16" description="Supply Voltage" name="SDO.LED3.2" parentsdo="SDO.LED3" subindex="3"/>
+	<ethercat.SdoEntryControl asynparameter="holdcurrent" bit_length="16" description="Hold Current" name="SDO.LED3.3" parentsdo="SDO.LED3" subindex="2"/>
+	<ethercat.SdoEntryControl asynparameter="swarnlevel" bit_length="8" description="Warning Level (supply)" name="SDO.LED3.4" parentsdo="SDO.LED3" subindex="17"/>
+	<ethercat.SdoEntryControl asynparameter="serrorlevel" bit_length="8" description="Error Level (supply)" name="SDO.LED3.5" parentsdo="SDO.LED3" subindex="18"/>
+	<ethercat.SdoEntryControl asynparameter="outwarnlevel" bit_length="8" description="Warning Level (output)" name="SDO.LED3.6" parentsdo="SDO.LED3" subindex="19"/>
+	<ethercat.SdoEntryControl asynparameter="outerrorlevel" bit_length="8" description="Error Level (output)" name="SDO.LED3.7" parentsdo="SDO.LED3" subindex="20"/>
+	<ethercat.SdoEntryControl asynparameter="voltage" bit_length="16" description="Output Voltage" name="SDO.LED4.1" parentsdo="SDO.LED4" subindex="4"/>
+	<ethercat.SdoEntryControl asynparameter="svoltage" bit_length="16" description="Supply Voltage" name="SDO.LED4.2" parentsdo="SDO.LED4" subindex="3"/>
+	<ethercat.SdoEntryControl asynparameter="holdcurrent" bit_length="16" description="Hold Current" name="SDO.LED4.3" parentsdo="SDO.LED4" subindex="2"/>
+	<ethercat.SdoEntryControl asynparameter="swarnlevel" bit_length="8" description="Warning Level (supply)" name="SDO.LED4.4" parentsdo="SDO.LED4" subindex="17"/>
+	<ethercat.SdoEntryControl asynparameter="serrorlevel" bit_length="8" description="Error Level (supply)" name="SDO.LED4.5" parentsdo="SDO.LED4" subindex="18"/>
+	<ethercat.SdoEntryControl asynparameter="outwarnlevel" bit_length="8" description="Warning Level (output)" name="SDO.LED4.6" parentsdo="SDO.LED4" subindex="19"/>
+	<ethercat.SdoEntryControl asynparameter="outerrorlevel" bit_length="8" description="Error Level (output)" name="SDO.LED4.7" parentsdo="SDO.LED4" subindex="20"/>
+	<!--DEVICE="SDO.LED1.1"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="voltage" PORT="DCS00024966_SDO" R=":VOLTAGE" name="D1.LedSdo.1"/>
+	<!--DEVICE="SDO.LED1.2"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="svoltage" PORT="DCS00024966_SDO" R=":SVOLTAGE" name="D1.LedSdo.2"/>
+	<!--DEVICE="SDO.LED1.3"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="holdcurrent" PORT="DCS00024966_SDO" R=":HOLDCURR" name="D1.LedSdo.3"/>
+	<!--DEVICE="SDO.LED1.4"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="swarnlevel" PORT="DCS00024966_SDO" R=":SUPWARNLVL" name="D1.LedSdo.4"/>
+	<!--DEVICE="SDO.LED1.5"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="serrorlevel" PORT="DCS00024966_SDO" R=":SUPERRORLVL" name="D1.LedSdo.5"/>
+	<!--DEVICE="SDO.LED1.6"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="outwarnlevel" PORT="DCS00024966_SDO" R=":OUTWARNLVL" name="D1.LedSdo.6"/>
+	<!--DEVICE="SDO.LED1.7"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-01" PARAM="outerrorlevel" PORT="DCS00024966_SDO" R=":OUTERRORLVL" name="D1.LedSdo.7"/>
+	<!--DEVICE="SDO.LED2.1"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="voltage" PORT="DCS00024778_SDO" R=":VOLTAGE" name="D2.LedSdo.1"/>
+	<!--DEVICE="SDO.LED2.2"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="svoltage" PORT="DCS00024778_SDO" R=":SVOLTAGE" name="D2.LedSdo.2"/>
+	<!--DEVICE="SDO.LED2.3"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="holdcurrent" PORT="DCS00024778_SDO" R=":HOLDCURR" name="D2.LedSdo.3"/>
+	<!--DEVICE="SDO.LED2.4"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="swarnlevel" PORT="DCS00024778_SDO" R=":SUPWARNLVL" name="D2.LedSdo.4"/>
+	<!--DEVICE="SDO.LED2.5"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="serrorlevel" PORT="DCS00024778_SDO" R=":SUPERRORLVL" name="D2.LedSdo.5"/>
+	<!--DEVICE="SDO.LED2.6"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="outwarnlevel" PORT="DCS00024778_SDO" R=":OUTWARNLVL" name="D2.LedSdo.6"/>
+	<!--DEVICE="SDO.LED2.7"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-02" PARAM="outerrorlevel" PORT="DCS00024778_SDO" R=":OUTERRORLVL" name="D2.LedSdo.7"/>
+	<!--DEVICE="SDO.LED3.1"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="voltage" PORT="DCS00024967_SDO" R=":VOLTAGE" name="D3A.LedSdo.1"/>
+	<!--DEVICE="SDO.LED3.2"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="svoltage" PORT="DCS00024967_SDO" R=":SVOLTAGE" name="D3A.LedSdo.2"/>
+	<!--DEVICE="SDO.LED3.3"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="holdcurrent" PORT="DCS00024967_SDO" R=":HOLDCURR" name="D3A.LedSdo.3"/>
+	<!--DEVICE="SDO.LED3.4"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="swarnlevel" PORT="DCS00024967_SDO" R=":SUPWARNLVL" name="D3A.LedSdo.4"/>
+	<!--DEVICE="SDO.LED3.5"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="serrorlevel" PORT="DCS00024967_SDO" R=":SUPERRORLVL" name="D3A.LedSdo.5"/>
+	<!--DEVICE="SDO.LED3.6"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="outwarnlevel" PORT="DCS00024967_SDO" R=":OUTWARNLVL" name="D3A.LedSdo.6"/>
+	<!--DEVICE="SDO.LED3.7"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-03" PARAM="outerrorlevel" PORT="DCS00024967_SDO" R=":OUTERRORLVL" name="D3A.LedSdo.7"/>
+	<!--DEVICE="SDO.LED4.1"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="voltage" PORT="DCS00024973_SDO" R=":VOLTAGE" name="FS1.LedSdo.1"/>
+	<!--DEVICE="SDO.LED4.2"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="svoltage" PORT="DCS00024973_SDO" R=":SVOLTAGE" name="FS1.LedSdo.2"/>
+	<!--DEVICE="SDO.LED4.3"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="holdcurrent" PORT="DCS00024973_SDO" R=":HOLDCURR" name="FS1.LedSdo.3"/>
+	<!--DEVICE="SDO.LED4.4"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="swarnlevel" PORT="DCS00024973_SDO" R=":SUPWARNLVL" name="FS1.LedSdo.4"/>
+	<!--DEVICE="SDO.LED4.5"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="serrorlevel" PORT="DCS00024973_SDO" R=":SUPERRORLVL" name="FS1.LedSdo.5"/>
+	<!--DEVICE="SDO.LED4.6"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="outwarnlevel" PORT="DCS00024973_SDO" R=":OUTWARNLVL" name="FS1.LedSdo.6"/>
+	<!--DEVICE="SDO.LED4.7"-->
+	<ethercat.SdoEntryTemplate P="BL21I-EA-LED-04" PARAM="outerrorlevel" PORT="DCS00024973_SDO" R=":OUTERRORLVL" name="FS1.LedSdo.7"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD1" PORT="DCS00026416" SCAN="I/O Intr" name="HLS_AI1"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD2" PORT="DCS00026553" SCAN="I/O Intr" name="HLS_AI2"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD3" PORT="DCS00026554" SCAN="I/O Intr" name="HLS_AI3"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD4" PORT="DCS00026555" SCAN="I/O Intr" name="HLS_AI4"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD5" PORT="DCS00026556" SCAN="I/O Intr" name="HLS_AI5"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-DI-ERIO-10:MOD6" PORT="DCS00026557" SCAN="I/O Intr" name="HLS_AI6"/>
+	<ethercat.auto_EL2595 DEVICE="BL21I-DI-LED-01" DRVH="200" DRVL="0" PORT="DCS00024966" SCAN="1 second" label="D1 Backlight LED" name="D1.Led"/>
+	<ethercat.auto_EL2595 DEVICE="BL21I-DI-LED-02" DRVH="200" DRVL="0" PORT="DCS00024778" SCAN="1 second" label="D2 Backlight LED" name="D2.Led"/>
+	<ethercat.auto_EL2595 DEVICE="BL21I-DI-LED-03" DRVH="200" DRVL="0" PORT="DCS00024967" SCAN="1 second" label="D3A Backlight LED" name="D3A.Led"/>
+	<ethercat.auto_EL2595 DEVICE="BL21I-OP-LED-01" DRVH="20" DRVL="0" PORT="DCS00024973" SCAN="1 second" label="FS1 Indicator LED" name="FS1.Led"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD6" PORT="DCS00026696" SCAN="I/O Intr" name="DIG01"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD7" PORT="DCS00026697" SCAN="I/O Intr" name="DIG02"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD8" PORT="DCS00026698" SCAN="I/O Intr" name="DIG03"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD9" PORT="DCS00026699" SCAN="I/O Intr" name="DIG04"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD10" PORT="DCS00026700" SCAN="I/O Intr" name="DIG05"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD11" PORT="DCS00026701" SCAN="I/O Intr" name="DIG06"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD12" PORT="DCS00026702" SCAN="I/O Intr" name="DIG07"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD13" PORT="DCS00026703" SCAN="I/O Intr" name="DIG08"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD14" PORT="DCS00026704" SCAN="I/O Intr" name="DIG09"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD15" PORT="DCS00026705" SCAN="I/O Intr" name="DIG10"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD16" PORT="DCS00024653" SCAN="I/O Intr" name="DIG11"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD17" PORT="DCS00024654" SCAN="I/O Intr" name="DIG12"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD18" PORT="DCS00024668" SCAN="I/O Intr" name="DIG13"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD19" PORT="DCS00024669" SCAN="I/O Intr" name="DIG14"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD20" PORT="DCS00024670" SCAN="I/O Intr" name="DIG15"/>
+	<!--<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD3" PORT="DCS00026706" SCAN="I/O Intr" name="DIG16"/>-->
+	<!--<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD4" PORT="DCS00026707" SCAN="I/O Intr" name="DIG17"/>-->
+	<!--<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD5" PORT="DCS00026708" SCAN="I/O Intr" name="DIG18"/>-->
+	<!--<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD6" PORT="DCS00026709" SCAN="I/O Intr" name="DIG19"/>-->
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD3" PORT="DCS00026712" SCAN="I/O Intr" name="DIG20"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD4" PORT="DCS00026714" SCAN="I/O Intr" name="DIG21"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-04:MOD5" PORT="DCS00026713" SCAN="I/O Intr" name="DIG22"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-05:MODSAM3" PORT="DCS00026706" SCAN="I/O Intr" name="DIG23"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-05:MODSAM4" PORT="DCS00026707" SCAN="I/O Intr" name="DIG24"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-05:MODSAM5" PORT="DCS00026708" SCAN="I/O Intr" name="DIG25"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-05:MODSAM6" PORT="DCS00026709" SCAN="I/O Intr" name="DIG26"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD1" PORT="DCS00026715" SCAN="I/O Intr" name="DIG27"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD2" PORT="DCS00026716" SCAN="I/O Intr" name="DIG28"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD3" PORT="DCS00026717" SCAN="I/O Intr" name="DIG29"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD4" PORT="DCS00026718" SCAN="I/O Intr" name="DIG30"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD5" PORT="DCS00026719" SCAN="I/O Intr" name="DIG31"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-09:MOD6" PORT="DCS00026720" SCAN="I/O Intr" name="DIG32"/>
+	<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-05:MODSAM7" PORT="DCS00026710" SCAN="I/O Intr" name="DIG33"/>
+	<ethercat.auto_EL4134 DEVICE="BL21I-MO-PIEZO-01" PORT="DCS00024817" SCAN="I/O Intr" name="M1.Piezo"/>
+	<ethercat.auto_EL4134 DEVICE="BL21I-MO-PIEZO-02" PORT="DCS00026270" SCAN="I/O Intr" name="M2.Piezo"/>
+	<!--<ethercat.auto_EL1014 DEVICE="BL21I-DI-ERIO-05:MOD6" PORT="DCS00026320" SCAN="I/O Intr" name="digsw01"/>-->
+	<!--<ethercat.auto_EL1014 DEVICE="BL21I-DI-ERIO-05:MOD7" PORT="DCS00026321" SCAN="I/O Intr" name="digsw02"/>-->
+	<ethercat.auto_EL3356_0010 DEVICE="BL21I-DI-ERIO-04:MOD12" PORT="DCS00026910" SCAN="I/O Intr" name="SCALES1"/>
+	<ethercat.auto_EL3356_0010 DEVICE="BL21I-DI-ERIO-04:MOD13" PORT="DCS00026911" SCAN="I/O Intr" name="SCALES2"/>
+	<ethercat.auto_EL3356_0010 DEVICE="BL21I-DI-ERIO-04:MOD14" PORT="DCS00026977" SCAN="I/O Intr" name="SCALES3"/>
+	<ethercat.auto_EL3356_0010 DEVICE="BL21I-DI-ERIO-04:MOD15" PORT="DCS00026971" SCAN="I/O Intr" name="SCALES4"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-AL-SLITS-02:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00025131" SAMPLES="100" SCAN="I/O Intr" name="S2.FemtoUpper_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-AL-SLITS-02:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00025131" SAMPLES="100" SCAN="I/O Intr" name="S2.FemtoLower_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-AL-SLITS-02:FEMTO3" INTSCAN="I/O Intr" PORT="DCS00025132" SAMPLES="100" SCAN="I/O Intr" name="S2.FemtoNearside_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-AL-SLITS-02:FEMTO4" INTSCAN="I/O Intr" PORT="DCS00025132" SAMPLES="100" SCAN="I/O Intr" name="S2.FemtoOffside_Avg"/>
+	<!--<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-DI-PHGDA-03:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00025133" SAMPLES="100" SCAN="I/O Intr" name="D3A.Femto1_Avg"/>-->
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-DI-PHGDB-03:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00025133" SAMPLES="100" SCAN="I/O Intr" name="D3B.Femto1_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-AL-SLITS-03:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00025134" SAMPLES="100" SCAN="I/O Intr" name="S3.FemtoUpper_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-AL-SLITS-03:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00025134" SAMPLES="100" SCAN="I/O Intr" name="S3.FemtoLower_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-AL-SLITS-03:FEMTO3" INTSCAN="I/O Intr" PORT="DCS00025135" SAMPLES="100" SCAN="I/O Intr" name="S3.FemtoOffside_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-AL-SLITS-03:FEMTO4" INTSCAN="I/O Intr" PORT="DCS00025135" SAMPLES="100" SCAN="I/O Intr" name="S3.FemtoNearside_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-DI-GAS-01:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026377" SAMPLES="100" SCAN="I/O Intr" name="D7.GasCellWire_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-DI-GAS-01:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00026377" SAMPLES="100" SCAN="I/O Intr" name="D7.GasCellPhotoDiode_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-OP-PGM-01:CHILLER1" INTSCAN="I/O Intr" PORT="DCS00024549" SAMPLES="100" SCAN="I/O Intr" name="PGM.ChillerPressure1"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-OP-PGM-01:CHILLER2" INTSCAN="I/O Intr" PORT="DCS00024549" SAMPLES="100" SCAN="I/O Intr" name="PGM.ChillerPressure2"/>
+	<ethercat.GenericADCTemplate CHANNEL="101" DEVICE="BL21I-MO-POD-01:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026381" SAMPLES="100" SCAN="I/O Intr" name="M4.DrainC1.Avg"/>
+	<!--101 and 102 refer to the same ERIO input; I have added two samplers for this.-->
+	<ethercat.GenericADCTemplate CHANNEL="102" DEVICE="BL21I-MO-POD-01:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026381" SAMPLES="100" SCAN="I/O Intr" name="M4.DrainC1.Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-MO-POD-01:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00026381" SAMPLES="100" SCAN="I/O Intr" name="M4.DrainC2_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-DI-PHDGN-08:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026382" SAMPLES="100" SCAN="I/O Intr" name="D8.Diode_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-OP-MIRR-01:HVPSU" INTSCAN="I/O Intr" PORT="DCS00024797" SAMPLES="1000" SCAN="I/O Intr" name="M1x.HvPsu_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-OP-MIRR-02:HVPSU" INTSCAN="I/O Intr" PORT="DCS00025133" SAMPLES="1000" SCAN="I/O Intr" name="M2x.HvPsu_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-OP-PGM-01:HVPSU" INTSCAN="I/O Intr" PORT="DCS00024801" SAMPLES="1000" SCAN="I/O Intr" name="PGMx.HvPsu_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-EA-SMPL-01:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026382" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.Drain_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="202" DEVICE="BL21I-EA-SMPL-01:FEMTO1" INTSCAN="I/O Intr" PORT="DCS00026382" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.Drain_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-EA-SMPL-01:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00026579" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.FY1_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="102" DEVICE="BL21I-EA-SMPL-01:FEMTO2" INTSCAN="I/O Intr" PORT="DCS00026579" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.FY1_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-EA-SMPL-01:FEMTO3" INTSCAN="I/O Intr" PORT="DCS00026579" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.FY3_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="202" DEVICE="BL21I-EA-SMPL-01:FEMTO3" INTSCAN="I/O Intr" PORT="DCS00026579" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.FY3_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-EA-SMPL-01:FEMTO4" INTSCAN="I/O Intr" PORT="DCS00026580" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.Diff3_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="102" DEVICE="BL21I-EA-SMPL-01:FEMTO4" INTSCAN="I/O Intr" PORT="DCS00026580" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.Diff3_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-EA-SMPL-01:FEMTO5" INTSCAN="I/O Intr" PORT="DCS00026580" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.FY2_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="202" DEVICE="BL21I-EA-SMPL-01:FEMTO5" INTSCAN="I/O Intr" PORT="DCS00026580" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.FY2_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-EA-SMPL-01:FEMTO6" INTSCAN="I/O Intr" PORT="DCS00026581" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.Diff1_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="102" DEVICE="BL21I-EA-SMPL-01:FEMTO6" INTSCAN="I/O Intr" PORT="DCS00026581" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.Diff1_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="2" DEVICE="BL21I-EA-SMPL-01:FEMTO7" INTSCAN="I/O Intr" PORT="DCS00026581" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.Diff2_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="202" DEVICE="BL21I-EA-SMPL-01:FEMTO7" INTSCAN="I/O Intr" PORT="DCS00026581" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.Diff2_Inst"/>
+	<ethercat.GenericADCTemplate CHANNEL="1" DEVICE="BL21I-EA-SMPL-01:FEMTO8" INTSCAN="I/O Intr" PORT="DCS00026258" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.ManipFemto_Avg"/>
+	<ethercat.GenericADCTemplate CHANNEL="102" DEVICE="BL21I-EA-SMPL-01:FEMTO8" INTSCAN="I/O Intr" PORT="DCS00026258" SAMPLES="1000" SCAN="I/O Intr" name="SMPL.samplers.inst.ManipFemto_Inst"/>
+	<ethercat.GenericADC channel="1" name="S2.Femto1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025131"/>
+	<ethercat.GenericADC channel="2" name="S2.Femto2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00025131"/>
+	<ethercat.GenericADC channel="1" name="S2.Femto3_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025132"/>
+	<ethercat.GenericADC channel="2" name="S2.Femto4_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00025132"/>
+	<!--<ethercat.GenericADC channel="1" name="D3A.Femto1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025133"/>-->
+	<ethercat.GenericADC channel="2" name="D3B.Femto2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00025133"/>
+	<ethercat.GenericADC channel="1" name="S3.Femto1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025134"/>
+	<ethercat.GenericADC channel="2" name="S3.Femto2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00025134"/>
+	<ethercat.GenericADC channel="1" name="S3.Femto3_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025135"/>
+	<ethercat.GenericADC channel="2" name="S3.Femto4_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00025135"/>
+	<ethercat.GenericADC channel="1" name="D7.Femto1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00026377"/>
+	<ethercat.GenericADC channel="2" name="D7.Femto2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00026377"/>
+	<ethercat.GenericADC channel="1" name="PGM.WaterPress1" pdoentry="AIStandardChannel1.Value : EL3124 rev 0x00110000" slave="DCS00024549"/>
+	<ethercat.GenericADC channel="2" name="PGM.WaterPress2" pdoentry="AIStandardChannel2.Value : EL3124 rev 0x00110000" slave="DCS00024549"/>
+	<ethercat.GenericADC channel="101" name="M4.DrainC1.adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00026381"/>
+	<!--101 and 102 refer to the same ERIO input; I have added two samplers for this.-->
+	<ethercat.GenericADC channel="102" name="M4.DrainC1.adc_inst" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00026381"/>
+	<ethercat.GenericADC channel="2" name="M4.DrainC2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00026381"/>
+	<ethercat.GenericADC channel="1" name="D8.Diode_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00026382"/>
+	<ethercat.GenericADC channel="1" name="M1.HvPsu_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00024797"/>
+	<ethercat.GenericADC channel="1" name="M2.HvPsu_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00120000" slave="DCS00025133"/>
+	<ethercat.GenericADC channel="2" name="PGM.HvPsu_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00024801"/>
+	<ethercat.GenericADC channel="2" name="SMPL.samplers.Drain_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00026382"/>
+	<ethercat.GenericADC channel="202" name="SMPL.samplers.Drain_inst" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00120000" slave="DCS00026382"/>
+	<ethercat.GenericADC channel="1" name="SMPL.samplers.FY1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026579"/>
+	<ethercat.GenericADC channel="102" name="SMPL.samplers.FY1_inst" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026579"/>
+	<ethercat.GenericADC channel="2" name="SMPL.samplers.FY3_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026579"/>
+	<ethercat.GenericADC channel="202" name="SMPL.samplers.FY3_inst" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026579"/>
+	<ethercat.GenericADC channel="1" name="SMPL.samplers.Diff3_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026580"/>
+	<ethercat.GenericADC channel="102" name="SMPL.samplers.Diff3_inst" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026580"/>
+	<ethercat.GenericADC channel="2" name="SMPL.samplers.FY2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026580"/>
+	<ethercat.GenericADC channel="202" name="SMPL.samplers.FY2_inst" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026580"/>
+	<ethercat.GenericADC channel="1" name="SMPL.samplers.Diff1_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026581"/>
+	<ethercat.GenericADC channel="102" name="SMPL.samplers.Diff1_inst" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026581"/>
+	<ethercat.GenericADC channel="2" name="SMPL.samplers.Diff2_adc" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026581"/>
+	<ethercat.GenericADC channel="202" name="SMPL.samplers.Diff2_inst" pdoentry="AIInputsChannel2.Value : EL3602 rev 0x00130000" slave="DCS00026581"/>
+	<ethercat.GenericADC channel="1" name="SMPL.samplers.ManipFemto_adc" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026258"/>
+	<ethercat.GenericADC channel="102" name="SMPL.samplers.ManipFemto_inst" pdoentry="AIInputsChannel1.Value : EL3602 rev 0x00130000" slave="DCS00026258"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="1" OUTGB0="BL21I-DI-ERIO-01:MOD6:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD6:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD6:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD6:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-02" Q=":FEMTO1" gda_desc="S2 Femto Upper" gda_name="$(name)" name="S2.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="1" OUTGB0="BL21I-DI-ERIO-01:MOD7:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD7:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD7:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD7:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-02" Q=":FEMTO2" gda_desc="S2 Femto Lower" gda_name="$(name)" name="S2.Femto2"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-01:MOD9:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD9:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD9:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD9:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-02" Q=":FEMTO3" gda_desc="S2 Femto Nearside" gda_name="$(name)" name="S2.Femto3"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-01:MOD8:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD8:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD8:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD8:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-02" Q=":FEMTO4" gda_desc="S2 Femto Offside" gda_name="$(name)" name="S2.Femto4"/>
+	<!--<femto.femto200 CGB0="" CGB1="" DTYP="Soft Channel" INITGAIN="0" OUTGB0="BL21I-DI-ERIO-01:MOD10:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD10:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD10:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD10:CHANNEL4:OUTPUT PP" P="BL21I-DI-PHGDA-03" Q=":FEMTO1" SGB0="" SGB1="" gda_desc="D3A Femto 1" gda_name="$(name)" name="D3A.Femto1"/>-->
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="0" OUTGB0="BL21I-DI-ERIO-01:MOD11:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD11:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD11:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD11:CHANNEL4:OUTPUT PP" P="BL21I-DI-PHGDB-03" Q=":FEMTO1" gda_desc="D3B Femto 1" gda_name="$(name)" name="D3B.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="1" OUTGB0="BL21I-DI-ERIO-01:MOD12:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD12:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD12:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD12:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-03" Q=":FEMTO1" gda_desc="S3 Femto Upper" gda_name="$(name)" name="S3.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="1" OUTGB0="BL21I-DI-ERIO-01:MOD13:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD13:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD13:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD13:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-03" Q=":FEMTO2" gda_desc="S3 Femto Lower" gda_name="$(name)" name="S3.Femto2"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-01:MOD14:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD14:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD14:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD14:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-03" Q=":FEMTO3" gda_desc="S3 Femto Offside" gda_name="$(name)" name="S3.Femto3"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-01:MOD15:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-01:MOD15:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-01:MOD15:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-01:MOD15:CHANNEL4:OUTPUT PP" P="BL21I-AL-SLITS-03" Q=":FEMTO4" gda_desc="S3 Femto Nearside" gda_name="$(name)" name="S3.Femto4"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-04:MOD3:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-04:MOD3:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-04:MOD3:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-04:MOD3:CHANNEL4:OUTPUT PP" P="BL21I-DI-GAS-01" Q=":FEMTO1" gda_desc="Gas Cell Wire" gda_name="$(name)" name="D7.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-04:MOD4:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-04:MOD4:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-04:MOD4:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-04:MOD4:CHANNEL4:OUTPUT PP" P="BL21I-DI-GAS-01" Q=":FEMTO2" gda_desc="Gas Cell Photo Diode" gda_name="$(name)" name="D7.Femto2"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="4" OUTGB0="BL21I-DI-ERIO-05:MODSAM3:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-05:MODSAM3:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-05:MODSAM3:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-05:MODSAM3:CHANNEL4:OUTPUT PP" P="BL21I-MO-POD-01" Q=":FEMTO1" gda_desc="M4 Drain Current 1" gda_name="$(name)" name="M4.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-05:MODSAM4:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-05:MODSAM4:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-05:MODSAM4:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-05:MODSAM4:CHANNEL4:OUTPUT PP" P="BL21I-MO-POD-01" Q=":FEMTO2" gda_desc="M4 Drain Current 2" gda_name="$(name)" name="M4.Femto2"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-05:MODSAM5:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-05:MODSAM5:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-05:MODSAM5:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-05:MODSAM5:CHANNEL4:OUTPUT PP" P="BL21I-DI-PHDGN-08" Q=":FEMTO1" gda_desc="M4 Photo Diode" gda_name="$(name)" name="D8.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="5" OUTGB0="BL21I-DI-ERIO-05:MODSAM6:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-05:MODSAM6:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-05:MODSAM6:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-05:MODSAM6:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO1" gda_desc="Sample Drain Current" gda_name="$(name)" name="SMPL.Femto1"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-09:MOD1:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD1:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD1:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD1:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO2" gda_desc="Sample FY Diode 1" gda_name="$(name)" name="SMPL.Femto2"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-09:MOD2:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD2:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD2:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD2:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO3" gda_desc="Sample FY Diode 3" gda_name="$(name)" name="SMPL.Femto3"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-09:MOD3:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD3:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD3:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD3:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO4" gda_desc="Sample Diffraction Diode 3" gda_name="$(name)" name="SMPL.Femto4"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-09:MOD4:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD4:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD4:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD4:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO5" gda_desc="Sample FY Diode 2" gda_name="$(name)" name="SMPL.Femto5"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="2" OUTGB0="BL21I-DI-ERIO-09:MOD5:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD5:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD5:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD5:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO6" gda_desc="Sample Diffraction Diode 1" gda_name="$(name)" name="SMPL.Femto6"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-09:MOD6:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-09:MOD6:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-09:MOD6:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-09:MOD6:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO7" gda_desc="Sample Diffraction Diode 2" gda_name="$(name)" name="SMPL.Femto7"/>
+	<femto.femto200 DTYP="Soft Channel" INITGAIN="6" OUTGB0="BL21I-DI-ERIO-05:MODSAM7:CHANNEL1:OUTPUT PP" OUTGB1="BL21I-DI-ERIO-05:MODSAM7:CHANNEL2:OUTPUT PP" OUTGB2="BL21I-DI-ERIO-05:MODSAM7:CHANNEL3:OUTPUT PP" OUTHIS="BL21I-DI-ERIO-05:MODSAM7:CHANNEL4:OUTPUT PP" P="BL21I-EA-SMPL-01" Q=":FEMTO8" gda_desc="Sample Manipulator Femto" gda_name="$(name)" name="SMPL.Femto8"/>
+	<femto.femto_ai DESC="S2 Femto 1" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025131_ADC1)VALUE" P="BL21I-AL-SLITS-02:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S2.Femto1_ai"/>
+	<femto.femto_ai DESC="S2 Femto 2" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025131_ADC2)VALUE" P="BL21I-AL-SLITS-02:FEMTO2" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S2.Femto2_ai"/>
+	<femto.femto_ai DESC="S2 Femto 3" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025132_ADC2)VALUE" P="BL21I-AL-SLITS-02:FEMTO3" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S2.Femto3_ai"/>
+	<femto.femto_ai DESC="S2 Femto 4" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025132_ADC1)VALUE" P="BL21I-AL-SLITS-02:FEMTO4" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S2.Femto4_ai"/>
+	<!--<femto.femto_ai DESC="D3A Femto 1" DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00025133_ADC1)VALUE" P="BL21I-DI-PHGDA-03:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="D3A.Femto1_ai"/>-->
+	<femto.femto_ai DESC="D3B Femto 1" DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00025133_ADC2)VALUE" P="BL21I-DI-PHGDB-03:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="D3B.Femto2_ai"/>
+	<femto.femto_ai DESC="S3 Femto 1" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025134_ADC1)VALUE" P="BL21I-AL-SLITS-03:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S3.Femto1_ai"/>
+	<femto.femto_ai DESC="S3 Femto 2" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025134_ADC2)VALUE" P="BL21I-AL-SLITS-03:FEMTO2" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S3.Femto2_ai"/>
+	<femto.femto_ai DESC="S3 Femto 3" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025135_ADC1)VALUE" P="BL21I-AL-SLITS-03:FEMTO3" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S3.Femto3_ai"/>
+	<femto.femto_ai DESC="S3 Femto 4" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00025135_ADC2)VALUE" P="BL21I-AL-SLITS-03:FEMTO4" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="S3.Femto4_ai"/>
+	<femto.femto_ai DESC="Gas Cell Wire" DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00026377_ADC1)VALUE" P="BL21I-DI-GAS-01:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="D7.Femto1_ai"/>
+	<femto.femto_ai DESC="Gas Cell Photo Diode" DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00026377_ADC2)VALUE" P="BL21I-DI-GAS-01:FEMTO2" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="D7.Femto2_ai"/>
+	<!--INP value for instantaneous reading-->
+	<!--<femto.femto_ai DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00026377)AIInputsChannel1.Value" PREC="6" Q=":I" SCAN=".1 sec" gda_name="$(name)"/>-->
+	<!--This is now the instantaneous reading.
+I am not sure if the one above could work, but it is undesirable as it does not offer any averaging over a period of time.-->
+	<femto.femto_ai DESC="M4 Drain Current 1" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026381_ADC102)VALUE" P="BL21I-MO-POD-01:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="M4.Femto1_ai"/>
+	<!--Need to include once support for multiple samplers per ADC input - use extra 'Type' or similar column to distinguish from above object.-->
+	<!--<femto.femto_ai DESC="M4 Drain Current 1 Instantaneous" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026381_ADC1)VALUE" P="BL21I-MO-POD-01:FEMTO1:INST" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="X.Femto1_ai_inst"/>-->
+	<femto.femto_ai DESC="M4 Drain Current 2" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026381_ADC2)VALUE" P="BL21I-MO-POD-01:FEMTO2" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="M4.Femto2_ai"/>
+	<femto.femto_ai DESC="D8 Photo Diode" DTYPE="asynInt32" EGU="V" EGUF="-10" EGUL="10" INP="@asyn(DCS00026382_ADC1)VALUE" P="BL21I-DI-PHDGN-08:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="D8.Femto3_ai"/>
+	<femto.femto_ai DESC="Sample Drain Current" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026382_ADC202)VALUE" P="BL21I-EA-SMPL-01:FEMTO1" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto1_ai"/>
+	<femto.femto_ai DESC="Sample FY1 Diode" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026579_ADC102)VALUE" P="BL21I-EA-SMPL-01:FEMTO2" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto2_ai"/>
+	<femto.femto_ai DESC="Sample Straight Diode" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026579_ADC202)VALUE" P="BL21I-EA-SMPL-01:FEMTO3" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto3_ai"/>
+	<femto.femto_ai DESC="Sample Rotating Diode" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026580_ADC102)VALUE" P="BL21I-EA-SMPL-01:FEMTO4" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto4_ai"/>
+	<femto.femto_ai DESC="Sample Fixed Diode 1" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026580_ADC202)VALUE" P="BL21I-EA-SMPL-01:FEMTO5" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto5_ai"/>
+	<femto.femto_ai DESC="Sample 2Theta Diode" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026581_ADC102)VALUE" P="BL21I-EA-SMPL-01:FEMTO6" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto6_ai"/>
+	<femto.femto_ai DESC="Sample Extra Diode" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026581_ADC202)VALUE" P="BL21I-EA-SMPL-01:FEMTO7" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto7_ai"/>
+	<femto.femto_ai DESC="Sample Manipulator Femto" DTYPE="asynInt32" EGU="V" EGUF="10" EGUL="-10" INP="@asyn(DCS00026258_ADC102)VALUE" P="BL21I-EA-SMPL-01:FEMTO8" PREC="6" Q=":I" SCAN="I/O Intr" gda_name="$(name)" name="SMPL.Femto8_ai"/>
+	<ethercat.PdoAssignment pdo_index="5633" slave="DCS00024966" smnumber="2"/>
+	<ethercat.PdoAssignment pdo_index="5633" slave="DCS00024778" smnumber="2"/>
+	<ethercat.PdoAssignment pdo_index="5633" slave="DCS00024967" smnumber="2"/>
+	<ethercat.PdoAssignment pdo_index="5633" slave="DCS00024973" smnumber="2"/>
+	<userIO.ai DESC="M1 Charge plate voltage" DTYP="asynInt32" EGU="V" EGUF="300" EGUL="-300" INP="@asyn(DCS00024797_ADC1)VALUE" LINR="2" P="BL21I-OP-MIRR-01:HVPSU" PREC="0" R=":I" SCAN="I/O Intr" name="M1.HvPsu"/>
+	<userIO.ai DESC="M2 Charge plate voltage" DTYP="asynInt32" EGU="V" EGUF="300" EGUL="-300" INP="@asyn(DCS00025133_ADC1)VALUE" LINR="2" P="BL21I-OP-MIRR-02:HVPSU" PREC="0" R=":I" SCAN="I/O Intr" name="M2.HvPsu"/>
+	<userIO.ai DESC="PGM Charge plate voltage" DTYP="asynInt32" EGU="V" EGUF="300" EGUL="-300" INP="@asyn(DCS00024801_ADC2)VALUE" LINR="2" P="BL21I-OP-PGM-01:HVPSU" PREC="0" R=":I" SCAN="I/O Intr" name="PGM.HvPsu"/>
+	<userIO.ai DESC="Outlet PGM mirror cooling pressure" DTYP="asynInt32" EGU="Bar" EGUF="6" EGUL="-6" INP="@asyn(DCS00024549_ADC2)VALUE" LINR="2" P="BL21I-OP-PGM-01:CHILLER2" PREC="3" R=":I" SCAN="I/O Intr" name="PGM.Chiller2PRS"/>
+	<userIO.bi DESC="M5 Limit 01" DTYP="asynInt32" INP="@asyn(DCS00026320)Channel1.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM01" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 01" name="M5.LIMIT1"/>
+	<userIO.bi DESC="M5 Limit 02" DTYP="asynInt32" INP="@asyn(DCS00026320)Channel2.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM02" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 02" name="M5.LIMIT2"/>
+	<userIO.bi DESC="M5 Limit 03" DTYP="asynInt32" INP="@asyn(DCS00026320)Channel3.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM03" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 03" name="M5.LIMIT3"/>
+	<userIO.bi DESC="M5 Limit 04" DTYP="asynInt32" INP="@asyn(DCS00026320)Channel4.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM04" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 04" name="M5.LIMIT4"/>
+	<userIO.bi DESC="M5 Limit 05" DTYP="asynInt32" INP="@asyn(DCS00026321)Channel1.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM05" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 05" name="M5.LIMIT5"/>
+	<userIO.bi DESC="M5 Limit 06" DTYP="asynInt32" INP="@asyn(DCS00026321)Channel2.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM06" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 06" name="M5.LIMIT6"/>
+	<userIO.bi DESC="M5 Limit 07" DTYP="asynInt32" INP="@asyn(DCS00026321)Channel3.Input" ONAM="On" P="BL21I-MO-ECM-02" R=":LIM07" SCAN="I/O Intr" ZNAM="Off" gda_desc="M5 Limit 07" name="M5.LIMIT7"/>
+	<!--<userIO.bi DESC="FS1 Status" DTYP="asynInt32" INP="@asyn(DCS00026321)Channel4.Input" ONAM="On" P="BL21I-OP-SHTR-01" R=":STATUS" SCAN="I/O Intr" ZNAM="Off" gda_desc="FS1 Status" name="FS1.STATUS"/>-->
+	<!--<userIO.bo DESC="Fast shutter control" DTYP="asynInt32" ONAM="OPEN" OUT="@asyn(DCS00024867)Channel1.Output" P="BL21I-OP-SHTR-01" PINI="YES" R=":CON" SCAN="Passive" ZNAM="CLOSED" name="FS1.CON"/>-->
+	<!--<userIO.bo DESC="Fast shutter source" DTYP="asynInt32" ONAM="XCAM" OUT="@asyn(DCS00024867)Channel3.Output" P="BL21I-OP-SHTR-01" PINI="YES" R=":SRC" SCAN="Passive" ZNAM="ERIO" name="FS1.SRC"/>-->
+	<!--LED controlled by binary output-->
+	<userIO.bo DESC="Sample Chamber Illumination" DTYP="asynInt32" HIGH="0" ONAM="On" OUT="@asyn(DCS00026627)Channel1.Output" P="BL21I-EA-SMPL-01" R=":BOLED1" SCAN="Passive" ZNAM="Off" name="SMPL.BOLED1"/>
+	<!--Dummy Coupling records for femtos which are not wired on this bwamline. Added to avoid need for a seperate GDA class and CSS screen for non coupling enabled femtos.-->
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-02:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-02:FEMTO2:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-02:FEMTO3:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-02:FEMTO4:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-DI-PHGDA-03:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-DI-PHGDB-03:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-03:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-03:FEMTO2:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-03:FEMTO3:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-AL-SLITS-03:FEMTO4:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-DI-GAS-01:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-DI-GAS-01:FEMTO2:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-MO-POD-01:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-MO-POD-01:FEMTO2:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-DI-PHDGN-08:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO1:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO2:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO3:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO4:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO5:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO6:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO7:ACDC"/>
+	<records.bo ONAM="DC" PINI="YES" VAL="1" ZNAM="AC" record="BL21I-EA-SMPL-01:FEMTO8:ACDC"/>
+	<records.ai DESC="HLS Height 1" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD1:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT01:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 2" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD1:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT02:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 3" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD1:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT03:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 4" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD1:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT04:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 5" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD2:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT05:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 6" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD2:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT06:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 7" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD2:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT07:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 8" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD2:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT08:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 9" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD3:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT09:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 10" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD3:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT10:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 11" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD3:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT11:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Height 12" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD3:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT12:LEVEL:SOURCE"/>
+	<records.ai DESC="HLS Temperature 1" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD4:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT01:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 2" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD4:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT02:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 3" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD4:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT03:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 4" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD4:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT04:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 5" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD5:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT05:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 6" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD5:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT06:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 7" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD5:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT07:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 8" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD5:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT08:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 9" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD6:INPUT1:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT09:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 10" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD6:INPUT2:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT10:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 11" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD6:INPUT3:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT11:TEMP:SOURCE"/>
+	<records.ai DESC="HLS Temperature 12" DTYP="Soft Channel" INP="BL21I-DI-ERIO-10:MOD6:INPUT4:VALUE CP" SCAN="Passive" record="BL21I-AL-HLS-01:POT12:TEMP:SOURCE"/>
+	<EPICS_BASE.dbpf name="gasfem1" pv="BL21I-DI-GAS-01:FEMTO2:I.ASLO" value="-1"/>
+	<EPICS_BASE.dbpf name="gasfem2" pv="BL21I-DI-GAS-01:FEMTO1:I.ASLO" value="1"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-MIRR-01:HVPSU:I.LOW" value="95"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-MIRR-01:HVPSU:I.LOLO" value="90"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-MIRR-02:HVPSU:I.LOW" value="95"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-MIRR-01:HVPSU:I.LOLO" value="90"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-PGM-01:HVPSU:I.LOW" value="95"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-PGM-01:HVPSU:I.LOLO" value="90"/>
+	<EPICS_BASE.dbpf pv="BL21I-DI-LED-01:DOXCURRENT:OUTPUTCURRENT" value="170"/>
+	<EPICS_BASE.dbpf pv="BL21I-DI-LED-03:DOXCURRENT:OUTPUTCURRENT" value="170"/>
+	<EPICS_BASE.dbpf pv="BL21I-DI-LED-02:DOXCURRENT:OUTPUTCURRENT" value="170"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-LED-01:DOXCURRENT:OUTPUTCURRENT" value="20"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-LED-01:HOLDCURR" value="20"/>
+	<EPICS_BASE.dbpf pv="BL21I-MO-POD-01:FEMTO1:GAIN" value="4"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO1:ADC2_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO2:ADC1_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO3:ADC2_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO4:ADC1_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO5:ADC2_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO6:ADC1_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO7:ADC2_AVERAGE" value="1000"/>
+	<EPICS_BASE.dbpf pv="BL21I-EA-SMPL-01:FEMTO8:ADC1_AVERAGE" value="1000"/>
+</components>

--- a/tests/samples/catio/BL21I-VA-IOC-01.xml
+++ b/tests/samples/catio/BL21I-VA-IOC-01.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<devIocStats.devIocStatsHelper ioc="BL21I-VA-IOC-01" name="BL21I-VA-IOC-01.DEVIOCSTATS"/>
+	<autosave.Autosave bl="True" iocName="BL21I-VA-IOC-01" name="BL21I-VA-IOC-01.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="VA1.PVLOGGING"/>
+	<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>
+	<!--Start of BL21I-VA-ERIO-04-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025070" position="DCS00025070" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024905" position="DCS00024905" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025130" position="DCS00025130" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026220" position="DCS00026220" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026221" position="DCS00026221" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025092" position="DCS00025092" type_rev="EL1014 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025093" position="DCS00025093" type_rev="EL1014 rev 0x00120000"/>
+	<!--Start of BL21I-VA-ERIO-12-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026851" position="DCS00026851" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026565" position="DCS00026565" type_rev="EL3104 rev 0x00130000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026570" position="DCS00026570" type_rev="EL3104 rev 0x00130000"/>
+	<!--Start of BL21I-VA-ERIO-03-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024929" position="DCS00024929" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024890" position="DCS00024890" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024891" position="DCS00024891" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025081" position="DCS00025081" type_rev="EL1014 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00025082" position="DCS00025082" type_rev="EL1014 rev 0x00120000"/>
+	<!--Start of BL21I-VA-ERIO-02-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00028304" position="DCS00028304" type_rev="EK1100 rev 0x00110000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024912" position="DCS00024912" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024913" position="DCS00024913" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023482" position="DCS00023482" type_rev="EL1014 rev 0x00100000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023483" position="DCS00023483" type_rev="EL1014 rev 0x00100000"/>
+	<!--Expecting ERIO-02 Module 5 EL1014 from drawing 1091223 page 26
+But not in the slaveinfo -d chain on bl21i-va-rserv-01
+(see Jira 884 and 476)-->
+	<!--<ethercat.EthercatSlave master="ECATM"/>-->
+	<!--Expecting ERIO-02 Module 6 EL1014 from drawing 1091223 page 26
+But not in the slaveinfo -d chain on bl21i-va-rserv-01
+(see Jira 884 and 476)-->
+	<!--<ethercat.EthercatSlave master="ECATM"/>-->
+	<!--Start of BL21I-VA-ERIO-01
+
+(coupler replaced on 03/02/2023)-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00028806" position="DCS00028806" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024908" position="DCS00024908" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024909" position="DCS00024909" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024910" position="DCS00024910" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024911" position="DCS00024911" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023480" position="DCS00023480" type_rev="EL1014 rev 0x00100000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00023481" position="DCS00023481" type_rev="EL1014 rev 0x00100000"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-01:MOD1" PORT="DCS00024908" SCAN="1 second" name="ADC1"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-01:MOD2" PORT="DCS00024909" SCAN="1 second" name="ADC2"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-01:MOD3" PORT="DCS00024910" SCAN="1 second" name="ADC3"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-01:MOD4" PORT="DCS00024911" SCAN="1 second" name="ADC4"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-02:MOD1" PORT="DCS00024912" SCAN="1 second" name="ADC5"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-02:MOD2" PORT="DCS00024913" SCAN="1 second" name="ADC6"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-03:MOD1" PORT="DCS00024890" SCAN="1 second" name="ADC7"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-03:MOD2" PORT="DCS00024891" SCAN="1 second" name="ADC8"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-04:MOD1" PORT="DCS00024905" SCAN="1 second" name="ADC9"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-04:MOD2" PORT="DCS00025130" SCAN="1 second" name="ADC10"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-04:MOD3" PORT="DCS00026220" SCAN="1 second" name="ADC11"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-04:MOD4" PORT="DCS00026221" SCAN="1 second" name="ADC12"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-12:MOD1" PORT="DCS00026565" SCAN="1 second" name="ADC13"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-12:MOD2" PORT="DCS00026570" SCAN="1 second" name="ADC14"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-01:MOD5" PORT="DCS00023480" SCAN="I/O Intr" name="DIGI1"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-01:MOD6" PORT="DCS00023481" SCAN="I/O Intr" name="DIGI2"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-03:MOD1" PORT="DCS00025081" SCAN="I/O Intr" name="DIGI3"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-03:MOD2" PORT="DCS00025082" SCAN="I/O Intr" name="DIGI4"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-04:MOD1" PORT="DCS00025092" SCAN="I/O Intr" name="DIGI5"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-04:MOD2" PORT="DCS00025093" SCAN="I/O Intr" name="DIGI6"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-02:MOD3" PORT="DCS00023482" SCAN="I/O Intr" name="DIGI7"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-02:MOD4" PORT="DCS00023483" SCAN="I/O Intr" name="DIGI8"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-01:FANC-01" name="VAFAN1" rio_dinput="BL21I-VA-ERIO-01:MOD5:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-01:PSU-01" name="VAPSU1" rio_dinput="BL21I-VA-ERIO-01:MOD6:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-02:FANC-01" name="VAFAN2" rio_dinput="BL21I-VA-ERIO-01:MOD5:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-02:PSU-01" name="VAPSU2" rio_dinput="BL21I-VA-ERIO-01:MOD6:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-03:FANC-01" name="VAFAN3" rio_dinput="BL21I-VA-ERIO-02:MOD4:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-03:PSU-01" name="VAPSU3" rio_dinput="BL21I-VA-ERIO-02:MOD4:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-04:FANC-01" name="VAFAN4" rio_dinput="BL21I-VA-ERIO-03:MOD3:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-04:PSU-01" name="VAPSU4" rio_dinput="BL21I-VA-ERIO-03:MOD3:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-05:FANC-01" name="VAFAN5" rio_dinput="BL21I-VA-ERIO-04:MOD5:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-05:PSU-01" name="VAPSU5" rio_dinput="BL21I-VA-ERIO-04:MOD5:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-06:FANC-01" name="VAFAN6" rio_dinput="BL21I-VA-ERIO-04:MOD6:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-06:PSU-01" name="VAPSU6" rio_dinput="BL21I-VA-ERIO-04:MOD6:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-PS-FANC-01" name="PSFAN1" rio_dinput="BL21I-VA-ERIO-01:MOD5:CHANNEL2:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-PS-PSU-01" name="PSPSU1" rio_dinput="BL21I-VA-ERIO-01:MOD6:CHANNEL2:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-PS-FANC-02" name="PSFAN2" rio_dinput="BL21I-VA-ERIO-01:MOD5:CHANNEL4:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-PS-PSU-02" name="PSPSU2" rio_dinput="BL21I-VA-ERIO-01:MOD6:CHANNEL4:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-NT-RACK-01:FANC-01" name="NTFAN1" rio_dinput="BL21I-VA-ERIO-02:MOD3:CHANNEL1:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-NT-RACK-01:PSU-01" name="NTPSU1" rio_dinput="BL21I-VA-ERIO-02:MOD6:CHANNEL1:INPUT"/>-->
+	<rackFan.rackFan_rio device="BL21I-NT-RACK-02:FANC-01" name="NTFAN2" rio_dinput="BL21I-VA-ERIO-02:MOD3:CHANNEL3:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-NT-RACK-02:PSU-01" name="NTPSU2" rio_dinput="BL21I-VA-ERIO-02:MOD6:CHANNEL3:INPUT"/>-->
+	<rackFan.rackFan_rio device="BL21I-NT-RACK-03:FANC-01" name="NTFAN3" rio_dinput="BL21I-VA-ERIO-02:MOD4:CHANNEL2:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-NT-RACK-03:PSU-01" name="NTPSU3" rio_dinput="BL21I-VA-ERIO-02:MOD6:CHANNEL2:INPUT"/>-->
+	<!--<rackFan.rackFan_rio device="BL21I-MO-RACK-01:FANC-01" name="MOFAN1" rio_dinput="BL21I-VA-ERIO-02:MOD6:CHANNEL4:INPUT"/>-->
+	<!--<rackFan.rackFan_rio device="BL21I-MO-RACK-01:PSU-01" name="MOPSU1" rio_dinput="BL21I-VA-ERIO-02:MOD5:CHANNEL1:INPUT"/>-->
+	<rackFan.rackFan_rio device="BL21I-MO-RACK-02:FANC-01" name="MOFAN2" rio_dinput="BL21I-VA-ERIO-02:MOD4:CHANNEL4:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-MO-RACK-02:PSU-01" name="MOPSU2" rio_dinput="BL21I-VA-ERIO-02:MOD5:CHANNEL3:INPUT"/>-->
+	<rackFan.rackFan_rio device="BL21I-MO-RACK-03:FANC-01" name="MOFAN3" rio_dinput="BL21I-VA-ERIO-02:MOD3:CHANNEL2:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-MO-RACK-03:PSU-01" name="MOPSU3" rio_dinput="BL21I-VA-ERIO-02:MOD5:CHANNEL2:INPUT"/>-->
+	<rackFan.rackFan_rio device="BL21I-MO-RACK-04:FANC-01" name="MOFAN4" rio_dinput="BL21I-VA-ERIO-02:MOD3:CHANNEL4:INPUT"/>
+	<!--<rackFan.rackFan_rio device="BL21I-MO-RACK-04:PSU-01" name="MOPSU4" rio_dinput="BL21I-VA-ERIO-02:MOD5:CHANNEL4:INPUT"/>-->
+</components>

--- a/tests/samples/catio/BL21I-VA-IOC-02.xml
+++ b/tests/samples/catio/BL21I-VA-IOC-02.xml
@@ -1,0 +1,618 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<EPICS_BASE.EpicsEnvSet key="EPICS_CA_AUTO_ADDR_LIST" value="NO"/>
+	<EPICS_BASE.EpicsEnvSet key="EPICS_CA_ADDR_LIST" value="172.23.121.255"/>
+	<devIocStats.devIocStatsHelper ioc="BL21I-VA-IOC-02" name="BL21I-VA-IOC-02.DEVIOCSTATS"/>
+	<autosave.Autosave bl="True" iocName="BL21I-VA-IOC-02" name="BL21I-VA-IOC-02.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="VA2.PVLOGGING"/>
+	<FINS.FINSUDPInit ip="10.121.3.1" name="fins_VLVCC1" simulation="localhost:11101"/>
+	<FINS.FINSUDPInit ip="10.121.3.2" name="fins_VLVCC2" simulation="localhost:11102"/>
+	<FINS.FINSUDPInit ip="10.121.3.3" name="fins_VLVCC3" simulation="localhost:11103"/>
+	<FINS.FINSUDPInit ip="10.121.3.4" name="fins_VLVCC4" simulation="localhost:11104"/>
+	<FINS.FINSUDPInit ip="10.121.3.5" name="fins_VLVCC5" simulation="localhost:11105"/>
+	<FINS.FINSUDPInit ip="10.121.3.6" name="fins_VLVCC6" simulation="localhost:11106"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-01" name="VLVCC1.0" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-01" name="VLVCC1.1" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-01" name="VLVCC1.2" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-01" name="VLVCC1.3" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-01" name="VLVCC1.4" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-01" name="VLVCC1.8" port="fins_VLVCC1"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-02" name="VLVCC2.0" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-02" name="VLVCC2.1" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-02" name="VLVCC2.2" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-02" name="VLVCC2.3" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-02" name="VLVCC2.4" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-02" name="VLVCC2.8" port="fins_VLVCC2"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-03" name="VLVCC3.0" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-03" name="VLVCC3.1" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-03" name="VLVCC3.2" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-03" name="VLVCC3.3" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-03" name="VLVCC3.4" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-03" name="VLVCC3.8" port="fins_VLVCC3"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-04" name="VLVCC4.0" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-04" name="VLVCC4.1" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-04" name="VLVCC4.2" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-04" name="VLVCC4.3" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-04" name="VLVCC4.4" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-04" name="VLVCC4.8" port="fins_VLVCC4"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-05" name="VLVCC5.0" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-05" name="VLVCC5.1" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-05" name="VLVCC5.2" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-05" name="VLVCC5.3" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-05" name="VLVCC5.4" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-05" name="VLVCC5.8" port="fins_VLVCC5"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-06" name="VLVCC6.0" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-06" name="VLVCC6.1" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-06" name="VLVCC6.2" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-06" name="VLVCC6.3" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-06" name="VLVCC6.4" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="5" device="BL21I-VA-VLVCC-06" name="VLVCC6.5" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-06" name="VLVCC6.8" port="fins_VLVCC6"/>
+	<dlsPLC.read100 century="10" device="BL21I-VA-VLVCC-06" name="VLVCC6.10" port="fins_VLVCC6"/>
+	<dlsPLC.vacValve addr="200" desc="Valve 20" device="BL21I-VA-VALVE-20" ilk1="IMG42" ilk15="Valve Fault" ilk2="IMG21 / IMG30 OK" ilk3="Tcryo &lt; 150K &amp; Cooling" ilk4="V29 Closed" name="V20" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="210" desc="Valve 21" device="BL21I-VA-VALVE-21" ilk1="Scroll21 at speed" ilk2="V30 Closed" name="V21" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="220" desc="Valve 22" device="BL21I-VA-VALVE-22" ilk1="V23 Open" ilk15="Valve Fault" ilk2="Turbo7 at speed" ilk3="IMG41" ilk4="IMG30" name="V22" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="230" desc="Valve 23" device="BL21I-VA-VALVE-23" ilk1="Scroll7 On at speed" name="V23" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="240" desc="Valve 25" device="BL21I-VA-VALVE-25" ilk1="V27 Open" ilk15="Valve Fault" ilk2="PIRG45" ilk3="Turbo5 at speed" name="V25" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="250" desc="Valve 26" device="BL21I-VA-VALVE-26" ilk1="V27 Open" ilk15="Valve Fault" ilk2="PIRG45" ilk3="Turbo6 at speed" ilk4="unused" name="V26" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="260" desc="Valve 27" device="BL21I-VA-VALVE-27" ilk1="Scroll5 On at speed" name="V27" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="270" desc="Valve 28" device="BL21I-VA-VALVE-28" ilk1="Scroll2 On at speed" name="V28" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="280" desc="Valve 29" device="BL21I-VA-VALVE-29" ilk1="V20 Closed" ilk2="Cryopump On" name="V29" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="290" desc="Valve 30" device="BL21I-VA-VALVE-30" ilk1="V21 Closed" ilk2="V20 Closed" name="V30" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValve addr="310" desc="Valve 80" device="BL21I-VA-VALVE-80" ilk1="Scroll4 On at speed" name="V80" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValveDebounce addr="40" desc="Fast Mask" device="BL21I-VA-FMASK-01" gilk0="IMG1 PIRG1" gilk1="IMG2 PIRG2" gilk2="IMG3 PIRG3" gilk3="IMG4 PIRG4" gilk4="IMG5 PIRG5" gilk5="IMG6 PIRG6" ilk1="runvac V1-4+4of6IMGs" ilk15="Fault" ilk2="V1 Open" ilk3="V2 Open" ilk4="V3 Open" ilk5="V4,5,6,7 Open" name="FM" port="fins_VLVCC1" valvetype="shutter" vlvcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 1" device="BL21I-VA-VALVE-01" gilk0="Gauge 1" gilk1="Gauge 2" gilk2="Gauge 3" gilk3="Gauge 4" gilk4="Gauge 5" gilk5="Gauge 6" ilk0="Air Pressure" ilk1="Initial/Run" ilk15="Valve Fault" ilk2="PIRG-01 &amp; Ser" ilk3="PIRG-02 &amp; Ser" ilk4="PIRG-03 &amp; Ser" name="V1" port="fins_VLVCC1" vlvcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.vacValveDebounce addr="20" desc="Valve 2" device="BL21I-VA-VALVE-02" gilk0="Gauge 1" gilk1="Gauge 2" gilk2="Gauge 3" gilk3="Gauge 4" gilk4="Gauge 5" gilk5="Gauge 6" ilk0="Air Pressure" ilk1="Initial/Run" ilk15="Valve Fault" ilk2="PIRG-02 &amp; Ser" ilk3="PIRG-04 &amp; Ser" name="V2" port="fins_VLVCC1" vlvcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.vacValveDebounce addr="30" desc="Valve 3" device="BL21I-VA-VALVE-03" gilk0="Gauge 1" gilk1="Gauge 2" gilk2="Gauge 3" gilk3="Gauge 4" gilk4="Gauge 5" gilk5="Gauge 6" ilk0="Air Pressure" ilk1="Initial/Run" ilk15="Valve Fault" ilk2="PIRG-03 &amp; Ser" ilk3="PIRG-05 &amp; Ser" name="V3" port="fins_VLVCC1" vlvcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 4" device="BL21I-VA-VALVE-04" gilk0="Gauge 6" gilk1="Gauge 7" gilk2="Gauge 8" ilk0="Air Pressure" ilk1="Initial/Run" ilk15="Valve Fault" ilk2="PIRG-04 &amp; Ser" ilk3="PIRG-06 &amp; Ser" name="V4" port="fins_VLVCC2" vlvcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.vacValveDebounce addr="20" desc="Valve 5" device="BL21I-VA-VALVE-05" gilk0="Gauge 6" gilk1="Gauge 7" gilk2="Gauge 8" ilk0="Air Pressure" ilk1="IMG6" ilk15="Valve Fault" ilk2="IMG7" ilk3="PIRG-06 &amp; Ser" ilk4="PIRG-07 &amp; Ser" name="V5" port="fins_VLVCC2" vlvcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.vacValveDebounce addr="30" desc="Valve 6" device="BL21I-VA-VALVE-06" gilk0="Gauge 6" gilk1="Gauge 7" gilk2="Gauge 8" ilk0="Air Pressure" ilk1="IMG7" ilk15="Valve Fault" ilk2="IMG8" ilk3="PIRG-07 &amp; Ser" ilk4="PIRG-08 &amp; Ser" name="V6" port="fins_VLVCC2" vlvcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 7" device="BL21I-VA-VALVE-07" gilk0="Gauge 9" gilk1="Gauge 10" gilk2="Gauge 11" gilk3="Gauge 12" ilk0="Air Pressure Healthy" ilk1="IMG-08" ilk15="Valve Fault" ilk2="IMG-09" ilk3="PIRG-40 / ABSB Open" ilk4="V40 Open" ilk5="PIRG-08 / Service" ilk6="PIRG-09 / Service" name="V7" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="20" desc="Valve 8" device="BL21I-VA-VALVE-08" gilk0="Gauge 9" gilk1="Gauge 10" gilk2="Gauge 11" gilk3="Gauge 12" ilk0="Air Pressure Healthy" ilk1="IMG-09 / Service" ilk15="Valve Fault" ilk2="IMG-10 / Service" ilk3="FV9 Open &amp; Armed" ilk4="Guard Vac on PGM" ilk5="Turbo40 | V40Closed" ilk6="PIRG-09 / Service" ilk7="PIRG-10 / Service" name="V8" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="60" con_label0="Out beam" con_label1="In beam" desc="Absorber 2" device="BL21I-VA-ABSB-02" ilk1="SH1" ilk2="FV9 Open" name="ABS2" port="fins_VLVCC3" sta_label1="Out of beam" sta_label3="In beam" valvetype="absorber" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="50" desc="Shutter 1" device="BL21I-PS-SHTR-01" ilk0="Air Pressure" ilk1="Guard Line A" ilk15="Valve Fault" ilk2="Guard Line B" ilk3="V10 Open" ilk4="FV12 Open" ilk5="V13 Open Xor gas mode" ilk6="14,15,16 Open or gas mode" name="SH1" port="fins_VLVCC3" valvetype="shutter" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="40" desc="Valve 10" device="BL21I-VA-VALVE-10" gilk0="Gauge 9" gilk1="Gauge 10" gilk2="Gauge 11" gilk3="Gauge 12" ilk0="Air Pressure" ilk1="IMG11" ilk15="Valve Fault" ilk2="IMG12" ilk3="PIRG-11 &amp; Ser" ilk4="PIRG-12 &amp; Ser" name="V10" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="40" desc="Valve 14" device="BL21I-VA-VALVE-14" gilk0="Gauge 12" gilk1="Gauge 13" gilk2="Gauge 16" gilk3="Gauge 17" gilk4="Gauge 18" ilk0="Air Pressure" ilk1="IMG17" ilk15="Valve Fault" ilk2="IMG18" ilk3="IMG19" ilk4="PIRG-17 &amp; Ser" ilk5="PIRG-18 &amp; Ser" ilk6="Gas Cell Mode" name="V14" port="fins_VLVCC4" vlvcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 15" device="BL21I-VA-VALVE-15" gilk0="Gauge 19" gilk1="Gauge 20" gilk2="Gauge 21" gilk3="Gauge 22" gilk4="Gauge 23" ilk0="Air Pressure" ilk1="IMG18" ilk15="Valve Fault" ilk2="IMG19" ilk3="IMG20" ilk4="PIRG-19 &amp; Ser" ilk5="PIRG-20 &amp; Ser" name="V15" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValveDebounce addr="20" desc="Valve 16" device="BL21I-VA-VALVE-16" gilk0="Gauge 19" gilk1="Gauge 20" gilk2="Gauge 21" gilk3="Gauge 22" gilk4="Gauge 23" ilk0="Air Pressure" ilk1="IMG20" ilk15="Valve Fault" ilk2="IMG21" ilk3="V70 Closed" ilk4="FV Open &amp; Armed" ilk5="PIRG-20 &amp; Ser" ilk6="PIRG-21 &amp; Ser" name="V16" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValveDebounce addr="30" desc="Valve 17" device="BL21I-VA-VALVE-17" gilk0="Gauge 24" gilk1="Gauge 25" ilk0="Air Pressure" ilk1="IMG21" ilk15="Valve Fault" ilk2="IMG24" ilk3="V70 Closed" ilk4="PIRG-21 &amp; Ser" ilk5="PIRG-24 &amp; Ser" name="V17" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacValveDebounce addr="30" desc="Valve 40" device="BL21I-VA-VALVE-40" ilk0="Air Pressure" ilk1="IMG9" ilk15="Valve Fault" ilk2="IMG40" ilk3="Turbo40" name="V40" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacValveDebounce addr="850" desc="Valve 41" device="BL21I-VA-VALVE-41" ilk0="Scrol-40" ilk1="Turbo-40/120S" name="V41" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<!--<dlsPLC.vacValveDebounce addr="890" desc="Valve 42" device="BL21I-VA-VALVE-42" ilk0="Scrol-41" ilk1="PIRG-40/60S" name="V42" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="10" desc="Valve 50" device="BL21I-VA-VALVE-50" name="V50" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="20" desc="Valve 51" device="BL21I-VA-VALVE-51" gilk0="Gauge 12" gilk1="Gauge 13" ilk0="Air Pressure" ilk1="IMG12" ilk15="Valve Fault" ilk2="IMG13" ilk3="Valve 55 Closed" name="V51" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="30" desc="Valve 52" device="BL21I-VA-VALVE-52" name="V52" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="40" desc="Valve 53" device="BL21I-VA-VALVE-53" name="V53" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="50" desc="Valve 54" device="BL21I-VA-VALVE-54" gilk0="Gauge 13" gilk1="Gauge 16" ilk0="Air Pressure" ilk1="IMG13" ilk15="Valve Fault" ilk2="IMG16" ilk3="Valve 55 Closed" name="V54" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<!--<dlsPLC.vacValveDebounce addr="60" desc="Valve 55" device="BL21I-VA-VALVE-55" gilk0="Gauge 13" gilk1="Gauge 14" ilk0="Air Pressure" ilk1="IMG13" ilk15="Valve Fault" ilk2="IMG14" ilk3="Valve 51 Closed" ilk4="Valve 54 Closed" name="V55" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<dlsPLC.vacPump addr="800" device="BL21I-VA-SCROL-01" name="SCR1" port="fins_VLVCC5" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-05"/>
+	<dlsPLC.vacPump addr="420" device="BL21I-VA-SCROL-02" name="SCR2" port="fins_VLVCC6" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="430" device="BL21I-VA-SCROL-04" name="SCR4" port="fins_VLVCC6" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="440" device="BL21I-VA-SCROL-05" name="SCR5" port="fins_VLVCC6" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="450" device="BL21I-VA-SCROL-07" name="SCR7" port="fins_VLVCC6" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="460" device="BL21I-VA-SCROL-08" name="SCR8" port="fins_VLVCC6" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="810" device="BL21I-VA-TURBO-01" ilk0="PIRG-14 OK" name="TRB1" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>
+	<dlsPLC.vacPump addr="340" device="BL21I-VA-TURBO-05" ilk0="V27 Open" name="TRB5" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="350" device="BL21I-VA-TURBO-06" ilk0="V27 Open" name="TRB6" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="360" device="BL21I-VA-TURBO-07" ilk0="V23 Open" name="TRB7" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="370" device="BL21I-VA-TURBO-08" ilk0="V28 Open" ilk1="Op / Service &amp; V31 Open" name="TRB8" port="fins_VLVCC6" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="490" device="BL21I-VA-CRYO-01" ilk0="V29 Closed" name="CRYO1" port="fins_VLVCC6" pumptype="cryo" sta_label1="T&gt;285K &amp; On" sta_label2="150K&lt;T&lt;285K &amp; On" sta_label3="T&lt;150K &amp; On" sta_label4="T&lt;150K &amp; Off" sta_label5="150K&lt;T&lt;285K &amp; Off" sta_label6="T&gt;285K &amp; Off" vlvcc="BL21I-VA-VLVCC-06"/>
+	<dlsPLC.vacPump addr="870" device="BL21I-VA-SCROL-40" name="SCR40" port="fins_VLVCC3" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacPump addr="880" device="BL21I-VA-SCROL-41" name="SCR41" port="fins_VLVCC3" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.vacPump addr="820" device="BL21I-VA-TURBO-40" ilk0="Scrol-40 OK" ilk1="V41 Open" name="TRB40" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<!--<dlsPLC.vacValveBistable addr="60" cilk0="Valve Fault" cilk1="Gauge 13" cilk2="Gauge 14" con_label1="Open" con_label2="Close" con_label3="Reset" device="BL21I-VA-VALVE-55" ilk0="valve" ilk1="Air Pressure" ilk2="IMG13" ilk3="IMG14" ilk4="Valve 51 Closed" ilk5="Valve 54 Closed" name="V55" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>-->
+	<dlsPLC.vacValveBistable addr="50" cilk0="Arm Out" device="BL21I-VA-VALVE-55" ilk0="Air Pressure" ilk1="IMG13" ilk2="IMG14" ilk3="Valve 51 Closed" ilk4="Valve 54 Closed" name="V55" port="fins_VLVCC5" vlvcc="BL21I-VA-VLVCC-05"/>
+	<dlsPLC.externalValve device="FE21I-VA-VALVE-02" name="FEV2"/>
+	<dlsPLC.externalValve device="FE21I-RS-ABSB-01" name="FEABSB1" valvetype="absorber"/>
+	<dlsPLC.externalValve device="FE21I-PS-SHTR-01" name="FESHTR1" valvetype="shutter"/>
+	<dlsPLC.vacValveReadOnly addr="30" device="BL21I-VA-VALVE-13" name="V13" vlvcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.vacValveReadOnly addr="300" device="BL21I-VA-VALVE-31" name="V31" vlvcc="BL21I-VA-VLVCC-06"/>
+	<!--<dlsPLC.vacValveReadOnly addr="860" device="BL21I-VA-VALVE-40" name="V40" vlvcc="BL21I-VA-VLVCC-03"/>-->
+	<dlsPLC.vacValveReadOnly addr="20" device="BL21I-VA-VALVE-51" name="V51" vlvcc="BL21I-VA-VLVCC-05"/>
+	<dlsPLC.vacValveReadOnly addr="40" device="BL21I-VA-VALVE-54" name="V54" vlvcc="BL21I-VA-VLVCC-05"/>
+	<dlsPLC.fastValve addr="70" allowpv="" device="BL21I-VA-FVALV-09" gilk0="Gauge 9" gilk1="Gauge 10" gilk2="Gauge 11" gilk3="Gauge 12" gilk8="BL21I-VA-FVI-01" gilk9="BL21I-VA-FVI-02" ilk0="Remote mode" ilk1="Limits healthy" ilk2="Open limit OK" ilk3="Move time" ilk4="IMG10" ilk5="IMG11" ilk6="FCTCL-01 trig" name="V9" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.fastValve addr="70" device="BL21I-VA-FVALV-12" ilk0="Remote mode" ilk1="Limits healthy" ilk2="Open limit OK" ilk3="Move time" ilk4="IMG12" ilk5="IMG16" ilk6="FCTCL-01 trig" name="V12" port="fins_VLVCC4" vlvcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="Temp 1" device="BL21I-AL-DIAGO-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="DGN.Temp1" offset="10" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="M1 Temp 1" device="BL21I-OP-MIRR-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M1.Temp1" offset="11" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="M1 Temp 1" device="BL21I-OP-MIRR-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M1.Temp2" offset="12" port="fins_VLVCC1" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="M1 Temp 1" device="BL21I-OP-MIRR-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M1.Temp3" offset="13" port="fins_VLVCC1" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="ABS1 Temp 1" device="BL21I-RS-ABS-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="ABS1.Temp1" offset="30" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="GBC1 Temp 1" device="BL21I-RS-GBC-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="GBC1.Temp1" offset="14" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="GBC1 Temp 2" device="BL21I-RS-GBC-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="GBC1.Temp2" offset="15" port="fins_VLVCC1" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="D1 Temp 1" device="BL21I-DI-PHDGN-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D1.Temp1" offset="16" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="S1 Temp Upper" device="BL21I-AL-SLITS-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S1.Temp1" offset="18" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="S1 Temp Lower" device="BL21I-AL-SLITS-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S1.Temp2" offset="19" port="fins_VLVCC1" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="S1 Temp Nearside" device="BL21I-AL-SLITS-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S1.Temp3" offset="20" port="fins_VLVCC1" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="S1 Temp Offside" device="BL21I-AL-SLITS-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S1.Temp4" offset="21" port="fins_VLVCC1" temp=":TEMP4" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="PS1 Temp 1" device="BL21I-RS-STAND-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PS1.Temp1" offset="31" port="fins_VLVCC1" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-01"/>
+	<dlsPLC.temperature desc="M2 Temp 1" device="BL21I-OP-MIRR-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M2.Temp1" offset="10" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="M2 Temp 2" device="BL21I-OP-MIRR-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M2.Temp2" offset="11" port="fins_VLVCC2" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="M2 Temp 3" device="BL21I-OP-MIRR-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M2.Temp3" offset="12" port="fins_VLVCC2" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S2 Temp Upper" device="BL21I-AL-SLITS-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S2.Temp1" offset="14" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S2 Temp Lower" device="BL21I-AL-SLITS-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S2.Temp2" offset="15" port="fins_VLVCC2" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S2 Temp Nearside" device="BL21I-AL-SLITS-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S2.Temp3" offset="16" port="fins_VLVCC2" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S2 Temp Offside" device="BL21I-AL-SLITS-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S2.Temp4" offset="17" port="fins_VLVCC2" temp=":TEMP4" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="D2 Temp 1" device="BL21I-DI-PHDGN-02" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D2.Temp1" offset="18" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="D3A Temp 1" device="BL21I-DI-PHDGA-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D3A.Temp1" offset="20" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="D3B Temp 1" device="BL21I-DI-PHDGB-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D3B.Temp1" offset="21" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S3 Temp Upper" device="BL21I-AL-SLITS-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S3.Temp1" offset="22" port="fins_VLVCC2" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S3 Temp Lower" device="BL21I-AL-SLITS-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S3.Temp2" offset="23" port="fins_VLVCC2" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S3 Temp Nearside" device="BL21I-AL-SLITS-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S3.Temp3" offset="24" port="fins_VLVCC2" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="S3 Temp Offside" device="BL21I-AL-SLITS-03" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S3.Temp4" offset="25" port="fins_VLVCC2" temp=":TEMP4" tmpcc="BL21I-VA-VLVCC-02"/>
+	<dlsPLC.temperature desc="VPG2 Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp1" offset="10" port="fins_VLVCC3" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="VPG4 Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp2" offset="11" port="fins_VLVCC3" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="VPG3 Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp3" offset="14" port="fins_VLVCC3" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-03"/>
+	<!--<dlsPLC.temperature desc="Not Connected" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp4" offset="15" port="fins_VLVCC3" temp=":TEMP4" tmpcc="BL21I-VA-VLVCC-03"/>-->
+	<!--<dlsPLC.temperature desc="VPG4 Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp5" offset="16" port="fins_VLVCC3" temp=":TEMP5" tmpcc="BL21I-VA-VLVCC-03"/>-->
+	<dlsPLC.temperature desc="VPG1 Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp6" offset="17" port="fins_VLVCC3" temp=":TEMP6" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="PGM Mirror Temp" device="BL21I-OP-PGM-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="PGM.Temp7" offset="18" port="fins_VLVCC3" temp=":TEMP7" tmpcc="BL21I-VA-VLVCC-03"/>
+	<!--Pressure of the cooling water to the PGM
+Related to the water flow to the mirror-->
+	<dlsPLC.temperature desc="Inlet PGM Grating Cooling Pressure" device="BL21I-OP-PGM-01" egu="Bar" high="6.0" hihi="6.2" hopr="6.2" lolo="0" lopr="0" low="0" name="PGM.CoolP1" offset="74" port="fins_VLVCC3" prec="3" scalefac="600" temp=":H2OP1" tmpcc="BL21I-VA-VLVCC-03"/>
+	<!--Pressure of the cooling water to the PGM
+Related to the water flow to the grating-->
+	<dlsPLC.temperature desc="Inlet PGM Mirror Cooling Pressure" device="BL21I-OP-PGM-01" egu="Bar" high="6.0" hihi="6.2" hopr="6.2" lolo="0" lopr="0" low="0" name="PGM.CoolP2" offset="75" port="fins_VLVCC3" prec="3" scalefac="600" temp=":H2OP2" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="D4 Temp 1" device="BL21I-DI-PHDGN-04" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D4.Temp1" offset="19" port="fins_VLVCC3" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="D4 Temp 2" device="BL21I-DI-PHDGN-04" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="D4.Temp2" offset="20" port="fins_VLVCC3" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.temperature desc="Exit Slits Temp" device="BL21I-AL-SLITS-05" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="S5.Temp1" offset="10" port="fins_VLVCC4" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="M5 Smarpod Plate Temp" device="BL21I-OP-MIRR-05" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M5.Temp1" offset="14" port="fins_VLVCC4" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="M5 Motor Temp" device="BL21I-OP-MIRR-05" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M5.Temp2" offset="34" port="fins_VLVCC4" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="M5 Newport Plate Temp" device="BL21I-OP-MIRR-05" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M5.Temp3" offset="15" port="fins_VLVCC4" temp=":TEMP3" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="M5 Granite Plate Temp" device="BL21I-OP-MIRR-05" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M5.Temp4" offset="13" port="fins_VLVCC4" temp=":TEMP4" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.temperature desc="M4 Temp" device="BL21I-MO-POD-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="M4.Temp1" offset="38" port="fins_VLVCC4" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.genericDevice addr="830" device="BL21I-OP-PGM-01:H2OP:OVRD" ilk0="PGM-GRAT press healthy" ilk1="PGM-MIRR press healthy" name="H2OP" port="fins_VLVCC3" vlvcc="BL21I-VA-VLVCC-03"/>
+	<dlsPLC.flow DESC="GBC1 Flow 1" P="BL21I-RS-GBC-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="2" loloaddress="808" lolobit="0" name="GBC1.Flow1"/>
+	<dlsPLC.flow DESC="S1 Flow 1" P="BL21I-AL-SLITS-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="3" loloaddress="818" lolobit="0" name="S1.Flow1"/>
+	<dlsPLC.flow DESC="DGN Flow 1" P="BL21I-AL-DIAGO-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="4" loloaddress="828" lolobit="0" name="DGN.Flow1"/>
+	<dlsPLC.flow DESC="M1 Flow 1" P="BL21I-OP-MIRR-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="5" loloaddress="858" lolobit="0" name="M1.Flow1"/>
+	<dlsPLC.flow DESC="D1 Flow 1" P="BL21I-DI-PHDGN-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="6" loloaddress="828" lolobit="2" name="D1.Flow1"/>
+	<dlsPLC.flow DESC="ABS1 Flow 1" P="BL21I-RS-ABSB-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="7" loloaddress="868" lolobit="0" name="ABS1.Flow1"/>
+	<dlsPLC.flow DESC="PS1 Flow 1" P="BL21I-RS-STAND-01" Q=":FLOW1" device="BL21I-VA-VLVCC-01" loaddress="4" lobit="8" loloaddress="98" lolobit="13" name="PS1.Flow1"/>
+	<dlsPLC.flow DESC="S2 Flow 1" P="BL21I-AL-SLITS-02" Q=":FLOW1" device="BL21I-VA-VLVCC-02" loaddress="4" lobit="0" loloaddress="808" lolobit="0" name="S2.Flow1"/>
+	<dlsPLC.flow DESC="S3 Flow 1" P="BL21I-AL-SLITS-03" Q=":FLOW1" device="BL21I-VA-VLVCC-02" loaddress="4" lobit="1" loloaddress="818" lolobit="0" name="S3.Flow1"/>
+	<dlsPLC.flow DESC="D2 Flow 1" P="BL21I-DI-PHDGN-02" Q=":FLOW1" device="BL21I-VA-VLVCC-02" loaddress="4" lobit="2" loloaddress="828" lolobit="0" name="D2.Flow1"/>
+	<dlsPLC.flow DESC="D3A Flow 1" P="BL21I-DI-PHDGA-03" Q=":FLOW1" device="BL21I-VA-VLVCC-02" loaddress="4" lobit="3" loloaddress="838" lolobit="0" name="D3A.Flow1"/>
+	<dlsPLC.flow DESC="M2 Flow 1" P="BL21I-OP-MIRR-02" Q=":FLOW1" device="BL21I-VA-VLVCC-02" loaddress="4" lobit="4" loloaddress="848" lolobit="0" name="M2.Flow1"/>
+	<dlsPLC.flow DESC="0 Ord Stop Flow" P="BL21I-OP-PGM-01" Q=":FLOW1" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="0" loloaddress="806" lolobit="0" name="PGM.Flow0"/>
+	<dlsPLC.flow DESC="PGM Grating" P="BL21I-OP-PGM-01" Q=":FLOW2" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="1" loloaddress="806" lolobit="1" name="PGM.Flow1"/>
+	<dlsPLC.flow DESC="PGM Mirror" P="BL21I-OP-PGM-01" Q=":FLOW3" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="2" loloaddress="806" lolobit="2" name="PGM.Flow2"/>
+	<dlsPLC.flow DESC="S4 Flow1" P="BL21I-AL-SLITS-04" Q=":FLOW1" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="3" loloaddress="816" lolobit="0" name="S4.Flow1"/>
+	<dlsPLC.flow DESC="D4 Flow1" P="BL21I-DI-PHDGN-04" Q=":FLOW1" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="4" loloaddress="816" lolobit="1" name="D4.Flow2"/>
+	<dlsPLC.flow DESC="Grating Chiller" P="BL21I-OP-PGM-01" Q=":FLOW4" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="5" loloaddress="807" lolobit="3" name="PGM.Flow3"/>
+	<dlsPLC.flow DESC="Mirror Chiller" P="BL21I-OP-PGM-01" Q=":FLOW5" device="BL21I-VA-VLVCC-03" loaddress="4" lobit="6" loloaddress="808" lolobit="4" name="PGM.Flow4"/>
+	<dlsPLC.readInt16 P="BL21I-DI-GAS-01" Q=":ILK-OVERRIDE" addr="4" name="D7Override" vlvcc="BL21I-VA-VLVCC-04"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:SSEAL:NTRGN:STATUS:RAW" addr="1011" vlvcc="BL21I-VA-VLVCC-06"/>
+	<!--Raw data readout
+
+Helium transfer line with motorized needle valve from ICE Oxford Ltd used with the SMPL Helium Dewar.
+
+Required 0-10V input signal provided by BL21I-MP-TRIO-11 (module 11).-->
+	<dlsPLC.readInt16 P="BL21I-EA-SMPL-01" Q=":HE:TRANSFER:RAW_RBV" addr="501" vlvcc="BL21I-VA-VLVCC-06"/>
+	<!--Raw data demand
+
+Helium transfer line with motorized needle valve from ICE Oxford Ltd used with the SMPL Helium Dewar.
+
+Required 0-10V input signal provided by BL21I-MP-TRIO-11 (module 11).\n-->
+	<dlsPLC.writeInt16 P="BL21I-EA-SMPL-01" Q=":HE:TRANSFER:RAW" addr="500" port="fins_VLVCC6"/>
+	<records.calcout CALC="((A &amp; 49152) = 49152) " DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:STATUS:RAW CP" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:STATUS PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:STATUS:CALC"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIHI="10.1" HOPR="10" HYST="0.05" INPA="BL21I-EA-SMPL-01:HE:TRANSFER:RAW_RBV CP" INPB="10" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="-0.1" LOPR="0" OOPT="On Change" OUT="BL21I-EA-SMPL-01:HE:TRANSFER:VOLTAGE_RBV PP" SCAN="Passive" record="BL21I-EA-SMPL-01:HE:TRANSFER:SCALED_RBV"/>
+	<records.calcout CALC="(A*B/C)+D" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIHI="10.1" HOPR="10" HYST="0.05" INPA="BL21I-EA-SMPL-01:HE:TRANSFER:VOLTAGE CP" INPB="6000" INPC="10" INPD="0" LLSV="MAJOR" LOLO="-0.1" LOPR="0" OOPT="On Change" OUT="BL21I-EA-SMPL-01:HE:TRANSFER:RAW PP" SCAN="Passive" record="BL21I-EA-SMPL-01:HE:TRANSFER:SCALED"/>
+	<records.calcout CALC="((B=0)&amp;&amp;(A=C))||((B=1)&amp;&amp;(A=D))||((B=2)&amp;&amp;(A=E))" DESC="Check if voltage matches selected menu" DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-EA-SMPL-01:HE:TRANSFER:VOLTAGE_RBV" INPB="BL21I-EA-SMPL-01:HE:TRANSFER:SELECT" INPC="BL21I-EA-SMPL-01:HE:TRANSFER:SELECT.ZRVL" INPD="BL21I-EA-SMPL-01:HE:TRANSFER:SELECT.ONVL" INPE="BL21I-EA-SMPL-01:HE:TRANSFER:SELECT.TWVL" OOPT="On Change" OUT="BL21I-EA-SMPL-01:HE:TRANSFER:MATCH_RBV PP" SCAN="Passive" record="BL21I-EA-SMPL-01:HE:TRANSFER:SELMATCH"/>
+	<records.ai DESC="Helium transfer line readout in volts" DTYP="Soft Channel" EGU="V" FLNK="BL21I-EA-SMPL-01:HE:TRANSFER:SELMATCH PP" PREC="3" SCAN="Passive" name="SMPL.HeTransferVoltage_rbv" record="BL21I-EA-SMPL-01:HE:TRANSFER:VOLTAGE_RBV"/>
+	<userIO.ao DESC="Dewar He Transfer Voltage" DRVH="10" DRVL="0" DTYP="Soft Channel" EGUF="" EGUL="" LINR="" OUT="" P="BL21I-EA-SMPL-01" PREC="3" R=":HE:TRANSFER:VOLTAGE" SCAN="Passive" name="SMPL.HeTransferVoltage"/>
+	<userIO.bi DESC="Matching voltage and menu readback" DTYP="Soft Channel" INP="" ONAM="In Position" P="BL21I-EA-SMPL-01" R=":HE:TRANSFER:MATCH_RBV" SCAN="Passive" ZNAM="Mismatch" name="SMPL.HeMenuMatch_rbv"/>
+	<records.mbbo DESC="Select Helium transfer line mode" DTYP="Raw Soft Channel" OMSL="supervisory" ONST="fully open" ONVL="5" OUT="BL21I-EA-SMPL-01:HE:TRANSFER:VOLTAGE PP" SCAN="Passive" TWST="optimal" TWVL="8" ZRST="fully close" ZRVL="10" name="SMPL.HeliumSelect" record="BL21I-EA-SMPL-01:HE:TRANSFER:SELECT"/>
+	<records.bi DTYP="Soft Channel" ONAM="On" SCAN="Passive" ZNAM="Off" record="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:STATUS"/>
+	<asyn.AsynIP name="vts_MPC1" port="bl21i-va-tserv-01:7001" simulation="localhost:11301"/>
+	<asyn.AsynIP name="vts_MPC2" port="bl21i-va-tserv-01:7002" simulation="localhost:11302"/>
+	<asyn.AsynIP name="vts_MPC3" port="bl21i-va-tserv-01:7003" simulation="localhost:11303"/>
+	<asyn.AsynIP name="vts_MPC4" port="bl21i-va-tserv-01:7004" simulation="localhost:11304"/>
+	<asyn.AsynIP name="vts_MPC5" port="bl21i-va-tserv-01:7005" simulation="localhost:11305"/>
+	<asyn.AsynIP name="vts_MPC6" port="bl21i-va-tserv-03:7001" simulation="localhost:11306"/>
+	<asyn.AsynIP name="vts_MPC7" port="bl21i-va-tserv-03:7002" simulation="localhost:11307"/>
+	<asyn.AsynIP name="vts_MPC8" port="bl21i-va-tserv-04:7001" simulation="localhost:11308"/>
+	<asyn.AsynIP name="vts_MPC9" port="bl21i-va-tserv-04:7002" simulation="localhost:11309"/>
+	<asyn.AsynIP name="vts_MPC40" port="bl21i-va-tserv-04:7003" simulation="localhost:11340"/>
+	<asyn.AsynIP name="vts_MPC10" port="bl21i-va-tserv-05:7001" simulation="localhost:11310"/>
+	<asyn.AsynIP name="vts_MPC11" port="bl21i-va-tserv-05:7002" simulation="localhost:11311"/>
+	<asyn.AsynIP name="vts_MPC12" port="bl21i-va-tserv-05:7003" simulation="localhost:11312"/>
+	<!--Disabled as currently not used-->
+	<!--<asyn.AsynIP name="vts_SPC1" port="bl21i-va-tserv-05:7008" simulation="localhost:11313"/>-->
+	<asyn.AsynIP name="vts_GCTLR1" port="bl21i-va-tserv-01:7009" simulation="localhost:11501"/>
+	<asyn.AsynIP name="vts_GCTLR2" port="bl21i-va-tserv-01:7010" simulation="localhost:11502"/>
+	<asyn.AsynIP name="vts_GCTLR3" port="bl21i-va-tserv-01:7011" simulation="localhost:11503"/>
+	<asyn.AsynIP name="vts_GCTLR4" port="bl21i-va-tserv-01:7012" simulation="localhost:11504"/>
+	<asyn.AsynIP name="vts_GCTLR5" port="bl21i-va-tserv-01:7013" simulation="localhost:11505"/>
+	<asyn.AsynIP name="vts_GCTLR6" port="bl21i-va-tserv-03:7009" simulation="localhost:11506"/>
+	<asyn.AsynIP name="vts_GCTLR7" port="bl21i-va-tserv-03:7010" simulation="localhost:11507"/>
+	<asyn.AsynIP name="vts_GCTLR8" port="bl21i-va-tserv-04:7009" simulation="localhost:11508"/>
+	<asyn.AsynIP name="vts_GCTLR9" port="bl21i-va-tserv-04:7010" simulation="localhost:11509"/>
+	<asyn.AsynIP name="vts_GCTLR10" port="bl21i-va-tserv-04:7011" simulation="localhost:11510"/>
+	<asyn.AsynIP name="vts_GCTLR11" port="bl21i-va-tserv-04:7012" simulation="localhost:11511"/>
+	<asyn.AsynIP name="vts_GCTLR12" port="bl21i-va-tserv-05:7009" simulation="localhost:11512"/>
+	<asyn.AsynIP name="vts_GCTLR13" port="bl21i-va-tserv-05:7010" simulation="localhost:11513"/>
+	<asyn.AsynIP name="vts_GCTLR14" port="bl21i-va-tserv-05:7011" simulation="localhost:11514"/>
+	<asyn.AsynIP name="vts_9XX_43" port="bl21i-va-tserv-20:7001"/>
+	<asyn.AsynIP name="vts_9XX_44" port="bl21i-va-tserv-20:7002"/>
+	<asyn.AsynIP name="vts_9XX_45" port="bl21i-va-tserv-20:7003"/>
+	<asyn.AsynIP name="vts_9XX_22" port="bl21i-va-tserv-20:7004"/>
+	<asyn.AsynIP name="vts_9XX_23" port="bl21i-va-tserv-21:7001"/>
+	<asyn.AsynIP name="vts_SCM10_01" port="bl21i-va-tserv-21:7003"/>
+	<!--Scientific Instruments single channel temperature monitor
+
+Used to monitor the cryo pump temperature in the sample vessel-->
+	<BL21I.SCM10 device="BL21I-VA-CRYO-01:SERIAL" name="SMPL.SCM10_01" port="vts_SCM10_01"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-01" name="MPC1" port="vts_MPC1"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-02" name="MPC2" port="vts_MPC2"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-03" name="MPC3" port="vts_MPC3"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-04" name="MPC4" port="vts_MPC4"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-05" name="MPC5" port="vts_MPC5"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-06" name="MPC6" port="vts_MPC6"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-07" name="MPC7" port="vts_MPC7"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-08" name="MPC8" port="vts_MPC8"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-09" name="MPC9" port="vts_MPC9"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-10" name="MPC10" port="vts_MPC10"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-11" name="MPC11" port="vts_MPC11"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-12" name="MPC12" port="vts_MPC12"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-40" name="MPC40" port="vts_MPC40"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC1" device="BL21I-VA-IONP-01" name="IONP1" pump="1" size="300"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC1" device="BL21I-VA-IONP-02" name="IONP2" pump="2" size="375" text="BL21I-VA-IONP-02-03"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC1" device="BL21I-VA-IONP-03" name="IONP3" pump="2" size="375" text="BL21I-VA-IONP-02-03"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC2" device="BL21I-VA-IONP-04" name="IONP4" pump="1" size="400"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC2" device="BL21I-VA-IONP-05" name="IONP5" pump="2" size="450" text="BL21I-VA-IONP-05-06"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC2" device="BL21I-VA-IONP-06" name="IONP6" pump="2" size="450" text="BL21I-VA-IONP-05-06"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC3" device="BL21I-VA-IONP-07" name="IONP7" pump="1" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC3" device="BL21I-VA-IONP-08" name="IONP8" pump="2" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC4" device="BL21I-VA-IONP-09" name="IONP9" pump="1" size="450" text="BL21I-VA-IONP-09-10"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC4" device="BL21I-VA-IONP-10" name="IONP10" pump="1" size="450" text="BL21I-VA-IONP-09-10"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC4" device="BL21I-VA-IONP-11" name="IONP11" pump="2" size="400"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC5" device="BL21I-VA-IONP-12" name="IONP12" pump="1" size="150"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC5" device="BL21I-VA-IONP-13" name="IONP13" pump="2" size="300"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC6" device="BL21I-VA-IONP-14" name="IONP14" pump="1" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC6" device="BL21I-VA-IONP-15" name="IONP15" pump="2" size="150"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC7" device="BL21I-VA-IONP-16" name="IONP16" pump="1" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC7" device="BL21I-VA-IONP-17" name="IONP17" pump="2" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC8" device="BL21I-VA-IONP-18" name="IONP18" pump="1" size="150"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC8" device="BL21I-VA-IONP-19" name="IONP19" pump="2" size="500"/>
+	<!--<digitelMpc.digitelMpcIonp MPC="MPC8" device="BL21I-VA-IONP-20" name="IONP20" pump="2" size="45"/>-->
+	<digitelMpc.digitelMpcIonp MPC="MPC9" device="BL21I-VA-IONP-21" name="IONP21" pump="1" size="160"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC9" device="BL21I-VA-IONP-22" name="IONP22" pump="2" size="160"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC40" device="BL21I-VA-IONP-23" name="IONP23" pump="2" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC10" device="BL21I-VA-IONP-24" name="IONP24" pump="1" size="500"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC10" device="BL21I-VA-IONP-25" name="IONP25" pump="2" size="500" text="BL21I-VA-IONP-25-26"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC10" device="BL21I-VA-IONP-26" name="IONP26" pump="2" size="500" text="BL21I-VA-IONP-25-26"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC11" device="BL21I-VA-IONP-30" name="IONP30" pump="1" size="1000" text="BL21I-VA-IONP-30"/>
+	<!--<digitelMpc.digitelMpcIonp MPC="MPC11" device="BL21I-VA-IONP-28" name="IONP28" pump="2" size="1000" text="BL21I-VA-IONP-28"/>-->
+	<digitelMpc.digitelMpcIonp MPC="MPC12" device="BL21I-VA-IONP-27" name="IONP27" pump="1" size="500" text="BL21I-VA-IONP-27"/>
+	<digitelMpc.digitelMpcTsp ctlsrc="0" device="BL21I-VA-TSP-01" name="TSP1" port="vts_MPC12" unit="01"/>
+	<!--Disabled as currently not connected
+(Ion Pump 29 near Smpl Manipulator is never used)-->
+	<!--<digitelSpc.digitelSpc device="BL21I-VA-SPC-01" name="SPC1" port="vts_SPC1"/>-->
+	<!--Disabled as currently not connected (never used)-->
+	<!--<digitelSpc.digitelSpcIonp SPC="SPC1" device="BL21I-VA-IONP-29" name="IONP29" size="3"/>-->
+	<!--<mks9xx.mks9xx P="BL21I-VA-PIRG-22" PORT="MKS9XX_22" serialport="vts_9XX_22"/>-->
+	<!--<mks9xx.mks9xx P="BL21I-VA-PIRG-23" PORT="MKS9XX_23" serialport="vts_9XX_23"/>-->
+	<!--<mks9xx.mks9xx P="BL21I-VA-PIRG-43" PORT="MKS9XX_43" serialport="vts_9XX_43"/>-->
+	<!--<mks9xx.mks9xx P="BL21I-VA-PIRG-44" PORT="MKS9XX_44" serialport="vts_9XX_44"/>-->
+	<!--<mks9xx.mks9xx P="BL21I-VA-PIRG-45" PORT="MKS9XX_45" serialport="vts_9XX_45"/>-->
+	<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-22" id="22" name="GAUGE22" param_A="1" param_B="6" plog_adc_pv="BL21I-VA-ERIO-12:MOD1:INPUT4:VALUE"/>
+	<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-23" id="23" name="GAUGE23" param_A="1" param_B="6" plog_adc_pv="BL21I-VA-ERIO-12:MOD2:INPUT1:VALUE"/>
+	<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-43" id="43" name="GAUGE43" plog_adc_pv="BL21I-VA-ERIO-12:MOD1:INPUT1:VALUE"/>
+	<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-44" id="44" name="GAUGE44" plog_adc_pv="BL21I-VA-ERIO-12:MOD1:INPUT3:VALUE"/>
+	<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-45" id="45" name="GAUGE45" param_A="1" param_B="6" plog_adc_pv="BL21I-VA-ERIO-12:MOD1:INPUT2:VALUE"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-01" name="GCTLR1" port="vts_GCTLR1"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-02" name="GCTLR2" port="vts_GCTLR2"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-03" name="GCTLR3" port="vts_GCTLR3"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-04" name="GCTLR4" port="vts_GCTLR4"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-05" name="GCTLR5" port="vts_GCTLR5"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-06" name="GCTLR6" port="vts_GCTLR6"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-07" name="GCTLR7" port="vts_GCTLR7"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-08" name="GCTLR8" port="vts_GCTLR8"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-09" name="GCTLR9" port="vts_GCTLR9"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-10" name="GCTLR10" port="vts_GCTLR10"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-11" name="GCTLR11" port="vts_GCTLR11"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-12" name="GCTLR12" port="vts_GCTLR12"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-13" name="GCTLR13" port="vts_GCTLR13"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-14" name="GCTLR14" port="vts_GCTLR14"/>
+	<mks937b.mks937bImg GCTLR="GCTLR1" channel="1" ctl_channel="0" device="BL21I-VA-IMG-01" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="IMG1" offwarn="1"/>
+	<mks937b.mks937bImg GCTLR="GCTLR1" channel="3" ctl_channel="1" device="BL21I-VA-IMG-02" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="IMG2" offwarn="1"/>
+	<mks937b.mks937bImg GCTLR="GCTLR2" channel="1" ctl_channel="0" device="BL21I-VA-IMG-03" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="IMG3" offwarn="1"/>
+	<mks937b.mks937bImg GCTLR="GCTLR2" channel="3" ctl_channel="1" device="BL21I-VA-IMG-04" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="IMG4"/>
+	<mks937b.mks937bImg GCTLR="GCTLR3" channel="1" ctl_channel="0" device="BL21I-VA-IMG-05" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="IMG5"/>
+	<mks937b.mks937bImg GCTLR="GCTLR4" channel="1" ctl_channel="0" device="BL21I-VA-IMG-06" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="IMG6"/>
+	<mks937b.mks937bImg GCTLR="GCTLR4" channel="3" ctl_channel="1" device="BL21I-VA-IMG-07" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="IMG7"/>
+	<mks937b.mks937bImg GCTLR="GCTLR5" channel="1" ctl_channel="0" device="BL21I-VA-IMG-08" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="IMG8"/>
+	<mks937b.mks937bImg GCTLR="GCTLR6" channel="1" ctl_channel="0" device="BL21I-VA-IMG-09" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="IMG9"/>
+	<mks937b.mks937bImg GCTLR="GCTLR6" channel="3" ctl_channel="1" device="BL21I-VA-IMG-10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="IMG10"/>
+	<mks937b.mks937bImg GCTLR="GCTLR7" channel="1" ctl_channel="0" device="BL21I-VA-IMG-11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="IMG11"/>
+	<!--IMG40 and PIRG40 are not related to each other, so the IMG Enable interlocks need to be ignored.
+i.e. control channel set to None (IMG Enable Gauge)
+and control mode set to Force On (IMG Enable Mode)-->
+	<mks937b.mks937bImg GCTLR="GCTLR7" channel="3" ctl_channel="2" device="BL21I-VA-IMG-40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" img_ctl_setmode="0" name="IMG40"/>
+	<mks937b.mks937bImg GCTLR="GCTLR8" channel="1" device="BL21I-VA-IMG-12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="IMG12"/>
+	<mks937b.mks937bImg GCTLR="GCTLR8" channel="3" ctl_channel="1" device="BL21I-VA-IMG-13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="IMG13"/>
+	<mks937b.mks937bImg GCTLR="GCTLR11" channel="1" device="BL21I-VA-IMG-14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="IMG14"/>
+	<!--<mks937b.mks937bImg GCTLR="GCTLR11" channel="3" ctl_channel="1" device="BL21I-VA-IMG-15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="IMG15"/>-->
+	<mks937b.mks937bImg GCTLR="GCTLR9" channel="1" device="BL21I-VA-IMG-16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="IMG16"/>
+	<mks937b.mks937bImg GCTLR="GCTLR9" channel="3" ctl_channel="1" device="BL21I-VA-IMG-17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="IMG17"/>
+	<mks937b.mks937bImg GCTLR="GCTLR10" channel="1" device="BL21I-VA-IMG-18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="IMG18"/>
+	<mks937b.mks937bImg GCTLR="GCTLR12" channel="1" device="BL21I-VA-IMG-19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="IMG19"/>
+	<mks937b.mks937bImg GCTLR="GCTLR12" channel="3" ctl_channel="1" device="BL21I-VA-IMG-20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="IMG20"/>
+	<mks937b.mks937bImg GCTLR="GCTLR13" channel="1" device="BL21I-VA-IMG-21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="IMG21"/>
+	<!--IMG41 / IMG30 swapped for I21-777-->
+	<mks937b.mks937bImg GCTLR="GCTLR13" channel="3" ctl_channel="1" device="BL21I-VA-IMG-41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="IMG41"/>
+	<mks937b.mks937bImg GCTLR="GCTLR14" channel="1" ctl_channel="2" device="BL21I-VA-IMG-30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="IMG30"/>
+	<mks937b.mks937bImg GCTLR="GCTLR14" channel="3" ctl_channel="2" device="BL21I-VA-IMG-42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="IMG42"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR1" channel="5" device="BL21I-VA-PIRG-01" name="PIRG1" offwarn="1"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR1" channel="6" device="BL21I-VA-PIRG-02" name="PIRG2" offwarn="1"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR2" channel="5" device="BL21I-VA-PIRG-03" name="PIRG3" offwarn="1"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR2" channel="6" device="BL21I-VA-PIRG-04" name="PIRG4"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR3" channel="5" device="BL21I-VA-PIRG-05" name="PIRG5"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR4" channel="5" device="BL21I-VA-PIRG-06" name="PIRG6"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR4" channel="6" device="BL21I-VA-PIRG-07" name="PIRG7"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR5" channel="5" device="BL21I-VA-PIRG-08" name="PIRG8"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR6" channel="5" device="BL21I-VA-PIRG-09" name="PIRG9"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR6" channel="6" device="BL21I-VA-PIRG-10" name="PIRG10"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR7" channel="5" device="BL21I-VA-PIRG-11" name="PIRG11"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR7" channel="6" device="BL21I-VA-PIRG-40" name="PGM.PIRG40"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR8" channel="5" device="BL21I-VA-PIRG-12" name="PIRG12"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR8" channel="6" device="BL21I-VA-PIRG-13" name="PIRG13"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR11" channel="5" device="BL21I-VA-PIRG-14" name="PIRG14"/>
+	<!--<mks937b.mks937bPirg GCTLR="GCTLR11" channel="6" device="BL21I-VA-PIRG-15" name="PIRG15"/>-->
+	<mks937b.mks937bPirg GCTLR="GCTLR9" channel="5" device="BL21I-VA-PIRG-16" name="PIRG16"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR9" channel="6" device="BL21I-VA-PIRG-17" name="PIRG17"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR10" channel="5" device="BL21I-VA-PIRG-18" name="PIRG18"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR12" channel="5" device="BL21I-VA-PIRG-19" name="PIRG19"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR12" channel="6" device="BL21I-VA-PIRG-20" name="PIRG20"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR13" channel="5" device="BL21I-VA-PIRG-21" name="PIRG21"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR13" channel="6" device="BL21I-VA-PIRG-41" name="PIRG41"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR14" channel="5" device="BL21I-VA-PIRG-30" name="PIRG30"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR14" channel="6" device="BL21I-VA-PIRG-42" name="PIRG42"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-01" dom="BL21I" id="01" name="GAUGE1" plog_adc_pv="BL21I-VA-ERIO-01:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-01" dom="BL21I" id="02" name="GAUGE2" plog_adc_pv="BL21I-VA-ERIO-01:MOD1:INPUT2:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-02" dom="BL21I" id="03" name="GAUGE3" plog_adc_pv="BL21I-VA-ERIO-01:MOD1:INPUT3:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-02" dom="BL21I" id="04" name="GAUGE4" plog_adc_pv="BL21I-VA-ERIO-01:MOD1:INPUT4:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-03" dom="BL21I" id="05" name="GAUGE5" plog_adc_pv="BL21I-VA-ERIO-01:MOD2:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-04" dom="BL21I" id="06" name="GAUGE6" plog_adc_pv="BL21I-VA-ERIO-01:MOD2:INPUT3:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-04" dom="BL21I" id="07" name="GAUGE7" plog_adc_pv="BL21I-VA-ERIO-01:MOD2:INPUT4:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-05" dom="BL21I" id="08" name="GAUGE8" plog_adc_pv="BL21I-VA-ERIO-01:MOD3:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-06" dom="BL21I" id="09" name="GAUGE9" plog_adc_pv="BL21I-VA-ERIO-02:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-06" dom="BL21I" id="10" name="GAUGE10" plog_adc_pv="BL21I-VA-ERIO-02:MOD1:INPUT2:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-07" dom="BL21I" id="11" name="GAUGE11" plog_adc_pv="BL21I-VA-ERIO-02:MOD1:INPUT3:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-07" dom="BL21I" id="40" name="GAUGE40" plog_adc_pv="BL21I-VA-ERIO-02:MOD1:INPUT4:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-08" dom="BL21I" id="12" name="GAUGE12" plog_adc_pv="BL21I-VA-ERIO-03:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-08" dom="BL21I" id="13" name="GAUGE13" plog_adc_pv="BL21I-VA-ERIO-03:MOD1:INPUT2:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-11" dom="BL21I" id="14" name="GAUGE14" plog_adc_pv="BL21I-VA-ERIO-03:MOD2:INPUT3:VALUE"/>
+	<!--<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-11" dom="BL21I" id="15" name="GAUGE15" plog_adc_pv="BL21I-VA-ERIO-03:MOD2:INPUT4:VALUE"/>-->
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-09" dom="BL21I" id="16" name="GAUGE16" plog_adc_pv="BL21I-VA-ERIO-03:MOD1:INPUT3:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-09" dom="BL21I" id="17" name="GAUGE17" plog_adc_pv="BL21I-VA-ERIO-03:MOD1:INPUT4:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-10" dom="BL21I" id="18" name="GAUGE18" plog_adc_pv="BL21I-VA-ERIO-03:MOD2:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-12" dom="BL21I" id="19" name="GAUGE19" plog_adc_pv="BL21I-VA-ERIO-04:MOD3:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-12" dom="BL21I" id="20" name="GAUGE20" plog_adc_pv="BL21I-VA-ERIO-04:MOD3:INPUT2:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-13" dom="BL21I" id="21" name="GAUGE21" plog_adc_pv="BL21I-VA-ERIO-04:MOD3:INPUT3:VALUE"/>
+	<!--41 and 42 have separated IMGs and PIRGs, but gauge template is still required for IMG Enable interlocks-->
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-13" dom="BL21I" id="41" name="GAUGE41" plog_adc_pv="BL21I-VA-ERIO-04:MOD3:INPUT4:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-14" dom="BL21I" id="30" name="GAUGE30" plog_adc_pv="BL21I-VA-ERIO-04:MOD4:INPUT1:VALUE"/>
+	<!--41 and 42 have separated IMGs and PIRGs, but gauge template is still required for IMG Enable interlocks-->
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-14" dom="BL21I" id="42" name="GAUGE42" plog_adc_pv="BL21I-VA-ERIO-04:MOD4:INPUT2:VALUE"/>
+	<mks937b.mks937bRelays GAUGE="IMG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY1" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-8" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY2" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY3" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY4" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY5" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-8" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY6" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY7" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY8" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY9" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG1" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="RLY10" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY11" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG2" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="RLY12" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY13" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY14" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY15" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY16" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY17" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY18" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY19" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY20" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY21" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG3" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="RLY22" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY23" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG4" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="RLY24" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY25" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY26" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY27" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY28" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY33" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="RLY34" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY29" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY30" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY31" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY32" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY37" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY38" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY39" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY40" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY35" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG6" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="RLY36" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY45" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG7" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="RLY46" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY41" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY42" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY43" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY44" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY47" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG8" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="RLY48" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY49" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY50" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY51" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY52" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY53" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY54" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY55" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY56" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY57" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG9" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="RLY58" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY59" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG10" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="RLY60" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY61" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY62" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY63" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY64" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY61a" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY62a" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY63a" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY64a" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY65" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG11" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="RLY66" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PGM.PIRG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY65a" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PGM.PIRG40" ilk_write_access_pv="BL21I-VA-GAUGE-40:ILKSETSP:NOWRITE" name="RLY66a" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="10" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY67" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY68" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY69" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY70" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY71" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY72" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY73" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY74" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY75" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG12" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="RLY76" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY77" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG13" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="RLY78" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY79" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY80" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY81" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY82" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<!--<mks937b.mks937bRelays GAUGE="IMG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY83" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>-->
+	<!--<mks937b.mks937bRelays GAUGE="IMG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY84" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>-->
+	<!--<mks937b.mks937bRelays GAUGE="IMG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY85" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>-->
+	<!--<mks937b.mks937bRelays GAUGE="IMG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY86" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>-->
+	<mks937b.mks937bRelays GAUGE="PIRG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY87" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG14" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="RLY88" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<!--<mks937b.mks937bRelays GAUGE="PIRG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY89" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>-->
+	<!--<mks937b.mks937bRelays GAUGE="PIRG15" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="RLY90" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>-->
+	<mks937b.mks937bRelays GAUGE="IMG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY91" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY92" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY93" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY94" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY95" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY96" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY97" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY98" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY99" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG16" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="RLY100" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY101" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG17" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="RLY102" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY103" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY104" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY105" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY106" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY107" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG18" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="RLY108" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY109" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY110" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY111" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY112" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY113" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY114" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY115" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY116" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY117" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG19" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="RLY118" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY119" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG20" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="RLY120" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY121" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY122" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY123" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY124" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY125" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY126" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY127" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY128" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY129" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG21" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="RLY130" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY131" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG30" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="RLY132" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_drvl="2.7e-10" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_lolo="2.6e-10" relay_lopr="2.7e-10" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off" relay_off_level="0.0"/>
+	<mks937b.mks937bRelays GAUGE="IMG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY133" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY134" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY135" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY136" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY137" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY138" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY139" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY140" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY141" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG41" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="RLY142" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY143" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG42" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="RLY144" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG1" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-01:ILKSETSP:NOWRITE" name="FRLY1"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG2" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-02:ILKSETSP:NOWRITE" name="FRLY2"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG3" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-03:ILKSETSP:NOWRITE" name="FRLY3"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG4" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-04:ILKSETSP:NOWRITE" name="FRLY4"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG5" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-05:ILKSETSP:NOWRITE" name="FRLY5"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG6" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-06:ILKSETSP:NOWRITE" name="FRLY6"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG7" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-07:ILKSETSP:NOWRITE" name="FRLY7"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG8" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-08:ILKSETSP:NOWRITE" name="FRLY8"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG9" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-09:ILKSETSP:NOWRITE" name="FRLY9"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG10" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-10:ILKSETSP:NOWRITE" name="FRLY10"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG11" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-11:ILKSETSP:NOWRITE" name="FRLY11"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG12" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-12:ILKSETSP:NOWRITE" name="FRLY12"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG13" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-13:ILKSETSP:NOWRITE" name="FRLY13"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG14" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-14:ILKSETSP:NOWRITE" name="FRLY14"/>
+	<!--<mks937b.mks937bFastRelay GAUGE="IMG15" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-15:ILKSETSP:NOWRITE" name="FRLY15"/>-->
+	<mks937b.mks937bFastRelay GAUGE="IMG16" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-16:ILKSETSP:NOWRITE" name="FRLY16"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG17" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-17:ILKSETSP:NOWRITE" name="FRLY17"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG18" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-18:ILKSETSP:NOWRITE" name="FRLY18"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG19" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-19:ILKSETSP:NOWRITE" name="FRLY19"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG20" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-20:ILKSETSP:NOWRITE" name="FRLY20"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG21" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-21:ILKSETSP:NOWRITE" name="FRLY21"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG30" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-30:ILKSETSP:NOWRITE" name="FRLY30"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG41" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-41:ILKSETSP:NOWRITE" name="FRLY41"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG42" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-42:ILKSETSP:NOWRITE" name="FRLY42"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-01" gauge0="GAUGE1" gauge1="GAUGE2" img0="IMG1" img1="IMG2" ionp0="IONP1" ionp1="IONP2" ionp2="IONP3" name="SP1" pirg0="PIRG1" pirg1="PIRG2" valve0="FEV2"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-02" gauge0="GAUGE3" img0="IMG3" ionp0="IONP4" name="SP2" pirg0="PIRG3" valve0="V1"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-03" gauge0="GAUGE4" img0="IMG4" ionp0="IONP5" ionp1="IONP6" name="SP3" pirg0="PIRG4" valve0="V2"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-04" gauge0="GAUGE5" img0="IMG5" ionp0="IONP7" ionp1="IONP8" name="SP4" pirg0="PIRG5" valve0="V3"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-05" gauge0="GAUGE6" img0="IMG6" ionp0="IONP9" ionp1="IONP10" name="SP5" pirg0="PIRG6" valve0="V4"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-06" gauge0="GAUGE7" img0="IMG7" ionp0="IONP11" name="SP6" pirg0="PIRG7" valve0="V5"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-07" gauge0="GAUGE8" img0="IMG8" ionp0="IONP12" ionp1="IONP13" name="SP7" pirg0="PIRG8" valve0="V6"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-08" gauge0="GAUGE9" img0="IMG9" ionp0="IONP14" name="SP8" pirg0="PIRG9" valve0="V7"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-09" gauge0="GAUGE10" img0="IMG10" ionp0="IONP15" name="SP9" pirg0="PIRG10" valve0="V8"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-10" gauge0="GAUGE11" img0="IMG11" ionp0="IONP16" ionp1="IONP17" name="SP10" pirg0="PIRG11" valve0="V9"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-11" gauge0="GAUGE12" img0="IMG12" ionp0="IONP18" name="SP11" pirg0="PIRG12" valve0="V10"/>
+	<!--<vacuumSpace.space_b device="BL21I-VA-SPACE-12" gauge0="GAUGE13" img0="IMG13" ionp0="IONP19" name="SP12" pirg0="PIRG13" valve0="V51"/>-->
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-12" gauge0="GAUGE13" img0="IMG13" ionp0="IONP19" name="SP12" pirg0="PIRG13"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-13" gauge0="GAUGE16" img0="IMG16" ionp0="IONP21" name="SP13" pirg0="PIRG16" valve0="V12"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-14" gauge0="GAUGE17" img0="IMG17" ionp0="IONP22" name="SP14" pirg0="PIRG17" valve0="V13"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-15" gauge0="GAUGE18" gauge1="GAUGE19" img0="IMG18" img1="IMG19" ionp0="IONP23" ionp1="IONP24" name="SP15" pirg0="PIRG18" pirg1="PIRG19" valve0="V14"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-16" gauge0="GAUGE20" img0="IMG20" ionp0="IONP25" name="SP16" pirg0="PIRG20" valve0="V15"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-17" gauge0="GAUGE21" img0="IMG21" ionp0="IONP26" ionp1="IONP27" name="SP17" pirg0="PIRG21" valve0="V16"/>
+	<!--<dlsPLC.reboot_rga addr="108" device="BL21I-VA-RGA-02" name="RGARB2" port="fins_VLVCC1"/>-->
+	<!--<dlsPLC.reboot_rga addr="109" device="BL21I-VA-RGA-03" name="RGARB3" port="fins_VLVCC1"/>-->
+	<!--<dlsPLC.reboot_rga addr="110" device="BL21I-VA-RGA-04" name="RGARB4" port="fins_VLVCC2"/>-->
+	<dlsPLC.interlock addr="90" desc="Front End Absorber" device="BL21I-VA-VLVCC-01" ilk0="inivac V1-4 + IMG1-6" ilk1="V1 Ope&amp;No close req" ilk10="ABSORBER-01" ilk11="Critical MPS" ilk12="VLVCC-02 Permit" ilk13="Temp Absorber Lo Lo FLow" ilk14="Temp Absorber T1" ilk15="FM open" ilk2="V2 Ope&amp;No close req" ilk3="V3 Ope&amp;No close req" ilk4="V1,2,3 Air T/2" ilk5="Vac MPS Limits" ilk6="GBC-01" ilk7="SLITS-01" ilk8="DIAGON" ilk9="MIRROR-01" interlock=":INT1" name="VLVCC1.ILK1" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="800" desc="GBC-01" device="BL21I-VA-VLVCC-01" ilk0="GBC-01 Lo Lo Flow" ilk1="GBC-01 T1" ilk2="GBC-01 T2" ilk3="unused" interlock=":INT2" name="VLVCC1.ILK2" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="810" desc="SLITS-01" device="BL21I-VA-VLVCC-01" ilk0="SLITS-01 Lo Lo Flow" ilk1="SLITS-01 T1" ilk2="SLITS-01 T2" ilk3="SLITS-01 T3" ilk4="SLITS-01 T4" interlock=":INT3" name="VLVCC1.ILK3" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="820" desc="DIAGON and D1" device="BL21I-VA-VLVCC-01" ilk0="DIAGON Lo Lo FLow" ilk1="DIAGON T1" ilk2="D1 Lo Lo FLow" ilk3="D1 T1" interlock=":INT4" name="VLVCC1.ILK4" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="830" desc="Critical MPS" device="BL21I-VA-VLVCC-01" ilk0="FM closed &gt;100ms" interlock=":INT5" name="VLVCC1.ILK5" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="840" desc="Motion Limits" device="BL21I-VA-VLVCC-01" interlock=":INT6" name="VLVCC1.ILK6" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="850" desc="MIRROR-01" device="BL21I-VA-VLVCC-01" ilk0="MIRROR-01 Lo Lo Flow" ilk1="MIRROR MASK T" ilk2="MIRROR UPSTREAM T" ilk3="MIRROR COOLING BLOCK" ilk4="unused" interlock=":INT7" name="VLVCC1.ILK7" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="860" desc="ABSORBER-01" device="BL21I-VA-VLVCC-01" ilk0="ABSORBER-01 Lo Lo Flow" ilk1="ABSORBER-01 T1" ilk2="unused" interlock=":INT8" name="VLVCC1.ILK8" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="870" desc="Vac MPS Limits" device="BL21I-VA-VLVCC-01" ilk0="IMG-01 MPS1" ilk1="IMG-02 MPS1" ilk2="IMG-03 MPS1" ilk3="IMG-04 MPS1" ilk4="IMG-05 MPS1" ilk5="IMG-6,7,8,9 MPS1" interlock=":INT9" name="VLVCC1.ILK9" port="fins_VLVCC1"/>
+	<dlsPLC.interlock addr="90" desc="VLVCC-02" device="BL21I-VA-VLVCC-02" ilk0="SLITS-02" ilk1="SLITS-03" ilk2="PHDGN-02" ilk3="PHDGN-03" ilk4="MIRROR-02" ilk5="V4 Open" ilk6="V5 Open" ilk7="V6 Open" ilk8="VLVCC-03" interlock=":INT1" name="VLVCC2.ILK1" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="800" desc="SLITS-02" device="BL21I-VA-VLVCC-02" ilk0="SLITS-02 Lo Lo Flow" ilk1="SLITS-02 T1" ilk2="SLITS-02 T2" ilk3="SLITS-02 T3" ilk4="SLITS-02 T4" interlock=":INT2" name="VLVCC2.ILK2" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="810" desc="SLITS-03" device="BL21I-VA-VLVCC-02" ilk0="SLITS-03 Lo Lo Flow" ilk1="SLITS-03 T1" ilk2="SLITS-03 T2" ilk3="SLITS-03 T3" ilk4="SLITS-03 T4" interlock=":INT3" name="VLVCC2.ILK3" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="820" desc="PHDGN-02" device="BL21I-VA-VLVCC-02" ilk0="PHDGN-02 Lo Lo Flow" ilk1="PHDGN-02 T1" ilk2="PHDGN-02 T1" ilk3="unused" interlock=":INT4" name="VLVCC2.ILK4" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="830" desc="PHDGN-03" device="BL21I-VA-VLVCC-02" ilk0="PHDGN-03 Lo Lo Flow" ilk1="PHDGN-03 T1" ilk2="PHDGN-03 T1" interlock=":INT5" name="VLVCC2.ILK5" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="840" desc="MIRROR-02" device="BL21I-VA-VLVCC-02" ilk0="MIRROR-02 Lo Lo Flow" ilk1="MIRROR-02 T1" ilk2="MIRROR-02 T2" ilk3="MIRROR-02 T3" interlock=":INT6" name="VLVCC2.ILK6" port="fins_VLVCC2"/>
+	<dlsPLC.interlock addr="90" desc="VLVCC-03" device="BL21I-VA-VLVCC-03" ilk0="V7 Open" ilk1="V8 Open" ilk2="PGM Interlocks" ilk3="OC1 Interlocks" ilk4="PIRG 40 IonP I/L" interlock=":INT1" name="VLVCC3.ILK1" port="fins_VLVCC3"/>
+	<dlsPLC.interlock addr="800" desc="PGM Interlocks" device="BL21I-VA-VLVCC-03" ilk0="PGM 0 Ord Stop Flow" ilk1="PGM Grating Flow" ilk2="PGM Mirror Flow" ilk3="PGM Mirror Temp" ilk4="PGM VPG1 Temp" ilk5="PGM VPG3 Temp" ilk6="PGM VPG2 Temp" ilk7="PGM VPG4 Temp" ilk8="H20 shutoff vlv open" interlock=":INT2" name="VLVCC3.ILK2" port="fins_VLVCC3"/>
+	<dlsPLC.interlock addr="810" desc="OC1 Interlocks" device="BL21I-VA-VLVCC-03" ilk0="S4 Water" ilk1="D4 Water" ilk2="ABS-02 T1" ilk3="D4 T1" interlock=":INT3" name="VLVCC3.ILK3" port="fins_VLVCC3"/>
+	<dlsPLC.interlock addr="800" desc="M4 M5 TTH Interlocks" device="BL21I-VA-VLVCC-04" ilk0="M4 Vert Fwd O/T" ilk1="M4 Vert Rev O/T" ilk2="M5 Vert Fwd O/T" ilk3="M5 Vert Rev O/T" ilk4="TTH Rot Fwd O/T" ilk5="TTH Rot Rev O/T" interlock=":INT1" name="M4.ILK1" port="fins_VLVCC4"/>
+	<!--<dlsPLC.interlock addr="800" desc="ELAN Interlocks" device="BL21I-VA-VLVCC-05" ilk0="ELAN Blah blah blah" ilk1="ELAN blah blah?" ilk2="Blah" ilk3="blahhhhhh" interlock=":INT1" name="ELAN.ILK1" port="fins_VLVCC5"/>-->
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-04:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-04:INT1:RAWILK CP" INPB="BL21I-VA-VLVCC-04:INT1:INIILK CP" INPC="BL21I-VA-VLVCC-04:INT1:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-04:INT1:STATE_RBV"/>
+	<!--Records used to provide a summary monitor for all the interlocks on VLVCC-04 related to the spectrometer.
+
+See CSS gui, interlock summary screen.-->
+	<records.calc CALC="A" INPA="BL21I-VA-VLVCC-04:INT1:STATE_RBV" SCAN="Passive" record="BL21I-VA-VLVCC-04:INT:STATE_RBV"/>
+</components>

--- a/tests/samples/catio/BL21I-VA-IOC-04.xml
+++ b/tests/samples/catio/BL21I-VA-IOC-04.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<EPICS_BASE.EpicsEnvSet key="EPICS_CA_AUTO_ADDR_LIST" value="NO"/>
+	<EPICS_BASE.EpicsEnvSet key="EPICS_CA_ADDR_LIST" value="172.23.121.255"/>
+	<devIocStats.devIocStatsHelper ioc="BL21I-VA-IOC-04" name="BL21I-VA-IOC-04.DEVIOCSTATS"/>
+	<autosave.Autosave bl="True" iocName="BL21I-VA-IOC-04" name="BL21I-VA-IOC-04.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="VA4.PVLOGGING"/>
+	<FINS.FINSUDPInit ip="10.121.3.7" name="fins_VLVCC7" simulation="localhost:11107"/>
+	<FINS.FINSUDPInit ip="10.121.3.8" name="fins_VLVCC8" simulation="localhost:11108"/>
+	<FINS.FINSUDPInit ip="10.121.3.9" name="fins_VLVCC9" simulation="localhost:11109"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-07" name="VLVCC7.0" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-07" name="VLVCC7.1" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-07" name="VLVCC7.2" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-07" name="VLVCC7.3" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-07" name="VLVCC7.4" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="7" device="BL21I-VA-VLVCC-07" name="VLVCC7.7" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-07" name="VLVCC7.8" port="fins_VLVCC7"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-08" name="VLVCC8.0" port="fins_VLVCC8"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-08" name="VLVCC8.1" port="fins_VLVCC8"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-08" name="VLVCC8.2" port="fins_VLVCC8"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-08" name="VLVCC8.3" port="fins_VLVCC8"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-08" name="VLVCC8.4" port="fins_VLVCC8"/>
+	<dlsPLC.read100 SCAN=".1 second" century="8" device="BL21I-VA-VLVCC-08" name="VLVCC8.8" port="fins_VLVCC8"/>
+	<dlsPLC.read100 century="0" device="BL21I-VA-VLVCC-09" name="VLVCC9.0" port="fins_VLVCC9"/>
+	<dlsPLC.read100 century="1" device="BL21I-VA-VLVCC-09" name="VLVCC9.1" port="fins_VLVCC9"/>
+	<dlsPLC.read100 century="2" device="BL21I-VA-VLVCC-09" name="VLVCC9.2" port="fins_VLVCC9"/>
+	<dlsPLC.read100 century="3" device="BL21I-VA-VLVCC-09" name="VLVCC9.3" port="fins_VLVCC9"/>
+	<dlsPLC.read100 century="4" device="BL21I-VA-VLVCC-09" name="VLVCC9.4" port="fins_VLVCC9"/>
+	<dlsPLC.read100 century="8" device="BL21I-VA-VLVCC-09" name="VLVCC9.8" port="fins_VLVCC9"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 18" device="BL21I-VA-VALVE-18" gilk0="Gauge 24" gilk1="Gauge 25" ilk0="Air Pressure" ilk1="IMG24" ilk15="Valve Fault" ilk2="IMG25" ilk3="PIRG24 &amp; Ser" ilk4="PIRG25 &amp; Ser" name="V18" port="fins_VLVCC7" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.vacValveDebounce addr="10" desc="Valve 19" device="BL21I-VA-VALVE-19" gilk0="Gauge 25" gilk1="Gauge 26" ilk0="Air Pressure" ilk1="IMG25" ilk15="Valve Fault" ilk2="IMG26" ilk3="PIRG25 &amp; Ser" ilk4="PIRG26 &amp; Ser" name="V19" port="fins_VLVCC8" vlvcc="BL21I-VA-VLVCC-08"/>
+	<!--<dlsPLC.vacValveDebounce addr="10" desc="Valve 70" device="BL21I-VA-VALVE-70" gilk0="Gauge 27" gilk1="Gauge 28" ilk0="Air Pressure" ilk1="IMG27" ilk15="Valve Fault" ilk2="IMG21" ilk3="V16 Closed" ilk4="V17 Closed" name="V70" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>-->
+	<dlsPLC.vacValveDebounce addr="20" desc="Valve 72" device="BL21I-VA-VALVE-72" gilk0="Gauge 27" gilk1="Gauge 28" ilk0="Air Pressure" ilk1="V73 Open" ilk15="Valve Fault" ilk2="Turbo4 On" ilk3="V75 Closed" ilk4="V74 Closed" ilk5="PIRG27" ilk6="PIRG28" name="V72" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.vacValveDebounce addr="30" desc="Valve 73" device="BL21I-VA-VALVE-73" gilk0="Gauge 27" gilk1="Gauge 28" ilk0="Scrol 3 On" ilk1="Scrol 3 @ speed" ilk15="Valve Fault" ilk2="V74 Closed" name="V73" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.vacValveDebounce addr="40" desc="Valve 74" device="BL21I-VA-VALVE-74" gilk0="Gauge 27" gilk1="Gauge 28" ilk0="Scrol 3 On" ilk1="V72 Closed" ilk15="Valve Fault" ilk2="V73 Closed" ilk3="V70 Closed/Service" ilk4="V75 Closed" name="V74" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.vacValveDebounce addr="50" desc="Valve 75 Vent" device="BL21I-VA-VALVE-75" gilk0="Gauge 27" gilk1="Gauge 28" ilk0="V72 Closed" ilk1="V74 Closed" ilk15="Valve Fault" ilk2="V70 Closed" name="V75" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<!--ZNAM field in bi records from dlsPLC_vacValveDebounce uses 'ilk'name and is limited to 20char
+(-> resolved here by shortening ilk names).
+
+Device name too long to enable $(device):RAWAIRSTAINP scalcout record to process (6 char too many in AA field)-->
+	<dlsPLC.vacValveDebounce addr="840" desc="SGM Traveller Air" device="BL21I-OP-SGM-01:TVLR:AIR" ilk0="Inboard Rack Sln off" ilk1="Granite Solenoid off" ilk2="OutbdDet Rot Sln off" name="SGM.Valves.TravellerAir" port="fins_VLVCC7" vlvcc="BL21I-VA-VLVCC-07"/>
+	<!--ZNAM field in bi records from dlsPLC_vacValveDebounce uses 'ilk'name and is limited to 20char
+(-> resolved here by shortening ilk names).
+
+Device name too long to enable $(device):RAWAIRSTAINP scalcout record to process (10 char too many in AA field)-->
+	<dlsPLC.vacValveDebounce addr="850" desc="Granite and Racks Air" device="BL21I-MO-ARM-01:TTH:GRNT:AIR" ilk0="SGM Travlr Soln off" name="TTH.Valves.GraniteAir" port="fins_VLVCC7" vlvcc="BL21I-VA-VLVCC-07"/>
+	<!--ZNAM field in bi records from dlsPLC_vacValveDebounce uses 'ilk'name and is limited to 20char
+(-> resolved here by shortening ilk names).
+
+Device name too long to enable $(device):RAWAIRSTAINP scalcout record to process (10 char too many in AA field)-->
+	<dlsPLC.vacValveDebounce addr="840" desc="Marble (Detector and Racks) Air" device="BL21I-MO-ARM-01:TTH:MRBL:AIR" ilk0="SGM Travlr Soln off" name="TTH.Valves.MarbleAir" port="fins_VLVCC8" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.vacValveBistable addr="10" cilk0="Air Pressure" cilk1="Arm out" cilk2="Enable close" device="BL21I-VA-VALVE-70" ilk0="Air Pressure" ilk1="IMG27" ilk15="Valve Fault" ilk2="IMG21" ilk3="V16 Closed" ilk4="V17 Closed" ilk5="Arm out" name="V70" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.vacValveBistable addr="60" cilk0="Air Pressure" cilk1="Arm out" cilk2="Enable close" device="BL21I-VA-VALVE-76" ilk0="Air Pressure" ilk1="IMG29" ilk15="Valve Fault" ilk2="IMG21" ilk3="V16 Closed" ilk4="V17 Closed" ilk5="Arm out" name="V76" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<!--<dlsPLC.vacPump device="BL21I-VA-SCROL-01" name="SCR1"/>-->
+	<!--<dlsPLC.vacPump device="BL21I-VA-SCROL-02" name="SCR2"/>-->
+	<dlsPLC.vacPump addr="70" device="BL21I-VA-SCROL-03" name="SCR3" port="fins_VLVCC9" pumptype="scroll" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.vacPump addr="80" device="BL21I-VA-TURBO-04" ilk0="Scrol 3 On" ilk1="PIRG28" ilk15="Valve Fault" name="TRB4" port="fins_VLVCC9" vlvcc="BL21I-VA-VLVCC-09"/>
+	<dlsPLC.externalValve device="BL21I-VA-VALVE-17" name="V17E"/>
+	<!--<dlsPLC.temperature desc="Smarpod Temp 1" device="BL21I-EA-SMPL-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="SMPL.Temp1" offset="10" port="fins_VLVCC8" temp=":TEMP1" tmpcc="BL21I-VA-VLVCC-08"/>-->
+	<!--<dlsPLC.temperature desc="M5 Rotation Temp 1" device="BL21I-EA-SMPL-01" high="45" hihi="50" hopr="50" lolo="0" lopr="0" low="0" name="SMPL.Temp2" offset="10" port="fins_VLVCC8" temp=":TEMP2" tmpcc="BL21I-VA-VLVCC-08"/>-->
+	<!--<dlsPLC.flow DESC="PS8 Flow 1" P="BL21I-RS-STAND-08" Q=":FLOW1" device="BL21I-VA-VLVCC-08" loaddress="4" lobit="0" loloaddress="808" lolobit="0" name="PS8.Flow1"/>-->
+	<!--<dlsPLC.flow DESC="PS8 Flow 2" P="BL21I-RS-STAND-08" Q=":FLOW2" device="BL21I-VA-VLVCC-08" loaddress="4" lobit="1" loloaddress="818" lolobit="0" name="PS8.Flow2"/>-->
+	<asyn.AsynIP name="vts_MPC13" port="bl21i-va-tserv-07:7001"/>
+	<asyn.AsynIP name="vts_MPC14" port="bl21i-va-tserv-08:7001"/>
+	<asyn.AsynIP name="vts_MPC15" port="bl21i-va-tserv-08:7002"/>
+	<asyn.AsynIP name="vts_MPC16" port="bl21i-va-tserv-06:7001"/>
+	<asyn.AsynIP name="vts_GCTLR15" port="bl21i-va-tserv-07:7009"/>
+	<asyn.AsynIP name="vts_GCTLR16" port="bl21i-va-tserv-08:7009"/>
+	<asyn.AsynIP name="vts_GCTLR17" port="bl21i-va-tserv-06:7009"/>
+	<asyn.AsynIP name="vts_GCTLR18" port="bl21i-va-tserv-06:7010"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-13" name="MPC13" port="vts_MPC13"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-14" name="MPC14" port="vts_MPC14"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-15" name="MPC15" port="vts_MPC15"/>
+	<digitelMpc.digitelMpc device="BL21I-VA-MPC-16" name="MPC16" port="vts_MPC16"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC13" device="BL21I-VA-IONP-33" name="IONP33" pump="1" size="200" text="BL21I-VA-IONP-33"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC13" device="BL21I-VA-IONP-34" name="IONP34" pump="2" size="400" text="BL21I-VA-IONP-34"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC14" device="BL21I-VA-IONP-35" name="IONP35" pump="1" size="300" text="BL21I-VA-IONP-35-38"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC14" device="BL21I-VA-IONP-38" name="IONP38" pump="1" size="300" text="BL21I-VA-IONP-35-38"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC14" device="BL21I-VA-IONP-36" name="IONP36" pump="2" size="200" text="BL21I-VA-IONP-36"/>
+	<digitelMpc.digitelMpcIonp MPC="MPC15" device="BL21I-VA-IONP-37" name="IONP37" pump="1" size="100" text="BL21I-VA-IONP-37"/>
+	<!--Ion pump for the sample storage
+see drawing 1091226 p22-->
+	<digitelMpc.digitelMpcIonp MPC="MPC16" device="BL21I-VA-IONP-40" name="IONP40" pump="1" size="45" text="BL21I-VA-IONP-40"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-15" name="GCTLR15" port="vts_GCTLR15"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-16" name="GCTLR16" port="vts_GCTLR16"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-17" name="GCTLR17" port="vts_GCTLR17"/>
+	<mks937b.mks937b address="1" device="BL21I-VA-GCTLR-18" name="GCTLR18" port="vts_GCTLR18"/>
+	<mks937b.mks937bImg GCTLR="GCTLR15" channel="1" device="BL21I-VA-IMG-24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="IMG24"/>
+	<mks937b.mks937bImg GCTLR="GCTLR16" channel="1" device="BL21I-VA-IMG-25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="IMG25"/>
+	<mks937b.mks937bImg GCTLR="GCTLR16" channel="3" device="BL21I-VA-IMG-26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="IMG26"/>
+	<mks937b.mks937bImg GCTLR="GCTLR17" channel="1" device="BL21I-VA-IMG-27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="IMG27"/>
+	<mks937b.mks937bImg GCTLR="GCTLR17" channel="3" device="BL21I-VA-IMG-28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="IMG28"/>
+	<!--IMG gauge for the sample storage
+see drawing 1091226 p20-->
+	<mks937b.mks937bImg GCTLR="GCTLR18" channel="1" device="BL21I-VA-IMG-29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="IMG29"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR15" channel="5" device="BL21I-VA-PIRG-24" name="PIRG24"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR16" channel="5" device="BL21I-VA-PIRG-25" name="PIRG25"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR16" channel="6" device="BL21I-VA-PIRG-26" name="PIRG26"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR17" channel="5" device="BL21I-VA-PIRG-27" name="PIRG27"/>
+	<mks937b.mks937bPirg GCTLR="GCTLR17" channel="6" device="BL21I-VA-PIRG-28" name="PIRG28"/>
+	<!--Pirani gauge for the sample storage
+see drawing 1091226 p20-->
+	<mks937b.mks937bPirg GCTLR="GCTLR18" channel="5" device="BL21I-VA-PIRG-29" name="PIRG29"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-15" dom="BL21I" id="24" name="GAUGE24" plog_adc_pv="BL21I-VA-ERIO-05:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-16" dom="BL21I" id="25" name="GAUGE25" plog_adc_pv="BL21I-VA-ERIO-06:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-16" dom="BL21I" id="26" name="GAUGE26" plog_adc_pv="BL21I-VA-ERIO-06:MOD1:INPUT2:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-17" dom="BL21I" id="27" name="GAUGE27" plog_adc_pv="BL21I-VA-ERIO-04:MOD1:INPUT1:VALUE"/>
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-17" dom="BL21I" id="28" name="GAUGE28" plog_adc_pv="BL21I-VA-ERIO-04:MOD1:INPUT2:VALUE"/>
+	<!--Gauge for the sample storage
+see drawing 1091226 p20-->
+	<mks937b.mks937bGauge GCTLR="BL21I-VA-GCTLR-18" dom="BL21I" id="29" name="GAUGE29" plog_adc_pv="BL21I-VA-ERIO-04:MOD2:INPUT1:VALUE"/>
+	<mks937b.mks937bRelays GAUGE="IMG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY139" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY140" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY141" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY142" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY143" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG24" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="RLY144" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY145" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY146" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY147" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY148" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY149" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY150" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY151" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY152" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY153" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG25" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="RLY154" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY155" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG26" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="RLY156" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY157" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-5" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-5"/>
+	<mks937b.mks937bRelays GAUGE="IMG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY158" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY159" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY160" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="IMG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY161" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-5" relay_low="9e-9" relay_number="5" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-5"/>
+	<mks937b.mks937bRelays GAUGE="IMG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY162" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="6" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY163" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="7" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY164" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="8" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY165" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-1" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off" relay_off_level="2.0e-1"/>
+	<mks937b.mks937bRelays GAUGE="PIRG27" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="RLY166" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY167" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-1" relay_low="9e-9" relay_number="11" relay_off_desc="Ion Pump I/L Off" relay_off_level="2.0e-1"/>
+	<mks937b.mks937bRelays GAUGE="PIRG28" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="RLY168" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="12" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bRelays GAUGE="IMG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY169" relay_desc="Valve I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-6" relay_low="9e-9" relay_number="1" relay_off_desc="Valve I/L Off" relay_off_level="1.1e-6"/>
+	<mks937b.mks937bRelays GAUGE="IMG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY170" relay_desc="MPS I/L 1 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="2" relay_off_desc="MPS I/L 1 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY171" relay_desc="MPS I/L 2 On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-7" relay_low="9e-9" relay_number="3" relay_off_desc="MPS I/L 2 Off" relay_off_level="1.1e-7"/>
+	<mks937b.mks937bRelays GAUGE="IMG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY172" relay_desc="RGA I/L On" relay_drvh="1e-3" relay_high="1.5e-4" relay_hihi="1e-3" relay_hopr="1e-3" relay_level="1.0e-4" relay_low="9e-9" relay_number="4" relay_off_desc="RGA I/L Off" relay_off_level="1.1e-4"/>
+	<mks937b.mks937bRelays GAUGE="PIRG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY177" relay_desc="Ion Pump I/L On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="9" relay_off_desc="Ion Pump I/L Off"/>
+	<mks937b.mks937bRelays GAUGE="PIRG29" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="RLY178" relay_desc="MPS I/L 1 On" relay_drvh="9.0e-1" relay_high="9.0e-1" relay_hihi="9.0e-1" relay_hopr="9.0e-1" relay_level="1.0e-2" relay_low="9e-9" relay_number="10" relay_off_desc="MPS I/L 1 Off"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG24" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-24:ILKSETSP:NOWRITE" name="FRLY24"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG25" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-25:ILKSETSP:NOWRITE" name="FRLY25"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG26" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-26:ILKSETSP:NOWRITE" name="FRLY26"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG27" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-27:ILKSETSP:NOWRITE" name="FRLY27"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG28" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-28:ILKSETSP:NOWRITE" name="FRLY28"/>
+	<mks937b.mks937bFastRelay GAUGE="IMG29" frcsp_level="1.0e-5" ilk_write_access_pv="BL21I-VA-GAUGE-29:ILKSETSP:NOWRITE" name="FRLY29"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-18" gauge0="GAUGE24" img0="IMG24" ionp0="IONP33" ionp1="IONP34" name="SP18" pirg0="PIRG24" valve0="V17E"/>
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-19" gauge0="GAUGE25" img0="IMG25" ionp0="IONP35" ionp1="IONP38" ionp2="IONP36" name="SP19" pirg0="PIRG25" valve0="V18"/>
+	<!--Need to add IONP39 when available-->
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-20" gauge0="GAUGE26" img0="IMG26" ionp0="IONP37" name="SP20" pirg0="PIRG26"/>
+	<!--Load Lock Vacuum Space-->
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-72" gauge0="GAUGE27" img0="IMG27" name="LoadLock.72" pirg0="PIRG27" valve0="V70"/>
+	<!--Turbo 4 Vacuum Space-->
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-73" gauge0="GAUGE28" img0="IMG28" name="LoadLock.73" pirg0="PIRG28" valve0="V72"/>
+	<!--Sample storage vacuum space-->
+	<vacuumSpace.space_b device="BL21I-VA-SPACE-74" gauge0="GAUGE29" img0="IMG29" ionp0="IONP40" name="Storage.74" pirg0="PIRG29" valve0="V76"/>
+	<!--<dlsPLC.reboot_rga addr="111" device="BL21I-VA-RGA-05" name="RGARB5" port="fins_VLVCC7"/>-->
+	<!--<dlsPLC.reboot_rga addr="112" device="BL21I-VA-RGA-06" name="RGARB6" port="fins_VLVCC8" timeout="0"/>-->
+	<dlsPLC.interlock addr="800" desc="SGM O/T Interlocks" device="BL21I-VA-VLVCC-07" ilk0="SGM TVLR Fwd O/T" ilk1="SGM TVLR Rev O/T" ilk2="SGM wedge 1 O/T" ilk3="SGM wedge 2 O/T" ilk4="SGM Grat Fwd O/T" ilk5="SGM Grat Rev O/T" ilk6="SGM Pitch Fwd O/T" ilk7="SGM Pitch Rev O/T" interlock=":INT1" name="SGM.ILK1" port="fins_VLVCC7"/>
+	<!--Links to VLVCC4 800-->
+	<dlsPLC.interlock addr="810" desc="Arm O/T Interlocks" device="BL21I-VA-VLVCC-07" ilk0="M4, M5, TTH O/T" ilk1="TTH Diff Fwd O/T" ilk2="TTH Diff Rev O/T" interlock=":INT2" name="TTH.ILK1" port="fins_VLVCC7"/>
+	<!--Links to VLVCC8 850-->
+	<dlsPLC.interlock addr="820" desc="SGM TRVLR Interlocks" device="BL21I-VA-VLVCC-07" ilk0="Spect Range O/T ILKs" ilk1="SGM TVLR Air Flow" ilk2="SGM TVLR Air Pressure" interlock=":INT3" name="SGM.ILK2" port="fins_VLVCC7"/>
+	<!--Links to VLVCC8 800-->
+	<dlsPLC.interlock addr="860" desc="TTH Interlocks" device="BL21I-VA-VLVCC-07" ilk0="TTH DET Air ILKs" ilk1="TTH Granite Air Flow" ilk2="TTH Granite Air Pressure" ilk3="SGM Rot Air Flow" ilk4="SGM Rot Air Pressure" interlock=":INT4" name="TTH.ILK2" port="fins_VLVCC7"/>
+	<dlsPLC.interlock addr="800" desc="TTH DET Air ILKs" device="BL21I-VA-VLVCC-08" ilk0="DET Rack Air Flow" ilk1="DET Rack Air Pressure" ilk10="DET CA09 Air Flow" ilk11="DET CA09 Air Pressure" ilk4="DET CA06 Air Flow" ilk5="DET CA06 Air Pressure" ilk6="DET CA07 Air Flow" ilk7="DET CA07 Air Pressure" ilk8="DET CA08 Air Flow" ilk9="DET CA08 Air Pressure" interlock=":INT1" name="TTH.ILK3" port="fins_VLVCC8"/>
+	<dlsPLC.interlock addr="810" desc="Spectromter O/T ILKs" device="BL21I-VA-VLVCC-08" ilk0="Vert Range O/T" ilk1="Trans Range O/T" ilk2="Spect Horz Fwd O/T" ilk3="Spect Horz Rev O/T" ilk4="Spect Vert Hi O/T" ilk5="Spect Vert Lo O/T" interlock=":INT2" name="ARM.ILK1" port="fins_VLVCC8"/>
+	<dlsPLC.interlock addr="820" desc="POL Y O/T ILKs" device="BL21I-VA-VLVCC-08" ilk0="POL Y Fwd O/T" ilk1="POL Y Rev O/T" interlock=":INT3" name="POL.ILK1" port="fins_VLVCC8"/>
+	<dlsPLC.interlock addr="850" desc="Spect Range O/T ILKs" device="BL21I-VA-VLVCC-08" ilk0="Vert Range O/T" ilk1="Trans Range O/T" interlock=":INT4" name="SGM.ILK3" port="fins_VLVCC8"/>
+	<!--For the fast valve FVALV-12, there is a 20 second protection delay enforced by the PLC before clearing the open and close commands from EPICS (to confirm that fast valve closing mechanism is charged with air, or to ensure that the absorbers close correctly).-->
+	<BL21I.SMPLValveSequence DELAY1="30" P="BL21I-EA-SMPL-01" R=":SEQ" VAC1_NAME="FVALV-12" VAC2_NAME="VALVE-16" VAC3_NAME="SHTR-01" VAC4_NAME="ABSB-02" VAC5_NAME="VALVE-17" VAC_ELEMENT1="BL21I-VA-FVALV-12" VAC_ELEMENT2="BL21I-VA-VALVE-16" VAC_ELEMENT3="BL21I-PS-SHTR-01" VAC_ELEMENT4="BL21I-VA-ABSB-02" VAC_ELEMENT5="BL21I-VA-VALVE-17" name="SMPL.VACSEQ"/>
+	<!--vlvcc-07 (granite) is set-up as master and it controls slave vlvcc-08 (marble).
+Air control demands only need to be made to vlvcc-07, which will in turn switch vlvcc-08 on or off accordingly.-->
+	<BL21I.ARMAirControl AirValveMasterCtrl="BL21I-MO-ARM-01:TTH:GRNT:AIR" AirValveSlaveCtrl="BL21I-MO-ARM-01:TTH:MRBL:AIR" MOTORSTATUS="BL21I-MO-ARM-01:TTH:WHEEL:REAL.MSTA" P="BL21I-MO-ARM-01" R=":TTH:AIR:CNTRL" name="TTHX.Valves.CombinedAirControl"/>
+	<BL21I.SGMTravellerAirControl MOTORSTATUS="BL21I-OP-SGM-01:TVLR.MSTA" P="BL21I-OP-SGM-01" R=":TRAVELLER:AIR:CNTRL" SGMTravellerAirValve="BL21I-OP-SGM-01:TVLR:AIR" name="SGMX.Valves.AirControl"/>
+	<BL21I.AirBearingInterlockWait DESC="ARM Air Bearing Combined Control" MOTORSTATUS="BL21I-MO-ARM-01:TTH:WHEEL.MSTA" OUT="BL21I-MO-ARM-01:TTH:AIR:CNTRL" P="BL21I-MO-ARM-01" R=":TTH:AIR" TIMEOUT="10" name="TTH.AirBearingControl"/>
+	<BL21I.AirBearingInterlockWait DESC="SGM Air Bearing Control" MOTORSTATUS="BL21I-OP-SGM-01:TVLR.MSTA" OUT="BL21I-OP-SGM-01:TRAVELLER:AIR:CNTRL" P="BL21I-OP-SGM-01" R=":TRAVELLER:AIR" TIMEOUT="5" name="SGM.AirBearingControl"/>
+	<dlsPLC.writeInt16 P="BL21I-EA-DET-01" Q=":POWER:SET" addr="860" port="fins_VLVCC8"/>
+	<dlsPLC.writeInt16 P="BL21I-EA-DET-02" Q=":POWER:SET" addr="870" port="fins_VLVCC8"/>
+	<dlsPLC.writeInt16 P="BL21I-EA-DET-03" Q=":POWER:SET" addr="880" port="fins_VLVCC8"/>
+	<dlsPLC.writeEnum P="BL21I-OP-SGM-01" Q=":TVLR:ENC_POWER" STR0="Enabled" STR1="Disabled" addr="320" port="fins_VLVCC7"/>
+	<dlsPLC.writeEnum P="BL21I-MO-ARM-01" Q=":TTH:MOVING:RAW" STR0="Not Expecting Movement" STR1="Expecting Movement" addr="890" port="fins_VLVCC8"/>
+	<dlsPLC.readEnum P="BL21I-OP-SGM-01" Q=":TVLR:ENC_POWER_RBV" STR0="Enabled" STR1="Disabled" addr="321" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:LASER:STATUS:RAW" addr="892" vlvcc="BL21I-VA-VLVCC-08"/>
+	<!--Bits:
+0: Top bump strip depressed
+1: Bottom bump strip depressed
+
+Need to identify the last time these were activated, as they can be easily triggered-->
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:BUMPSTRIP:STATUS:RAW" addr="894" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-SGM-01" Q=":TVLR:AIR:FLOW:RAW" addr="216" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-SGM-01" Q=":TVLR:AIR:PRESSURE:RAW" addr="217" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:GRNT:RACKS:AIR:FLOW:RAW" addr="218" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:GRNT:RACKS:AIR:PRESSURE:RAW" addr="219" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:GRNT:AIR:FLOW:RAW" addr="220" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:GRNT:AIR:PRESSURE:RAW" addr="221" vlvcc="BL21I-VA-VLVCC-07"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:RACKS:AIR:FLOW:RAW" addr="216" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:RACKS:AIR:PRESSURE:RAW" addr="217" vlvcc="BL21I-VA-VLVCC-08"/>
+	<!--Disconnected (but not removed) and replaced by CA06->CA09-->
+	<!--<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:FLOW:RAW" addr="218" vlvcc="BL21I-VA-VLVCC-08"/>-->
+	<!--<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:PRESSURE:RAW" addr="219" vlvcc="BL21I-VA-VLVCC-08"/>-->
+	<!--New set of air pads installed in 2021/2022-->
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA06:FLOW:RAW" addr="210" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA06:PRESSURE:RAW" addr="211" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA07:FLOW:RAW" addr="212" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA07:PRESSURE:RAW" addr="213" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA08:FLOW:RAW" addr="214" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA08:PRESSURE:RAW" addr="215" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA09:FLOW:RAW" addr="220" vlvcc="BL21I-VA-VLVCC-08"/>
+	<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:DET:AIR:CA09:PRESSURE:RAW" addr="221" vlvcc="BL21I-VA-VLVCC-08"/>
+	<!--<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:SSEAL:NTRGN:FLOW:RAW"/>-->
+	<!--<dlsPLC.readInt16 P="BL21I-MO-ARM-01" Q=":TTH:SSEAL:NTRGN:PRESSURE:RAW"/>-->
+	<userIO.ai DESC="SGM Traveller Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-SGM-01" PREC="3" R=":TVLR:AIR:FLOW" SCAN="Passive" name="SGM.FLW1"/>
+	<userIO.ai DESC="SGM Traveller Air Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-SGM-01" PREC="3" R=":TVLR:AIR:PRESSURE" SCAN="Passive" name="SGM.PRS1"/>
+	<userIO.ai DESC="TTH Granite Racks Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:GRNT:RACKS:AIR:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW1"/>
+	<userIO.ai DESC="TTH Granite Racks Air Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:GRNT:RACKS:AIR:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS1"/>
+	<userIO.ai DESC="TTH Granite Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:GRNT:AIR:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW2"/>
+	<userIO.ai DESC="TTH Granite Air Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:GRNT:AIR:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS2"/>
+	<userIO.ai DESC="TTH Detector Racks Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:RACKS:AIR:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW3"/>
+	<userIO.ai DESC="TTH Detector Racks Air Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:RACKS:AIR:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS3"/>
+	<!--<userIO.ai DESC="TTH Detector Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW4"/>-->
+	<!--<userIO.ai DESC="TTH Detector Air Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS4"/>-->
+	<userIO.ai DESC="TTH Detector CA06 Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA06:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW5"/>
+	<userIO.ai DESC="TTH Detector CA06 Air Pressure" DTYP="Soft Channel" EGU=" Bar" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA06:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS5"/>
+	<userIO.ai DESC="TTH Detector CA07 Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA07:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW6"/>
+	<userIO.ai DESC="TTH Detector CA07 Air Pressure" DTYP="Soft Channel" EGU="Bar" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA07:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS6"/>
+	<userIO.ai DESC="TTH Detector CA08 Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA08:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW7"/>
+	<userIO.ai DESC="TTH Detector CA08 Air Pressure" DTYP="Soft Channel" EGU="Bar" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA08:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS7"/>
+	<userIO.ai DESC="TTH Detector CA09 Air Flow" DTYP="Soft Channel" EGU=" L/min" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA09:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW8"/>
+	<userIO.ai DESC="TTH Detector CA09 Air Pressure" DTYP="Soft Channel" EGU=" Bar" EGUF="" EGUL="" INP="" LINR="" P="BL21I-MO-ARM-01" PREC="3" R=":TTH:DET:AIR:CA09:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS8"/>
+	<!--<userIO.ai DESC="TTH Sliding Seal Flow" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:FLOW:RAW CP" LINR="" P="BL21I-MO-ARM-01" PREC="0" R=":TTH:SSEAL:NTRGN:FLOW" SCAN="Passive" name="TTH.AirStatus.FLW5"/>-->
+	<!--<userIO.ai DESC="TTH Sliding Seal Pressure" DTYP="Soft Channel" EGU="" EGUF="" EGUL="" INP="BL21I-MO-ARM-01:TTH:SSEAL:NTRGN:PRESSURE:RAW CP" LINR="" P="BL21I-MO-ARM-01" PREC="0" R=":TTH:SSEAL:NTRGN:PRESSURE" SCAN="Passive" name="TTH.AirStatus.PRS5"/>-->
+	<!--Mock air control PV-->
+	<!--<records.bo DTYP="Soft Channel" ONAM="Air On" PINI="YES" SCAN="Passive" VAL="1" ZNAM="Air Off" record="BL21I-OP-SGM-01:TRAVELLER:AIR"/>-->
+	<records.bo DTYP="Soft Channel" OMSL="supervisory" ONAM="Power Off" OUT="BL21I-EA-DET-01:POWER:SET CA" SCAN="Passive" VAL="1" ZNAM="Power On" name="ANDOR.POWER" record="BL21I-EA-DET-01:POWER"/>
+	<records.bo DTYP="Soft Channel" OMSL="supervisory" ONAM="Power Off" OUT="BL21I-EA-DET-02:POWER:SET CA" SCAN="Passive" VAL="1" ZNAM="Power On" name="POLPI.POWER" record="BL21I-EA-DET-02:POWER"/>
+	<records.bo DTYP="Soft Channel" OMSL="supervisory" ONAM="Power Off" OUT="BL21I-EA-DET-03:POWER:SET CA" SCAN="Passive" VAL="1" ZNAM="Power On" name="POLSIGMA.POWER" record="BL21I-EA-DET-03:POWER"/>
+	<!--Tells VLVCC8 when we expect to be moving. Used as part of warning lights routine
+
+$(P)$(R):MOVING:GDA input is controlled by GDA and indicates whether we are in the middle of a (possibly paused) move-->
+	<!--<records.calcout CALC="((A &amp; 1024) = 1024) || B" DOPT="Use OCAL" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:WHEEL:REAL.MSTA" INPB="BL21I-MO-ARM-01:TTH:GDA:PAUSED" OCAL="1" OOPT="When Non-zero" OUT="BL21I-MO-ARM-01:TTH:MOVING:RAW PP" SCAN=".5 second" record="BL21I-MO-ARM-01:TTH:MOVING"/>-->
+	<!--Tells VLVCC8 when we expect to be moving. Used as part of warning lights routine-->
+	<!--<records.calcout CALC="(A &amp; 1024) = 1024" DOPT="Use OCAL" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:WHEEL.MSTA" OCAL="1" OOPT="When Non-zero" OUT="BL21I-MO-ARM-01:TTH:MOVING:RAW PP" SCAN=".5 second" record="BL21I-MO-ARM-01:TTH:MOVING"/>-->
+	<records.calcout CALC="(!((A&amp;16392)=16392))?3:(!((A&amp;8196)=8196))?2:(!(A&amp;2))?1:0" DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:LASER:STATUS:RAW CP" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:LASER:STATUS PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:LASER:STATUS:CALC"/>
+	<records.calcout CALC="(A &amp; 1)" DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:BUMPSTRIP:STATUS:RAW CP" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:BUMPSTRIP:TOP PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:BUMPSTRIP:TOP:CALC"/>
+	<records.calcout CALC="(A &amp; 2) = 2" DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:BUMPSTRIP:STATUS:RAW CP" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:BUMPSTRIP:BOTTOM PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:BUMPSTRIP:BOTTOM:CALC"/>
+	<!--Start of air supply monitoring for the SGM and the air pads supporting the spectrometer arm.-->
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="150" HIHI="180" HOPR="200" HSV="MINOR" HYST="50" INPA="BL21I-MO-SGM-01:TVLR:AIR:FLOW:RAW CP" INPB="198" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="10" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-SGM-01:TVLR:AIR:FLOW PP" SCAN="Passive" record="BL21I-MO-SGM-01:TVLR:AIR:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-SGM-01:TVLR:AIR:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="12" LLSV="MAJOR" LOLO="3" LOPR="0" LOW="3.5" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-SGM-01:TVLR:AIR:PRESSURE PP" SCAN="Passive" record="BL21I-MO-SGM-01:TVLR:AIR:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A&lt;10000)?(A-D)*B/C:0" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="150" HIHI="180" HOPR="200" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:FLOW:RAW CP" INPB="198" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="10" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="6" LLSV="MAJOR" LOLO="3" LOPR="0" LOW="3.5" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:GRNT:RACKS:AIR:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A&lt;10000)?(A-D)*B/C:0" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="150" HIHI="180" HOPR="200" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:GRNT:AIR:FLOW:RAW CP" INPB="198" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="10" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:GRNT:AIR:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:GRNT:AIR:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:GRNT:AIR:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="6" LLSV="MAJOR" LOLO="3" LOPR="0" LOW="3.5" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:GRNT:AIR:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:GRNT:AIR:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A&lt;10000)?(A-D)*B/C:0" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="150" HIHI="180" HOPR="200" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:FLOW:RAW CP" INPB="198" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="10" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="-12" LLSV="MAJOR" LOLO="3" LOPR="0" LOW="3.5" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:RACKS:AIR:PRESSURE:SCALED"/>
+	<!--<records.calcout CALC="A" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="950" HIHI="1000" HOPR="1000" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:FLOW:RAW CP" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="50" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:FLOW:SCALED"/>-->
+	<!--<records.calcout CALC="A" DOPT="Use CALC" DTYP="Soft Channel" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:PRESSURE:RAW CP" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:PRESSURE:SCALED"/>-->
+	<!--The flowmeter is U5 SFAM-1000-M-2SA-M12 and has a reading range of 0-1000 L/min.
+
+The pressure sensor is SPAU-P10R-MS6-F-L-PNLK-PNVBA-M12D and has a pressure range of 0 - 10 Bar.
+
+The analog card has a resolution of 1/6000, thus the following scaling:
+flow: 6000 reading = 1000 L/min
+pressure: 6000 reading = 10 Bar
+
+A value outside the range [0-6000] will be treated as an error state.
+
+The input D of the CALC represents stray counts from the parasitic current induced on the wiring (thus substracted to get to the real value).-->
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="950" HIHI="1000" HOPR="1000" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:FLOW:RAW CP" INPB="1000" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="50" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="1" LLSV="MAJOR" LOLO="3.2" LOPR="0" LOW="3.3" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA06:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="950" HIHI="1000" HOPR="1000" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:FLOW:RAW CP" INPB="1000" INPC="6000" INPD="2" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="50" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:FLOW:SCALED"/>
+	<records.calcout CALC="(A&lt;10000)?(A-D)*B/C:0" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="3.2" LOPR="0" LOW="3.3" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA07:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="950" HIHI="1000" HOPR="1000" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:FLOW:RAW CP" INPB="1000" INPC="6000" INPD="2" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="50" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:FLOW:SCALED"/>
+	<records.calcout CALC="(A&lt;10000)?(A-D)*B/C:0" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="0" LLSV="MAJOR" LOLO="3.2" LOPR="0" LOW="3.3" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:DET:AIR:CA08:PRESSURE:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="950" HIHI="1000" HOPR="1000" HSV="MINOR" HYST="50" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA09:FLOW:RAW CP" INPB="1000" INPC="6000" INPD="2" LLSV="MAJOR" LOLO="0" LOPR="0" LOW="50" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA09:FLOW PP" SCAN="Passive" record="BL21I-MO-ARM-01::TTH:DET:AIR:CA09:FLOW:SCALED"/>
+	<records.calcout CALC="(A-D)*B/C" DOPT="Use CALC" DTYP="Soft Channel" HHSV="MAJOR" HIGH="5.5" HIHI="6" HOPR="10" HSV="MINOR" HYST="0.5" INPA="BL21I-MO-ARM-01:TTH:DET:AIR:CA09:PRESSURE:RAW CP" INPB="10" INPC="6000" INPD="17" LLSV="MAJOR" LOLO="3.2" LOPR="0" LOW="3.3" LSV="MINOR" OOPT="On Change" OUT="BL21I-MO-ARM-01:TTH:DET:AIR:CA09:PRESSURE PP" SCAN="Passive" record="BL21I-MO-ARM-01::TTH:DET:AIR:CA09:PRESSURE:SCALED"/>
+	<!--This record is to be set to 1 when the motion is paused, and zero otherwise.
+
+If GDA is not updated to control this, keep it set to 0 to maintain correct behaviour with EPICS motion.-->
+	<records.bi DTYP="Soft Channel" ONAM="Paused" SCAN="Passive" VAL="0" ZNAM="Not Paused" record="BL21I-MO-ARM-01:TTH:GDA:PAUSED"/>
+	<!--The bumpstrip values have been separated out here to provide easy archive viewing of when each strip was activated-->
+	<records.bi DTYP="Soft Channel" ONAM="On" ZNAM="Off" record="BL21I-MO-ARM-01:TTH:BUMPSTRIP:TOP"/>
+	<records.bi DTYP="Soft Channel" ONAM="On" ZNAM="Off" record="BL21I-MO-ARM-01:TTH:BUMPSTRIP:BOTTOM"/>
+	<BL21I.TTHBumpstripMonitor DESC="Top Bumpstrip" P="BL21I-MO-ARM-01" R=":TTH:BUMPSTRIP:TOP" name="TTH.Safety.BumpstripTop"/>
+	<BL21I.TTHBumpstripMonitor DESC="Bottom Bumpstrip" P="BL21I-MO-ARM-01" R=":TTH:BUMPSTRIP:BOTTOM" name="TTH.Safety.BumpstripBottom"/>
+	<records.mbbi DTYP="Soft Channel" ONST="Warning" SCAN="Passive" THST="Kill" TWST="Pause" ZRST="Clear" record="BL21I-MO-ARM-01:TTH:LASER:STATUS"/>
+	<!--<records.transform CLCB="!(A&amp;2)" CLCC="!(A&amp;4)" CLCD="!(A&amp;8)" CLCE="(D) ? 3 : (C)? 2 : (B)? 1 : 0" INPA="BL21I-MO-ARM-01:TTH:LASER:STATUS:RAW CP" OUTE="BL21I-MO-ARM-01:TTH:LASER:STATUS PP" SCAN="Passive" record="BL21I-MO-ARM-01:TTH:LASER:STATUS:CALC"/>-->
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-07:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-07:INT1:RAWILK CP" INPB="BL21I-VA-VLVCC-07:INT1:INIILK CP" INPC="BL21I-VA-VLVCC-07:INT1:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-07:INT1:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-07:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-07:INT2:RAWILK CP" INPB="BL21I-VA-VLVCC-07:INT2:INIILK CP" INPC="BL21I-VA-VLVCC-07:INT2:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-07:INT2:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-07:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-07:INT3:RAWILK CP" INPB="BL21I-VA-VLVCC-07:INT3:INIILK CP" INPC="BL21I-VA-VLVCC-07:INT3:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-07:INT3:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-07:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-07:INT4:RAWILK CP" INPB="BL21I-VA-VLVCC-07:INT4:INIILK CP" INPC="BL21I-VA-VLVCC-07:INT4:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-07:INT4:STATE_RBV"/>
+	<!--Records used to provide a summary monitor for all the interlocks on VLVCC-07 related to the spectrometer.
+
+See CSS gui, interlock summary screen.-->
+	<records.calc CALC="A&amp;&amp;B&amp;&amp;C&amp;&amp;D" INPA="BL21I-VA-VLVCC-07:INT1:STATE_RBV" INPB="BL21I-VA-VLVCC-07:INT2:STATE_RBV" INPC="BL21I-VA-VLVCC-07:INT3:STATE_RBV" INPD="BL21I-VA-VLVCC-07:INT4:STATE_RBV" SCAN="Passive" record="BL21I-VA-VLVCC-07:INT:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-08:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-08:INT1:RAWILK CP" INPB="BL21I-VA-VLVCC-08:INT1:INIILK CP" INPC="BL21I-VA-VLVCC-08:INT1:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-08:INT1:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-08:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-08:INT2:RAWILK CP" INPB="BL21I-VA-VLVCC-08:INT2:INIILK CP" INPC="BL21I-VA-VLVCC-08:INT2:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-08:INT2:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-08:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-08:INT3:RAWILK CP" INPB="BL21I-VA-VLVCC-08:INT3:INIILK CP" INPC="BL21I-VA-VLVCC-08:INT3:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-08:INT3:STATE_RBV"/>
+	<records.calc CALC="(A+B+C)%65535=0" FLNK="BL21I-VA-VLVCC-08:INT:STATE_RBV" INPA="BL21I-VA-VLVCC-08:INT4:RAWILK CP" INPB="BL21I-VA-VLVCC-08:INT4:INIILK CP" INPC="BL21I-VA-VLVCC-08:INT4:ILK CP" SCAN="Passive" record="BL21I-VA-VLVCC-08:INT4:STATE_RBV"/>
+	<!--Records used to provide a summary monitor for all the interlocks on VLVCC-08 related to the spectrometer.
+
+See CSS gui, interlock summary screen.-->
+	<records.calc CALC="A&amp;&amp;B&amp;&amp;C&amp;&amp;D" INPA="BL21I-VA-VLVCC-08:INT1:STATE_RBV" INPB="BL21I-VA-VLVCC-08:INT2:STATE_RBV" INPC="BL21I-VA-VLVCC-08:INT3:STATE_RBV" INPD="BL21I-VA-VLVCC-08:INT4:STATE_RBV" SCAN="Passive" record="BL21I-VA-VLVCC-08:INT:STATE_RBV"/>
+	<!--Attempt to correct for error during IOC initialisation due to length of PV name passed to record in dlsPLC_vacValveDebounce.template (line 1163):
+
+[Tue Nov 22 16:15:01 2022]dbLoadRecords 'db/BL21I-VA-IOC-04_expanded.db'
+[Tue Nov 22 16:15:01 2022]Can't set "BL21I-OP-SGM-01:TVLR:AIR:RAWAIRSTAINP.AA" to "BL21I-OP-SGM-01:TVLR:AIR:RAWAIRALL.B%1X CP MS"
+[Tue Nov 22 16:15:01 2022]Error at or before ")" in file "db/BL21I-VA-IOC-04_expanded.db" line 9600
+[Tue Nov 22 16:15:01 2022]Can't set "BL21I-MO-ARM-01:TTH:GRNT:AIR:RAWAIRSTAINP.AA" to "BL21I-MO-ARM-01:TTH:GRNT:AIR:RAWAIRALL.B%1X CP MS"
+[Tue Nov 22 16:15:01 2022]ErrorCan't set "BL21I-MO-ARM-01:TTH:MRBL:AIR:RAWAIRSTAINP.AA" to "BL21I-MO-ARM-01:TTH:MRBL:AIR:RAWAIRALL.B%1X CP MS"
+[Tue Nov 22 16:15:01 2022]ErrordbLoadRecords 'db/BL21I-VA-IOC-04.db'-->
+	<EPICS_BASE.dbpf pv="BL21I-OP-SGM-01:TVLR:AIR:RAWAIRSTA.INP CA" value="BL21I-OP-SGM-01:TVLR:AIR:RAWAIRALL.BF CP MS"/>
+	<EPICS_BASE.dbpf pv="BL21I-OP-SGM-01:TVLR:AIR:RAWAIRSTA.PROC" value="1"/>
+	<EPICS_BASE.dbpf pv="BL21I-MO-ARM-01:TTH:GRNT:AIR:RAWAIRSTA.INP CA" value="BL21I-MO-ARM-01:TTH:GRNT:AIR:RAWAIRALL.BF CP MS"/>
+	<EPICS_BASE.dbpf pv="BL21I-MO-ARM-01:TTH:GRNT:AIR:RAWAIRSTA.PROC" value="1"/>
+	<EPICS_BASE.dbpf pv="BL21I-MO-ARM-01:TTH:MRBL:AIR:RAWAIRSTA.INP CA" value="BL21I-MO-ARM-01:TTH:MRBL:AIR:RAWAIRALL.BF CP MS"/>
+	<EPICS_BASE.dbpf pv="BL21I-MO-ARM-01:TTH:MRBL:AIR:RAWAIRSTA.PROC" value="1"/>
+</components>

--- a/tests/samples/catio/BL21I-VA-IOC-05.xml
+++ b/tests/samples/catio/BL21I-VA-IOC-05.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<devIocStats.devIocStatsHelper ioc="BL21I-VA-IOC-05" name="BL21I-VA-IOC-05.DEVIOCSTATS"/>
+	<autosave.Autosave bl="True" iocName="BL21I-VA-IOC-05" name="BL21I-VA-IOC-05.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="VA5.PVLOGGING"/>
+	<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>
+	<!--Start of BL21I-VA-ERIO-05-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026289" position="DCS00026289" type_rev="EK1100 rev 0x00120000"/>
+	<!--ERIO-05, Module 1, EL3104-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026229" position="DCS00026229" type_rev="EL3104 rev 0x00120000"/>
+	<!--ERIO-05, Module 2, EL3104-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026230" position="DCS00026230" type_rev="EL3104 rev 0x00120000"/>
+	<!--ERIO-05, Module 3, EL1014-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026204" position="DCS00026204" type_rev="EL1014 rev 0x00120000"/>
+	<!--ERIO-05, Module 4, EL1014-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026205" position="DCS00026205" type_rev="EL1014 rev 0x00120000"/>
+	<!--Start of BL21I-VA-ERIO-06-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026290" position="DCS00026290" type_rev="EK1100 rev 0x00120000"/>
+	<!--ERIO-06, Module 1, EL3104-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026231" position="DCS00026231" type_rev="EL3104 rev 0x00120000"/>
+	<!--ERIO-06, Module 2, EL3104-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026232" position="DCS00026232" type_rev="EL3104 rev 0x00120000"/>
+	<!--ERIO-06, Module 3, EL1014-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026206" position="DCS00026206" type_rev="EL1014 rev 0x00120000"/>
+	<!--ERIO-06, Module 4, EL1014-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026207" position="DCS00026207" type_rev="EL1014 rev 0x00120000"/>
+	<!--ERIO-0?, Module ?, coupler EK1100
+
+use = ???
+(returned by the Ethercat chain, but not visible in drawing 1109314 page 8)-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026728" position="DCS00026728" type_rev="EK1100 rev 0x00120000"/>
+	<!--ERIO-0?, Module ?, EL1014
+
+use = ???
+(returned by the Ethercat chain, but not visible in drawing 1109314 page 8)-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00024655" position="DCS00024655" type_rev="EL2024 rev 0x00110000"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-05:MOD1" PORT="DCS00026229" SCAN="1 second" name="ADC1"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-05:MOD2" PORT="DCS00026230" SCAN="1 second" name="ADC2"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-06:MOD1" PORT="DCS00026231" SCAN="1 second" name="ADC3"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-06:MOD2" PORT="DCS00026232" SCAN="1 second" name="ADC4"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-05:MOD3" PORT="DCS00026204" SCAN="I/O Intr" name="DIGI1"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-05:MOD4" PORT="DCS00026205" SCAN="I/O Intr" name="DIGI2"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-06:MOD3" PORT="DCS00026206" SCAN="I/O Intr" name="DIGI3"/>
+	<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-06:MOD4" PORT="DCS00026207" SCAN="I/O Intr" name="DIGI4"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-07:FANC-01" name="VAFAN7" rio_dinput="BL21I-VA-ERIO-05:MOD3:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio DESC="Status of rack PSU" device="BL21I-VA-RACK-07:PSU-01" name="VAPSU7" rio_dinput="BL21I-VA-ERIO-05:MOD3:CHANNEL3:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-08:FANC-01" name="VAFAN8" rio_dinput="BL21I-VA-ERIO-06:MOD3:CHANNEL1:INPUT"/>
+	<rackFan.rackFan_rio device="BL21I-VA-RACK-08:PSU-01" name="VAPSU8" rio_dinput="BL21I-VA-ERIO-06:MOD3:CHANNEL3:INPUT"/>
+</components>

--- a/tests/samples/catio/BL21I-VA-IOC-06.xml
+++ b/tests/samples/catio/BL21I-VA-IOC-06.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+	<devIocStats.devIocStatsHelper ioc="BL21I-VA-IOC-06" name="BL21I-VA-IOC-06.DEVIOCSTATS"/>
+	<autosave.Autosave bl="True" iocName="BL21I-VA-IOC-06" name="BL21I-VA-IOC-06.AUTOSAVE" path="/dls_sw/i21/epics/autosave"/>
+	<pvlogging.PvLogging access_file="/dls_sw/prod/R3.14.12.7/support/pvlogging/1-4/data/access.acf" name="VA6.PVLOGGING"/>
+	<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>
+	<!--Start of BL21I-VA-ERIO-05-->
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026847" position="DCS00026847" type_rev="EK1100 rev 0x00120000"/>
+	<ethercat.EthercatSlave master="ECATM" name="DCS00026564" position="DCS00026564" type_rev="EL3104 rev 0x00120000"/>
+	<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-99:MOD1" PORT="DCS00026564" SCAN="1 second" name="ADC1"/>
+	<!--<rackFan.rackFan_rio name="VAFAN1"/>-->
+	<!--<rackFan.rackFan_rio DESC="Status of rack PSU" name="VAPSU1"/>-->
+</components>

--- a/tests/samples/catio/README.md
+++ b/tests/samples/catio/README.md
@@ -1,0 +1,151 @@
+# catio sample fixtures
+
+Inputs and checked-in expected results for `builder2ibek catio` — the migration
+of DLS beamlines off the legacy `ethercat` support module onto `fastcs-catio`.
+
+These live in a **subfolder** on purpose. `tests/samples/make_samples.sh` runs
+`ls *.xml` from `tests/samples/`, and `tests/test_file_conversion.py` uses
+`SAMPLES.glob("*.xml")` — both non-recursive. Keeping these XMLs in `catio/`
+keeps them out of the `xml2yaml` + `generate2` regeneration set and out of the
+`GENERATED_AGAINST` pin-freshness contract. **Do not move them up a level.**
+
+## Provenance of the XMLs
+
+| | |
+|---|---|
+| Source | `/dls_sw/work/R3.14.12.7/support/BL21I-BUILDER/etc/makeIocs/` |
+| BUILDER revision | `cf39c887ac8a34d01e637ebbc71a58a55f6a9a29` (2026-05-28, "EA-03,MO-18,VA-02: update support dependencies") |
+| Copied | 2026-08-07 |
+| Modified? | **No.** Byte-for-byte copies, verified with `cmp` against the source. Do not reformat, re-indent or run a formatter over them. |
+
+| file | md5 | role |
+|---|---|---|
+| `BL21I-VA-IOC-01.xml` | `974ddef488927ae1d6bb2d3734eabc68` | scanner (5 couplers) |
+| `BL21I-VA-IOC-05.xml` | `5900c70024c02459b14fb6df5c7f3b26` | scanner (3 couplers, one unlabelled) |
+| `BL21I-VA-IOC-06.xml` | `1920063f50757c5f68232e775d72c349` | scanner (1 coupler; declares `ERIO-99`, contradicting its comment) |
+| `BL21I-DI-IOC-01.xml` | `25a4799e6442107f05438545e08b522e` | scanner (10 couplers; the hard one) |
+| `BL21I-VA-IOC-02.xml` | `e99d40a496f4ad4fd9b11172f2a2a444` | consumer only |
+| `BL21I-VA-IOC-04.xml` | `35bb4fcead376aa40037002bedfc4a7b` | consumer only; straddles a clean and a failing chain |
+
+`BL21I-VA-IOC-03.xml` is deliberately absent: it has no EtherCAT references.
+Together these six carry **every** one of the 247 EtherCAT reference rows in the
+beamline (155 / 44 / 29 / 12 / 6 / 1 for DI-01, VA-01, VA-02, VA-05, VA-04,
+VA-06).
+
+## `expected_chains.json`
+
+The chain topology the tool must reproduce from the four scanner XMLs:
+
+```json
+{"<scanner ioc>": {"couplers": [
+  {"node": 0, "label": "BL21I-VA-ERIO-04", "slave_name": "DCS00025070",
+   "terminals": [
+     {"position": 0, "type_name": "EK1100", "revision": "0x00120000",
+      "declared_device": "", "entity_type": null, "entity_name": null,
+      "slave_name": "DCS00025070"},
+     ...]}]}}
+```
+
+Conventions, which match `.catio-spec/spec_ground.json` exactly:
+
+* `node` is **0-based** and increments per coupler in bus order.
+* `position` **0 is the coupler itself**; the first terminal after it is 1.
+  Every coupler therefore has a `terminals[0]` whose `type_name` is `EK1100`.
+* `revision` is the verbatim hex string from the XML's `type_rev`
+  (`"EL3104 rev 0x00120000"` → `type_name` `EL3104`, `revision` `0x00120000`),
+  not an int.
+* `declared_device` is `""` (not `null`) when no `auto_*` entity binds that
+  terminal — verbatim from the ground truth.
+* `label` is `null` when underivable (the ground truth spells this `""`).
+
+### How it was derived
+
+`node`, `position`, `type_name`, `revision` and `declared_device` come straight
+from `.catio-spec/spec_ground.json`'s `scanners[].couplers[].terminals[]`, and
+`label` from its `derived_label`. The three fields the ground truth does not
+carry — `entity_type`, `entity_name`, `slave_name` — were derived by re-parsing
+each XML with `builder2ibek.builder.Builder` and matching each `auto_*`
+entity's `PORT=` to an `EthercatSlave`'s `name=`.
+
+The whole file was then re-derived from the XMLs alone and compared field by
+field with the ground truth, using these rules:
+
+* **D1 chain topology** — walk `ethercat.EthercatSlave` elements in XML order.
+  A slave is a coupler if `type_name == "EK1100"` or it matches
+  `^(E[PQR]P?\d{4})`; then `node += 1` and `position = 0`. Otherwise
+  `position += 1`. `EK1122` junctions are *not* couplers (`EK` is not
+  `E[PQR]`) and consume an ordinary position — see `BL21I-DI-IOC-01` node 8.
+* **D2 label derivation** — the unanimous part before `:MOD` of the
+  `DEVICE=` values of the `auto_*` entities bound to that coupler's terminals.
+  `DEVICE=` values with no `:MOD` part (`BL21I-OP-LED-01`,
+  `BL21I-MO-PIEZO-01`, …) are ignored. `<!--Start of ...-->` comments are
+  ignored entirely — they are unvalidatable free text and are wrong in
+  `BL21I-VA-IOC-06`.
+
+**Result: zero discrepancies.** The XMLs and `spec_ground.json` agree on the
+flat bus order, every `type_rev`, every coupler/position assignment, every
+`slave_name` and every derived label.
+
+## `expected_references.json`
+
+The 247 `references[]` rows from `.catio-spec/spec_ground.json`, verbatim and in
+order, so tests can assert that every one either rewrites to a new PV or
+produces a named diagnostic.
+
+```json
+[{"ioc": "BL21I-DI-IOC-01", "entity_type": "BL21I.DewarScales",
+  "entity_name": "SMPL.SCALES", "attribute": "LOAD_CELL_1",
+  "value": "BL21I-DI-ERIO-04:MOD12:RMB:VALUE"}, ...]
+```
+
+Notes for anyone writing assertions against it:
+
+* `value` is the **whole attribute value**, including any trailing link flags
+  (`"BL21I-DI-ERIO-10:MOD1:INPUT1:VALUE CP"`). That is what the link-direction
+  rule keys on, and what token-wise substitution must preserve.
+* `entity_name` is the entity's `name=` attribute **except for `records.*`
+  entities, which carry their PV in `record=` instead**. Index by
+  `attributes.get("name") or attributes.get("record")` when looking a row up.
+* `entity_type` is `"<module>.<element>"`, e.g. `ethercat.auto_EL3104`.
+  Distribution: `femto.femto200` 88, `mks937b.mks937bGauge` 30,
+  `ethercat.auto_EL2024_0010` 29, `rackFan.rackFan_rio` 26,
+  `ethercat.auto_EL3104` 25, `records.ai` 24, `ethercat.auto_EL1014` 12,
+  `mks9xx.mks9xxGauge` 5, `BL21I.DewarScales` 4, `ethercat.auto_EL3356_0010` 4.
+
+### How it was validated
+
+Every row was checked twice against its copied XML: that `value` occurs as a
+substring of the file, and that the entity identified by
+`(entity_type, entity_name)` really carries that exact string on that
+`attribute`. **All 247 rows passed.**
+
+## Interesting cases these fixtures pin down
+
+* `BL21I-VA-IOC-01` node 0 (`BL21I-VA-ERIO-04`) — four `auto_EL3104` declaring
+  `MOD1`..`MOD4` at positions 1–4, then two `auto_EL1014` **restarting at
+  `MOD1`** at positions 5–6. The dual-key substitution map is what makes this
+  harmless. Node 2 (`ERIO-03`) has the same defect.
+* `BL21I-VA-IOC-05` node 2 — an unlabelled coupler carrying a plain `EL2024`
+  (not `-0010`) with no `auto_*` entity at all.
+* `BL21I-VA-IOC-06` — a single coupler whose `auto_EL3104` declares
+  `BL21I-VA-ERIO-99`, while the `<!--Start of BL21I-VA-ERIO-05-->` comment
+  above it says otherwise. The declaration wins.
+* `BL21I-DI-IOC-01` nodes 7 and 8 — **two physical couplers deriving the same
+  label** `BL21I-DI-ERIO-01`, with continuous MOD numbering (MOD6–MOD15 then
+  MOD16–MOD20). Declared names stay distinct; only the chain-derived aliases
+  collide.
+* `BL21I-DI-IOC-01` node 1 (`BL21I-DI-ERIO-05`) — non-numeric MOD names
+  `MODSAM3`..`MODSAM7`, referenced live by `femto200`.
+* `BL21I-DI-IOC-01` — five `EL2024` slaves bound to `auto_EL2024_0010`
+  entities (a genuine type mismatch, e.g. slave `DCS00024653`), and terminal
+  types well outside the five inventoried in `leaves.py`: `EL3602`, `EL2595`,
+  `EL9512`, `EL9510`, `EL9505`, `EL2124`, `EL4134`, `EL3124`, `EK1122`.
+* **Four** of `BL21I-DI-IOC-01`'s ten couplers have `label: null` — nodes 0, 4,
+  5 and 6. (`.catio-spec/HANDOFF.md` says "5 of 10 couplers have no derivable
+  label"; the ground truth data and the XML both say four. Trust the data.)
+  Nodes 0, 4 and 5 have no `auto_*` entity at all; node 6 has two, but both
+  declare a `DEVICE=` with no `:MOD` part — `BL21I-MO-PIEZO-01`
+  (`auto_EL4134`) and `BL21I-DI-LED-01` (`auto_EL2595`) — so both are ignored
+  for label derivation (`device-without-mod`, WARNING) and nothing is left to
+  derive from. It is the only coupler that reaches `unlabelled-coupler` *via*
+  `device-without-mod`.

--- a/tests/samples/catio/expected_chains.json
+++ b/tests/samples/catio/expected_chains.json
@@ -1,0 +1,1456 @@
+{
+  "BL21I-DI-IOC-01": {
+    "couplers": [
+      {
+        "node": 0,
+        "label": null,
+        "slave_name": "DCS00026299",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026299"
+          },
+          {
+            "position": 1,
+            "type_name": "EK1122",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026199"
+          }
+        ]
+      },
+      {
+        "node": 1,
+        "label": "BL21I-DI-ERIO-05",
+        "slave_name": "DCS00026293",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026293"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026381"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026382"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026258"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026259"
+          },
+          {
+            "position": 5,
+            "type_name": "EL3602",
+            "revision": "0x00100000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023720"
+          },
+          {
+            "position": 6,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026320"
+          },
+          {
+            "position": 7,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026321"
+          },
+          {
+            "position": 8,
+            "type_name": "EL2595",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026210"
+          },
+          {
+            "position": 9,
+            "type_name": "EL2595",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026211"
+          },
+          {
+            "position": 10,
+            "type_name": "EL9512",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026672"
+          },
+          {
+            "position": 11,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-05:MODSAM3",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG23",
+            "slave_name": "DCS00026706"
+          },
+          {
+            "position": 12,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-05:MODSAM4",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG24",
+            "slave_name": "DCS00026707"
+          },
+          {
+            "position": 13,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-05:MODSAM5",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG25",
+            "slave_name": "DCS00026708"
+          },
+          {
+            "position": 14,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-05:MODSAM6",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG26",
+            "slave_name": "DCS00026709"
+          },
+          {
+            "position": 15,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-05:MODSAM7",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG33",
+            "slave_name": "DCS00026710"
+          },
+          {
+            "position": 16,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026711"
+          }
+        ]
+      },
+      {
+        "node": 2,
+        "label": "BL21I-DI-ERIO-04",
+        "slave_name": "DCS00026292",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026292"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026377"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026380"
+          },
+          {
+            "position": 3,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-OP-LED-01",
+            "entity_type": "auto_EL2595",
+            "entity_name": "FS1.Led",
+            "slave_name": "DCS00024973"
+          },
+          {
+            "position": 4,
+            "type_name": "EL2595",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026214"
+          },
+          {
+            "position": 5,
+            "type_name": "EL9512",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026673"
+          },
+          {
+            "position": 6,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD3",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG20",
+            "slave_name": "DCS00026712"
+          },
+          {
+            "position": 7,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD4",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG21",
+            "slave_name": "DCS00026714"
+          },
+          {
+            "position": 8,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD5",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG22",
+            "slave_name": "DCS00026713"
+          },
+          {
+            "position": 9,
+            "type_name": "EL9510",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026913"
+          },
+          {
+            "position": 10,
+            "type_name": "EL3356-0010",
+            "revision": "0x0018000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD12",
+            "entity_type": "auto_EL3356_0010",
+            "entity_name": "SCALES1",
+            "slave_name": "DCS00026910"
+          },
+          {
+            "position": 11,
+            "type_name": "EL3356-0010",
+            "revision": "0x0018000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD13",
+            "entity_type": "auto_EL3356_0010",
+            "entity_name": "SCALES2",
+            "slave_name": "DCS00026911"
+          },
+          {
+            "position": 12,
+            "type_name": "EL3356-0010",
+            "revision": "0x0019000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD14",
+            "entity_type": "auto_EL3356_0010",
+            "entity_name": "SCALES3",
+            "slave_name": "DCS00026977"
+          },
+          {
+            "position": 13,
+            "type_name": "EL3356-0010",
+            "revision": "0x0019000a",
+            "declared_device": "BL21I-DI-ERIO-04:MOD15",
+            "entity_type": "auto_EL3356_0010",
+            "entity_name": "SCALES4",
+            "slave_name": "DCS00026971"
+          },
+          {
+            "position": 14,
+            "type_name": "EL9505",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024957"
+          },
+          {
+            "position": 15,
+            "type_name": "EL2124",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024867"
+          },
+          {
+            "position": 16,
+            "type_name": "EL2124",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026627"
+          }
+        ]
+      },
+      {
+        "node": 3,
+        "label": "BL21I-DI-ERIO-09",
+        "slave_name": "DCS00026539",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026539"
+          },
+          {
+            "position": 1,
+            "type_name": "EL9512",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026674"
+          },
+          {
+            "position": 2,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD1",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG27",
+            "slave_name": "DCS00026715"
+          },
+          {
+            "position": 3,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD2",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG28",
+            "slave_name": "DCS00026716"
+          },
+          {
+            "position": 4,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD3",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG29",
+            "slave_name": "DCS00026717"
+          },
+          {
+            "position": 5,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD4",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG30",
+            "slave_name": "DCS00026718"
+          },
+          {
+            "position": 6,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD5",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG31",
+            "slave_name": "DCS00026719"
+          },
+          {
+            "position": 7,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-09:MOD6",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG32",
+            "slave_name": "DCS00026720"
+          }
+        ]
+      },
+      {
+        "node": 4,
+        "label": null,
+        "slave_name": "DCS00026540",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026540"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026579"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026580"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026581"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026582"
+          },
+          {
+            "position": 5,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026583"
+          },
+          {
+            "position": 6,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026584"
+          },
+          {
+            "position": 7,
+            "type_name": "EL3602",
+            "revision": "0x00130000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026585"
+          },
+          {
+            "position": 8,
+            "type_name": "EK1122",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026441"
+          }
+        ]
+      },
+      {
+        "node": 5,
+        "label": null,
+        "slave_name": "DCS00024927",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024927"
+          },
+          {
+            "position": 1,
+            "type_name": "EK1122",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023938"
+          }
+        ]
+      },
+      {
+        "node": 6,
+        "label": null,
+        "slave_name": "DCS00024933",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024933"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024797"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024798"
+          },
+          {
+            "position": 3,
+            "type_name": "EL4134",
+            "revision": "0x03fa0000",
+            "declared_device": "BL21I-MO-PIEZO-01",
+            "entity_type": "auto_EL4134",
+            "entity_name": "M1.Piezo",
+            "slave_name": "DCS00024817"
+          },
+          {
+            "position": 4,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024652"
+          },
+          {
+            "position": 5,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024965"
+          },
+          {
+            "position": 6,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-DI-LED-01",
+            "entity_type": "auto_EL2595",
+            "entity_name": "D1.Led",
+            "slave_name": "DCS00024966"
+          },
+          {
+            "position": 7,
+            "type_name": "EK1122",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023939"
+          }
+        ]
+      },
+      {
+        "node": 7,
+        "label": "BL21I-DI-ERIO-01",
+        "slave_name": "DCS00024941",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024941"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025131"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025132"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025133"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025134"
+          },
+          {
+            "position": 5,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025135"
+          },
+          {
+            "position": 6,
+            "type_name": "EL4134",
+            "revision": "0x03fa0000",
+            "declared_device": "BL21I-MO-PIEZO-02",
+            "entity_type": "auto_EL4134",
+            "entity_name": "M2.Piezo",
+            "slave_name": "DCS00026270"
+          },
+          {
+            "position": 7,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-DI-LED-03",
+            "entity_type": "auto_EL2595",
+            "entity_name": "D3A.Led",
+            "slave_name": "DCS00024967"
+          },
+          {
+            "position": 8,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-DI-LED-02",
+            "entity_type": "auto_EL2595",
+            "entity_name": "D2.Led",
+            "slave_name": "DCS00024778"
+          },
+          {
+            "position": 9,
+            "type_name": "EL9512",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026671"
+          },
+          {
+            "position": 10,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD6",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG01",
+            "slave_name": "DCS00026696"
+          },
+          {
+            "position": 11,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD7",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG02",
+            "slave_name": "DCS00026697"
+          },
+          {
+            "position": 12,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD8",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG03",
+            "slave_name": "DCS00026698"
+          },
+          {
+            "position": 13,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD9",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG04",
+            "slave_name": "DCS00026699"
+          },
+          {
+            "position": 14,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD10",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG05",
+            "slave_name": "DCS00026700"
+          },
+          {
+            "position": 15,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD11",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG06",
+            "slave_name": "DCS00026701"
+          },
+          {
+            "position": 16,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD12",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG07",
+            "slave_name": "DCS00026702"
+          },
+          {
+            "position": 17,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD13",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG08",
+            "slave_name": "DCS00026703"
+          },
+          {
+            "position": 18,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD14",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG09",
+            "slave_name": "DCS00026704"
+          },
+          {
+            "position": 19,
+            "type_name": "EL2024-0010",
+            "revision": "0x0012000a",
+            "declared_device": "BL21I-DI-ERIO-01:MOD15",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG10",
+            "slave_name": "DCS00026705"
+          },
+          {
+            "position": 20,
+            "type_name": "EK1122",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023940"
+          }
+        ]
+      },
+      {
+        "node": 8,
+        "label": "BL21I-DI-ERIO-01",
+        "slave_name": "DCS00024940",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024940"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024799"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024800"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3602",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024801"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3124",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024549"
+          },
+          {
+            "position": 5,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "BL21I-DI-ERIO-01:MOD16",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG11",
+            "slave_name": "DCS00024653"
+          },
+          {
+            "position": 6,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "BL21I-DI-ERIO-01:MOD17",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG12",
+            "slave_name": "DCS00024654"
+          },
+          {
+            "position": 7,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "BL21I-DI-ERIO-01:MOD18",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG13",
+            "slave_name": "DCS00024668"
+          },
+          {
+            "position": 8,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "BL21I-DI-ERIO-01:MOD19",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG14",
+            "slave_name": "DCS00024669"
+          },
+          {
+            "position": 9,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "BL21I-DI-ERIO-01:MOD20",
+            "entity_type": "auto_EL2024_0010",
+            "entity_name": "DIG15",
+            "slave_name": "DCS00024670"
+          },
+          {
+            "position": 10,
+            "type_name": "EL2595",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024782"
+          },
+          {
+            "position": 11,
+            "type_name": "EK1122",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023941"
+          },
+          {
+            "position": 12,
+            "type_name": "EK1122",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00023942"
+          }
+        ]
+      },
+      {
+        "node": 9,
+        "label": "BL21I-DI-ERIO-10",
+        "slave_name": "DCS00026726",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026726"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI1",
+            "slave_name": "DCS00026416"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI2",
+            "slave_name": "DCS00026553"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD3",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI3",
+            "slave_name": "DCS00026554"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD4",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI4",
+            "slave_name": "DCS00026555"
+          },
+          {
+            "position": 5,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD5",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI5",
+            "slave_name": "DCS00026556"
+          },
+          {
+            "position": 6,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-DI-ERIO-10:MOD6",
+            "entity_type": "auto_EL3104",
+            "entity_name": "HLS_AI6",
+            "slave_name": "DCS00026557"
+          }
+        ]
+      }
+    ]
+  },
+  "BL21I-VA-IOC-01": {
+    "couplers": [
+      {
+        "node": 0,
+        "label": "BL21I-VA-ERIO-04",
+        "slave_name": "DCS00025070",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00025070"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC9",
+            "slave_name": "DCS00024905"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC10",
+            "slave_name": "DCS00025130"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD3",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC11",
+            "slave_name": "DCS00026220"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD4",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC12",
+            "slave_name": "DCS00026221"
+          },
+          {
+            "position": 5,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD1",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI5",
+            "slave_name": "DCS00025092"
+          },
+          {
+            "position": 6,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-04:MOD2",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI6",
+            "slave_name": "DCS00025093"
+          }
+        ]
+      },
+      {
+        "node": 1,
+        "label": "BL21I-VA-ERIO-12",
+        "slave_name": "DCS00026851",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026851"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-VA-ERIO-12:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC13",
+            "slave_name": "DCS00026565"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00130000",
+            "declared_device": "BL21I-VA-ERIO-12:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC14",
+            "slave_name": "DCS00026570"
+          }
+        ]
+      },
+      {
+        "node": 2,
+        "label": "BL21I-VA-ERIO-03",
+        "slave_name": "DCS00024929",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024929"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-03:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC7",
+            "slave_name": "DCS00024890"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-03:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC8",
+            "slave_name": "DCS00024891"
+          },
+          {
+            "position": 3,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-03:MOD1",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI3",
+            "slave_name": "DCS00025081"
+          },
+          {
+            "position": 4,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-03:MOD2",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI4",
+            "slave_name": "DCS00025082"
+          }
+        ]
+      },
+      {
+        "node": 3,
+        "label": "BL21I-VA-ERIO-02",
+        "slave_name": "DCS00028304",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00028304"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-02:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC5",
+            "slave_name": "DCS00024912"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-02:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC6",
+            "slave_name": "DCS00024913"
+          },
+          {
+            "position": 3,
+            "type_name": "EL1014",
+            "revision": "0x00100000",
+            "declared_device": "BL21I-VA-ERIO-02:MOD3",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI7",
+            "slave_name": "DCS00023482"
+          },
+          {
+            "position": 4,
+            "type_name": "EL1014",
+            "revision": "0x00100000",
+            "declared_device": "BL21I-VA-ERIO-02:MOD4",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI8",
+            "slave_name": "DCS00023483"
+          }
+        ]
+      },
+      {
+        "node": 4,
+        "label": "BL21I-VA-ERIO-01",
+        "slave_name": "DCS00028806",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00028806"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC1",
+            "slave_name": "DCS00024908"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC2",
+            "slave_name": "DCS00024909"
+          },
+          {
+            "position": 3,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD3",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC3",
+            "slave_name": "DCS00024910"
+          },
+          {
+            "position": 4,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD4",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC4",
+            "slave_name": "DCS00024911"
+          },
+          {
+            "position": 5,
+            "type_name": "EL1014",
+            "revision": "0x00100000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD5",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI1",
+            "slave_name": "DCS00023480"
+          },
+          {
+            "position": 6,
+            "type_name": "EL1014",
+            "revision": "0x00100000",
+            "declared_device": "BL21I-VA-ERIO-01:MOD6",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI2",
+            "slave_name": "DCS00023481"
+          }
+        ]
+      }
+    ]
+  },
+  "BL21I-VA-IOC-05": {
+    "couplers": [
+      {
+        "node": 0,
+        "label": "BL21I-VA-ERIO-05",
+        "slave_name": "DCS00026289",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026289"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-05:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC1",
+            "slave_name": "DCS00026229"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-05:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC2",
+            "slave_name": "DCS00026230"
+          },
+          {
+            "position": 3,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-05:MOD3",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI1",
+            "slave_name": "DCS00026204"
+          },
+          {
+            "position": 4,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-05:MOD4",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI2",
+            "slave_name": "DCS00026205"
+          }
+        ]
+      },
+      {
+        "node": 1,
+        "label": "BL21I-VA-ERIO-06",
+        "slave_name": "DCS00026290",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026290"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-06:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC3",
+            "slave_name": "DCS00026231"
+          },
+          {
+            "position": 2,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-06:MOD2",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC4",
+            "slave_name": "DCS00026232"
+          },
+          {
+            "position": 3,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-06:MOD3",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI3",
+            "slave_name": "DCS00026206"
+          },
+          {
+            "position": 4,
+            "type_name": "EL1014",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-06:MOD4",
+            "entity_type": "auto_EL1014",
+            "entity_name": "DIGI4",
+            "slave_name": "DCS00026207"
+          }
+        ]
+      },
+      {
+        "node": 2,
+        "label": null,
+        "slave_name": "DCS00026728",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026728"
+          },
+          {
+            "position": 1,
+            "type_name": "EL2024",
+            "revision": "0x00110000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00024655"
+          }
+        ]
+      }
+    ]
+  },
+  "BL21I-VA-IOC-06": {
+    "couplers": [
+      {
+        "node": 0,
+        "label": "BL21I-VA-ERIO-99",
+        "slave_name": "DCS00026847",
+        "terminals": [
+          {
+            "position": 0,
+            "type_name": "EK1100",
+            "revision": "0x00120000",
+            "declared_device": "",
+            "entity_type": null,
+            "entity_name": null,
+            "slave_name": "DCS00026847"
+          },
+          {
+            "position": 1,
+            "type_name": "EL3104",
+            "revision": "0x00120000",
+            "declared_device": "BL21I-VA-ERIO-99:MOD1",
+            "entity_type": "auto_EL3104",
+            "entity_name": "ADC1",
+            "slave_name": "DCS00026564"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/samples/catio/expected_references.json
+++ b/tests/samples/catio/expected_references.json
@@ -1,0 +1,1731 @@
+[
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "BL21I.DewarScales",
+    "entity_name": "SMPL.SCALES",
+    "attribute": "LOAD_CELL_1",
+    "value": "BL21I-DI-ERIO-04:MOD12:RMB:VALUE"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "BL21I.DewarScales",
+    "entity_name": "SMPL.SCALES",
+    "attribute": "LOAD_CELL_2",
+    "value": "BL21I-DI-ERIO-04:MOD13:RMB:VALUE"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "BL21I.DewarScales",
+    "entity_name": "SMPL.SCALES",
+    "attribute": "LOAD_CELL_3",
+    "value": "BL21I-DI-ERIO-04:MOD14:RMB:VALUE"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "BL21I.DewarScales",
+    "entity_name": "SMPL.SCALES",
+    "attribute": "LOAD_CELL_4",
+    "value": "BL21I-DI-ERIO-04:MOD15:RMB:VALUE"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI1",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD1"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI2",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD2"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI3",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD3"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI4",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD4"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI5",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD5"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "HLS_AI6",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-10:MOD6"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG01",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD6"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG02",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD7"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG03",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD8"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG04",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD9"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG05",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD10"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG06",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD11"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG07",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD12"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG08",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD13"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG09",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD14"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG10",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD15"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG11",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD16"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG12",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD17"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG13",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD18"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG14",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD19"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG15",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-01:MOD20"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG20",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD3"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG21",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD4"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG22",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD5"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG23",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-05:MODSAM3"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG24",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-05:MODSAM4"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG25",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-05:MODSAM5"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG26",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-05:MODSAM6"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG27",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD1"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG28",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD2"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG29",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD3"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG30",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD4"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG31",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD5"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG32",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-09:MOD6"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL2024_0010",
+    "entity_name": "DIG33",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-05:MODSAM7"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3356_0010",
+    "entity_name": "SCALES1",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD12"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3356_0010",
+    "entity_name": "SCALES2",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD13"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3356_0010",
+    "entity_name": "SCALES3",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD14"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "ethercat.auto_EL3356_0010",
+    "entity_name": "SCALES4",
+    "attribute": "DEVICE",
+    "value": "BL21I-DI-ERIO-04:MOD15"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD6:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD6:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD6:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD6:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto2",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD7:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto2",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD7:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto2",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD7:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto2",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD7:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto3",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD9:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto3",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD9:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto3",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD9:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto3",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD9:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto4",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD8:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto4",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD8:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto4",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD8:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S2.Femto4",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD8:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D3B.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD11:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D3B.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD11:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D3B.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD11:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D3B.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD11:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD12:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD12:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD12:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD12:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto2",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD13:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto2",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD13:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto2",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD13:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto2",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD13:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto3",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD14:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto3",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD14:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto3",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD14:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto3",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD14:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto4",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-01:MOD15:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto4",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-01:MOD15:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto4",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-01:MOD15:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "S3.Femto4",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-01:MOD15:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-04:MOD3:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-04:MOD3:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-04:MOD3:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-04:MOD3:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto2",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-04:MOD4:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto2",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-04:MOD4:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto2",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-04:MOD4:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D7.Femto2",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-04:MOD4:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-05:MODSAM3:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-05:MODSAM3:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-05:MODSAM3:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-05:MODSAM3:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto2",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-05:MODSAM4:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto2",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-05:MODSAM4:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto2",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-05:MODSAM4:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "M4.Femto2",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-05:MODSAM4:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D8.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-05:MODSAM5:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D8.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-05:MODSAM5:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D8.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-05:MODSAM5:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "D8.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-05:MODSAM5:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto1",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-05:MODSAM6:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto1",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-05:MODSAM6:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto1",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-05:MODSAM6:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto1",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-05:MODSAM6:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto2",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD1:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto2",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD1:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto2",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD1:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto2",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD1:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto3",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD2:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto3",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD2:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto3",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD2:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto3",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD2:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto4",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD3:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto4",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD3:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto4",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD3:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto4",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD3:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto5",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD4:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto5",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD4:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto5",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD4:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto5",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD4:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto6",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD5:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto6",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD5:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto6",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD5:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto6",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD5:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto7",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-09:MOD6:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto7",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-09:MOD6:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto7",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-09:MOD6:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto7",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-09:MOD6:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto8",
+    "attribute": "OUTGB0",
+    "value": "BL21I-DI-ERIO-05:MODSAM7:CHANNEL1:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto8",
+    "attribute": "OUTGB1",
+    "value": "BL21I-DI-ERIO-05:MODSAM7:CHANNEL2:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto8",
+    "attribute": "OUTGB2",
+    "value": "BL21I-DI-ERIO-05:MODSAM7:CHANNEL3:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "femto.femto200",
+    "entity_name": "SMPL.Femto8",
+    "attribute": "OUTHIS",
+    "value": "BL21I-DI-ERIO-05:MODSAM7:CHANNEL4:OUTPUT PP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT01:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD1:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT02:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD1:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT03:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD1:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT04:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD1:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT05:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD2:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT06:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD2:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT07:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD2:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT08:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD2:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT09:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD3:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT10:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD3:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT11:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD3:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT12:LEVEL:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD3:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT01:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD4:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT02:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD4:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT03:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD4:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT04:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD4:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT05:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD5:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT06:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD5:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT07:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD5:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT08:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD5:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT09:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD6:INPUT1:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT10:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD6:INPUT2:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT11:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD6:INPUT3:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-DI-IOC-01",
+    "entity_type": "records.ai",
+    "entity_name": "BL21I-AL-HLS-01:POT12:TEMP:SOURCE",
+    "attribute": "INP",
+    "value": "BL21I-DI-ERIO-10:MOD6:INPUT4:VALUE CP"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC1",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC2",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC3",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD3"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC4",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD4"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC5",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-02:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC6",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-02:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC7",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-03:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC8",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-03:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC9",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC10",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC11",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD3"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC12",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD4"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC13",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-12:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC14",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-12:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI1",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD5"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI2",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-01:MOD6"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI3",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-03:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI4",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-03:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI5",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI6",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-04:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI7",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-02:MOD3"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI8",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-02:MOD4"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN1",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD5:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU1",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD6:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD5:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD6:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN3",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD4:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU3",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD4:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN4",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-03:MOD3:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU4",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-03:MOD3:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN5",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-04:MOD5:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU5",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-04:MOD5:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN6",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-04:MOD6:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU6",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-04:MOD6:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "PSFAN1",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD5:CHANNEL2:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "PSPSU1",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD6:CHANNEL2:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "PSFAN2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD5:CHANNEL4:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "PSPSU2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-01:MOD6:CHANNEL4:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "NTFAN1",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD3:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "NTFAN2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD3:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "NTFAN3",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD4:CHANNEL2:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "MOFAN2",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD4:CHANNEL4:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "MOFAN3",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD3:CHANNEL2:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-01",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "MOFAN4",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-02:MOD3:CHANNEL4:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks9xx.mks9xxGauge",
+    "entity_name": "GAUGE22",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-12:MOD1:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks9xx.mks9xxGauge",
+    "entity_name": "GAUGE23",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-12:MOD2:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks9xx.mks9xxGauge",
+    "entity_name": "GAUGE43",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-12:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks9xx.mks9xxGauge",
+    "entity_name": "GAUGE44",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-12:MOD1:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks9xx.mks9xxGauge",
+    "entity_name": "GAUGE45",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-12:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE1",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE2",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE3",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD1:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE4",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD1:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE5",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD2:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE6",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD2:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE7",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD2:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE8",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-01:MOD3:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE9",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-02:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE10",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-02:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE11",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-02:MOD1:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE40",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-02:MOD1:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE12",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE13",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE14",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD2:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE16",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD1:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE17",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD1:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE18",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-03:MOD2:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE19",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD3:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE20",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD3:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE21",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD3:INPUT3:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE41",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD3:INPUT4:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE30",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD4:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-02",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE42",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD4:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE24",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-05:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE25",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-06:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE26",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-06:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE27",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD1:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE28",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD1:INPUT2:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-04",
+    "entity_type": "mks937b.mks937bGauge",
+    "entity_name": "GAUGE29",
+    "attribute": "plog_adc_pv",
+    "value": "BL21I-VA-ERIO-04:MOD2:INPUT1:VALUE"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC1",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-05:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC2",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-05:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC3",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-06:MOD1"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC4",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-06:MOD2"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI1",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-05:MOD3"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI2",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-05:MOD4"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI3",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-06:MOD3"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "ethercat.auto_EL1014",
+    "entity_name": "DIGI4",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-06:MOD4"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN7",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-05:MOD3:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU7",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-05:MOD3:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAFAN8",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-06:MOD3:CHANNEL1:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-05",
+    "entity_type": "rackFan.rackFan_rio",
+    "entity_name": "VAPSU8",
+    "attribute": "rio_dinput",
+    "value": "BL21I-VA-ERIO-06:MOD3:CHANNEL3:INPUT"
+  },
+  {
+    "ioc": "BL21I-VA-IOC-06",
+    "entity_type": "ethercat.auto_EL3104",
+    "entity_name": "ADC1",
+    "attribute": "DEVICE",
+    "value": "BL21I-VA-ERIO-99:MOD1"
+  }
+]

--- a/tests/test_catio_chains.py
+++ b/tests/test_catio_chains.py
@@ -1,0 +1,660 @@
+"""Tests for `builder2ibek.catio.chains`.
+
+Split deliberately in two. Everything that is pure topology -- bus walking,
+coupler labels, ordinal allocation, diagnostics -- runs under plain
+``uv run pytest``, because builder2ibek's own environment must never depend on
+`fastcs_catio`. Only the tests that assert real fastcs-catio PV names are gated
+behind ``pytest.importorskip``; run those with ``.venv-catio/bin/python -m
+pytest``.
+
+Fixtures live in ``tests/samples/catio/`` and are byte-identical copies of the
+BL21I BUILDER XMLs. Note their ``node`` is **0-based** while
+:class:`~builder2ibek.catio.chains.Slave.node` is 1-based (node 0 means "ahead
+of the first coupler", as in fastcs-catio), so comparisons add one.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from builder2ibek.builder import Builder
+from builder2ibek.catio.chains import (
+    Chain,
+    Slave,
+    UnresolvedMap,
+    _locate,
+    _split_type_rev,
+    build_substituter,
+    catio_ioc_name,
+    discover_chains,
+    domain_of,
+    is_scanner,
+    parse_chain,
+    predict_prefixes,
+    report_unused_ambiguities,
+)
+from builder2ibek.catio.diagnostics import DiagnosticLog, Severity
+
+SAMPLES = Path(__file__).parent / "samples" / "catio"
+SCANNERS = ["BL21I-DI-IOC-01", "BL21I-VA-IOC-01", "BL21I-VA-IOC-05", "BL21I-VA-IOC-06"]
+CONSUMERS = ["BL21I-VA-IOC-02", "BL21I-VA-IOC-04"]
+
+
+@pytest.fixture(scope="module")
+def expected_chains() -> dict:
+    return json.loads((SAMPLES / "expected_chains.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def expected_references() -> list[dict]:
+    return json.loads((SAMPLES / "expected_references.json").read_text())
+
+
+def parsed(scanner: str, log: DiagnosticLog | None = None, **kwargs) -> Chain:
+    """Parse one sample scanner. Beware: an empty DiagnosticLog is falsy."""
+    if log is None:
+        log = DiagnosticLog(**kwargs)
+    chain = parse_chain(SAMPLES / f"{scanner}.xml", log, ordinal=1)
+    assert chain is not None
+    return chain
+
+
+def codes(log: DiagnosticLog) -> Counter:
+    return Counter(d.code for d in log)
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+def test_split_type_rev_handles_a_missing_rev_part():
+    assert _split_type_rev("EL3104 rev 0x00120000") == ("EL3104", 0x00120000)
+    assert _split_type_rev("EL2024-0010") == ("EL2024-0010", None)
+    assert _split_type_rev("EL3104 rev not-a-number") == ("EL3104", None)
+
+
+def test_catio_ioc_name_renames_only_a_whole_ioc_segment():
+    assert catio_ioc_name("BL21I-VA-IOC-01") == "BL21I-VA-CATIO-01"
+    assert catio_ioc_name("BL21I-IOCX-IOC-01") == "BL21I-IOCX-CATIO-01"
+
+
+def test_domain_of_takes_the_first_two_segments():
+    assert domain_of("BL21I-VA-IOC-01") == "BL21I-VA"
+
+
+def test_chain_properties_are_the_single_source_of_the_name_templates():
+    chain = Chain("BL21I-VA-IOC-05", "BL21I-VA", 2)
+    assert chain.catio_ioc == "BL21I-VA-CATIO-05"
+    assert chain.services_folder == "bl21i-va-catio-05"
+    assert chain.node_prefix == "BL21I-VA-E2RIO-{:02d}"
+    assert chain.name_mappings() == {
+        "device_prefix": chain.device_prefix,
+        "node_prefix": chain.node_prefix,
+        "module_prefix": chain.module_prefix,
+    }
+
+
+# -- UnresolvedMap -----------------------------------------------------------
+
+
+def test_unresolved_map_prefix_lookup_requires_a_colon_boundary():
+    entry = ("unknown-entity-type", "no table", "BL21I-DI-IOC-01")
+    unresolved = UnresolvedMap()
+    unresolved.add_prefix("BL21I-DI-LED-01", entry)
+    assert unresolved.get("BL21I-DI-LED-01:CHANNEL1:OUTPUT") == entry
+    # a longer sibling name must not be swallowed by the shorter prefix
+    assert unresolved.get("BL21I-DI-LED-011:CHANNEL1:OUTPUT") is None
+    assert unresolved.get("BL21I-DI-LED-01") is None
+
+
+def test_unresolved_map_prefers_exact_keys_and_the_longest_prefix():
+    exact = ("unmapped-suffix", "exact", None)
+    short = ("unknown-entity-type", "short", None)
+    long_ = ("unknown-entity-type", "long", None)
+    unresolved = UnresolvedMap({"A:MOD1:X": exact})
+    unresolved.add_prefix("A", short)
+    unresolved.add_prefix("A:MOD1", long_)
+    assert unresolved.get("A:MOD1:X") == exact
+    assert unresolved.get("A:MOD1:Y") == long_
+    assert unresolved.get("A:MOD2:Y") == short
+    # membership and indexing stay exact -- only get() consults prefixes
+    assert "A:MOD1:Y" not in unresolved
+
+
+# -- scanner detection and topology ------------------------------------------
+
+
+def test_is_scanner_picks_exactly_the_four_scanners():
+    found = []
+    for xml in sorted(SAMPLES.glob("*.xml")):
+        builder = Builder()
+        builder.load(xml)
+        if is_scanner(builder):
+            found.append(xml.stem)
+    assert found == SCANNERS
+    assert not set(found) & set(CONSUMERS)
+
+
+def test_parse_chain_returns_none_for_a_consumer_only_ioc():
+    log = DiagnosticLog()
+    assert parse_chain(SAMPLES / "BL21I-VA-IOC-02.xml", log, ordinal=1) is None
+    assert len(log) == 0
+
+
+@pytest.mark.parametrize("scanner", SCANNERS)
+def test_chain_topology_matches_the_fixture(scanner, expected_chains):
+    chain = parsed(scanner)
+    want = [
+        # the fixture numbers couplers from 0, Slave.node from 1
+        (
+            coupler["node"] + 1,
+            t["position"],
+            t["type_name"],
+            t["declared_device"] or None,
+            t["entity_type"],
+        )
+        for coupler in expected_chains[scanner]["couplers"]
+        for t in coupler["terminals"]
+    ]
+    got = [
+        (s.node, s.position, s.type_name, s.declared_device, s.entity_type)
+        for s in chain.slaves
+    ]
+    assert got == want
+
+
+@pytest.mark.parametrize("scanner", SCANNERS)
+def test_slave_names_and_revisions_match_the_fixture(scanner, expected_chains):
+    chain = parsed(scanner)
+    want = [
+        (t["slave_name"], int(t["revision"], 16))
+        for coupler in expected_chains[scanner]["couplers"]
+        for t in coupler["terminals"]
+    ]
+    assert [(s.slave_name, s.revision) for s in chain.slaves] == want
+
+
+@pytest.mark.parametrize("scanner", SCANNERS)
+def test_coupler_labels_match_the_fixture(scanner, expected_chains):
+    chain = parsed(scanner)
+    want = {c["node"] + 1: c["label"] for c in expected_chains[scanner]["couplers"]}
+    assert chain.labels == want
+
+
+def test_ek1122_consumes_an_ordinary_position_not_a_node():
+    """`EK1122` is a junction, not a coupler: `EK` is not `E[PQR]`."""
+    assert _locate(["EK1100", "EL3104", "EK1122", "EL1014"]) == [
+        (1, 0, "coupler"),
+        (1, 1, "slave"),
+        (1, 2, "slave"),
+        (1, 3, "slave"),
+    ]
+    chain = parsed("BL21I-DI-IOC-01")
+    junctions = [s for s in chain.slaves if s.type_name == "EK1122"]
+    assert junctions, "the DI chain should carry EK1122 junctions"
+    assert all(s.category == "slave" and s.position > 0 for s in junctions)
+    # node 8 (fixture node 7) ends in a junction at position 20, after MOD15
+    node8 = [s for s in chain.slaves if s.node == 8]
+    assert (node8[-1].type_name, node8[-1].position) == ("EK1122", 20)
+
+
+def test_the_coupler_itself_is_position_zero():
+    chain = parsed("BL21I-VA-IOC-01")
+    couplers = [s for s in chain.slaves if s.category == "coupler"]
+    assert len(couplers) == 5
+    assert all(s.position == 0 and s.type_name == "EK1100" for s in couplers)
+
+
+# -- label derivation --------------------------------------------------------
+
+
+def test_va05_third_coupler_is_unlabelled():
+    log = DiagnosticLog()
+    chain = parsed("BL21I-VA-IOC-05", log)
+    assert chain.labels == {1: "BL21I-VA-ERIO-05", 2: "BL21I-VA-ERIO-06", 3: None}
+    unlabelled = [d for d in log if d.code == "unlabelled-coupler"]
+    assert len(unlabelled) == 1
+    assert unlabelled[0].severity is Severity.WARNING
+    assert unlabelled[0].chain == "BL21I-VA-IOC-05"
+    assert not log.has_errors()
+
+
+def test_va06_label_comes_from_the_declaration_not_the_comment():
+    """The XML comment says ERIO-05; the only `DEVICE=` says ERIO-99."""
+    log = DiagnosticLog()
+    chain = parsed("BL21I-VA-IOC-06", log)
+    assert chain.labels == {1: "BL21I-VA-ERIO-99"}
+    assert len(log) == 0
+
+
+def test_two_couplers_sharing_a_label_is_a_warning_not_a_failure():
+    log = DiagnosticLog()
+    chain = parsed("BL21I-DI-IOC-01", log)
+    assert chain.labels[8] == chain.labels[9] == "BL21I-DI-ERIO-01"
+    duplicates = [d for d in log if d.code == "duplicate-coupler-label"]
+    assert len(duplicates) == 1
+    assert duplicates[0].severity is Severity.WARNING
+    assert not log.has_errors()
+    assert "BL21I-DI-IOC-01" not in log.failed_chains()
+
+
+def test_devices_without_a_mod_part_are_ignored_for_label_derivation():
+    log = DiagnosticLog()
+    chain = parsed("BL21I-DI-IOC-01", log)
+    without = [d for d in log if d.code == "device-without-mod"]
+    assert len(without) == 6
+    assert all(d.severity is Severity.WARNING for d in without)
+    assert {d.entity for d in without} == {
+        "D1.Led",
+        "D2.Led",
+        "D3A.Led",
+        "FS1.Led",
+        "M1.Piezo",
+        "M2.Piezo",
+    }
+    assert all(d.attribute == "DEVICE" for d in without)
+    # node 7 has two such entities and nothing else, so it ends up unlabelled
+    assert chain.labels[7] is None
+
+
+def test_unlabelled_couplers_are_exactly_the_four_the_fixture_names():
+    log = DiagnosticLog()
+    chain = parsed("BL21I-DI-IOC-01", log)
+    assert [n for n, label in chain.labels.items() if label is None] == [1, 5, 6, 7]
+    assert codes(log)["unlabelled-coupler"] == 4
+
+
+def test_disagreeing_devices_on_one_coupler_are_a_label_conflict(tmp_path):
+    xml = tmp_path / "BL99Z-XX-IOC-01.xml"
+    xml.write_text(
+        '<?xml version="1.0" ?>\n'
+        '<components arch="linux-x86_64">\n'
+        '<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>\n'
+        '<ethercat.EthercatSlave master="ECATM" name="C1" type_rev="EK1100 rev 0x1"/>\n'
+        '<ethercat.EthercatSlave master="ECATM" name="T1" type_rev="EL3104 rev 0x1"/>\n'
+        '<ethercat.EthercatSlave master="ECATM" name="T2" type_rev="EL3104 rev 0x1"/>\n'
+        '<ethercat.auto_EL3104 DEVICE="BL99Z-XX-ERIO-01:MOD1" PORT="T1" name="A"/>\n'
+        '<ethercat.auto_EL3104 DEVICE="BL99Z-XX-ERIO-02:MOD2" PORT="T2" name="B"/>\n'
+        "</components>\n"
+    )
+    log = DiagnosticLog()
+    chain = parse_chain(xml, log, ordinal=1)
+    assert chain is not None
+    assert chain.labels == {1: None}
+    conflicts = [d for d in log if d.code == "coupler-label-conflict"]
+    assert len(conflicts) == 1
+    assert conflicts[0].severity is Severity.ERROR
+    assert log.failed_chains() == {"BL99Z-XX-IOC-01"}
+
+
+# -- declaration cross-checks ------------------------------------------------
+
+
+def test_mod1_restart_raises_device_mod_mismatch_at_warning():
+    log = DiagnosticLog()
+    parsed("BL21I-VA-IOC-01", log)
+    mismatches = [d for d in log if d.code == "device-mod-mismatch"]
+    # ERIO-04 and ERIO-03 each restart at MOD1 for their two EL1014s
+    assert len(mismatches) == 4
+    assert all(d.severity is Severity.WARNING for d in mismatches)
+    assert not log.has_errors()
+
+
+def test_device_mod_mismatch_becomes_an_error_under_strict():
+    log = DiagnosticLog(strict=True)
+    parsed("BL21I-VA-IOC-01", log)
+    mismatches = [d for d in log if d.code == "device-mod-mismatch"]
+    assert len(mismatches) == 4
+    assert all(d.severity is Severity.ERROR for d in mismatches)
+    assert log.failed_chains() == {"BL21I-VA-IOC-01"}
+
+
+def test_non_numeric_mod_names_never_raise_device_mod_mismatch():
+    """`MODSAM3`..`MODSAM7` are opaque labels, not bus positions."""
+    log = DiagnosticLog()
+    chain = parsed("BL21I-DI-IOC-01", log)
+    sam = [
+        s
+        for s in chain.slaves
+        if (s.declared_device or "").startswith("BL21I-DI-ERIO-05:MODSAM")
+    ]
+    assert len(sam) == 5
+    flagged = {d.entity for d in log if d.code == "device-mod-mismatch"}
+    assert not flagged & {s.entity_name for s in sam}
+
+
+def test_slave_type_mismatch_is_a_warning():
+    """Five `EL2024` slaves are bound to `auto_EL2024_0010` entities."""
+    log = DiagnosticLog()
+    parsed("BL21I-DI-IOC-01", log)
+    mismatches = [d for d in log if d.code == "slave-type-mismatch"]
+    assert len(mismatches) == 5
+    assert all(d.severity is Severity.WARNING for d in mismatches)
+    assert not log.has_errors()
+
+
+def test_unknown_entity_types_raise_nothing_while_parsing():
+    """`auto_EL2595` / `auto_EL4134` only matter if something references them."""
+    log = DiagnosticLog()
+    chain = parsed("BL21I-DI-IOC-01", log)
+    unknown = [s for s in chain.slaves if s.entity_type and not s.is_known]
+    assert {s.entity_type for s in unknown} == {"auto_EL2595", "auto_EL4134"}
+    assert "unknown-entity-type" not in codes(log)
+    assert not log.has_errors()
+
+
+def test_the_whole_bl21i_beamline_parses_without_a_single_error():
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log)
+    assert [c.scanner_ioc for c in chains] == SCANNERS
+    assert codes(log) == Counter(
+        {
+            "device-mod-mismatch": 32,
+            "device-without-mod": 6,
+            "unlabelled-coupler": 5,
+            "slave-type-mismatch": 5,
+            "duplicate-coupler-label": 1,
+        }
+    )
+    assert not log.has_errors()
+
+
+# -- ordinal allocation ------------------------------------------------------
+
+
+def test_ordinals_are_allocated_per_domain_in_scanner_name_order():
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log)
+    assert {c.scanner_ioc: c.ordinal for c in chains} == {
+        "BL21I-DI-IOC-01": 1,
+        "BL21I-VA-IOC-01": 1,
+        "BL21I-VA-IOC-05": 2,
+        "BL21I-VA-IOC-06": 3,
+    }
+    assert {c.scanner_ioc: c.node_prefix for c in chains}["BL21I-VA-IOC-06"] == (
+        "BL21I-VA-E3RIO-{:02d}"
+    )
+
+
+def test_sticky_ordinals_are_honoured_and_never_renumbered():
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log, sticky={"BL21I-VA-CATIO-05": 3})
+    allocated = {c.scanner_ioc: c.ordinal for c in chains}
+    assert allocated["BL21I-VA-IOC-05"] == 3
+    # the other two take the lowest ordinals still free, in name order
+    assert allocated["BL21I-VA-IOC-01"] == 1
+    assert allocated["BL21I-VA-IOC-06"] == 2
+    assert allocated["BL21I-DI-IOC-01"] == 1
+
+
+def test_sticky_ordinals_from_another_domain_do_not_leak():
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log, sticky={"BL21I-DI-CATIO-01": 4})
+    allocated = {c.scanner_ioc: c.ordinal for c in chains}
+    assert allocated["BL21I-DI-IOC-01"] == 4
+    assert allocated["BL21I-VA-IOC-01"] == 1
+
+
+def test_clashing_sticky_ordinals_are_a_value_error_not_a_diagnostic():
+    log = DiagnosticLog()
+    with pytest.raises(ValueError, match="pins ordinal 2 to both"):
+        discover_chains(
+            SAMPLES,
+            log,
+            sticky={"BL21I-VA-CATIO-01": 2, "BL21I-VA-CATIO-05": 2},
+        )
+
+
+def test_discover_chains_accepts_a_builder_root(tmp_path):
+    make_iocs = tmp_path / "etc" / "makeIocs"
+    make_iocs.mkdir(parents=True)
+    for scanner in SCANNERS:
+        (make_iocs / f"{scanner}.xml").write_text(
+            (SAMPLES / f"{scanner}.xml").read_text()
+        )
+    log = DiagnosticLog()
+    assert [c.scanner_ioc for c in discover_chains(tmp_path, log)] == SCANNERS
+
+
+# -- the fastcs-catio boundary ----------------------------------------------
+
+
+def test_predict_prefixes_names_the_side_venv_when_fastcs_is_absent():
+    try:
+        import fastcs_catio  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        pytest.skip("fastcs_catio is installed, so the ImportError cannot fire")
+    with pytest.raises(ImportError, match=r"\.venv-catio"):
+        predict_prefixes(parsed("BL21I-VA-IOC-06"), DiagnosticLog())
+
+
+# ============================================================================
+# Everything below needs the real fastcs-catio naming API.
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def _fastcs():
+    return pytest.importorskip(
+        "fastcs_catio.naming",
+        reason="run with .venv-catio/bin/python -m pytest",
+    )
+
+
+@pytest.fixture(scope="module")
+def converted():
+    """Every sample chain, with its substituter, built exactly as the CLI does."""
+    pytest.importorskip("fastcs_catio.naming")
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log)
+    substituter = build_substituter(chains, log)
+    return chains, substituter, log
+
+
+def test_local_locate_agrees_with_fastcs_catio(_fastcs):
+    """The one guard against the duplicated bus walk drifting."""
+    for scanner in SCANNERS:
+        chain = parsed(scanner)
+        entries = [_fastcs.ChainEntry(s.type_name, s.revision) for s in chain.slaves]
+        theirs = _fastcs._locate(entries)
+        ours = [(s.node, s.position, s.category) for s in chain.slaves]
+        assert ours == theirs, scanner
+
+
+def test_the_three_worked_examples(converted):
+    _, substituter, _ = converted
+    assert substituter.subs["BL21I-VA-ERIO-01:MOD1:INPUT1:VALUE"].read == (
+        "BL21I-VA-E1RIO-05:10VAI01:AiStandardChannel1Value"
+    )
+    assert substituter.subs["BL21I-VA-ERIO-01:MOD5:CHANNEL1:INPUT"].read == (
+        "BL21I-VA-E1RIO-05:24VDI01:Channel1"
+    )
+    assert substituter.subs["BL21I-VA-ERIO-04:MOD1:INPUT1:VALUE"].read == (
+        "BL21I-VA-E1RIO-01:10VAI01:AiStandardChannel1Value"
+    )
+
+
+def test_the_dual_key_map_makes_the_mod1_restart_harmless(converted):
+    """Declared `MOD1` and chain-derived `MOD5` land on the same terminal."""
+    _, substituter, _ = converted
+    declared = substituter.subs["BL21I-VA-ERIO-04:MOD1:CHANNEL1:INPUT"]
+    derived = substituter.subs["BL21I-VA-ERIO-04:MOD5:CHANNEL1:INPUT"]
+    assert declared == derived
+    assert declared.read == "BL21I-VA-E1RIO-01:24VDI01:Channel1"
+    # and the EL3104 that also declares MOD1 is disambiguated by its leaf
+    assert substituter.subs["BL21I-VA-ERIO-04:MOD1:INPUT1:VALUE"].read.endswith(
+        "10VAI01:AiStandardChannel1Value"
+    )
+
+
+def test_a_declared_name_beats_a_colliding_chain_derived_alias(converted):
+    """`ERIO-01:MOD10` is declared at bus position 14 and derived at 10."""
+    chains, substituter, _ = converted
+    di = next(c for c in chains if c.scanner_ioc == "BL21I-DI-IOC-01")
+    declared_at = next(
+        s for s in di.slaves if s.declared_device == "BL21I-DI-ERIO-01:MOD10"
+    )
+    assert (declared_at.node, declared_at.position) == (8, 14)
+    prefixes = predict_prefixes(di, DiagnosticLog())
+    assert substituter.subs["BL21I-DI-ERIO-01:MOD10:CHANNEL1:OUTPUT"].write == (
+        f"{prefixes[(8, 14)]}:Channel1"
+    )
+    assert "BL21I-DI-ERIO-01:MOD10:CHANNEL1:OUTPUT" not in substituter.unresolved
+
+
+def test_modsam_names_resolve_because_declared_names_are_opaque(converted):
+    _, substituter, _ = converted
+    for n in range(3, 8):
+        key = f"BL21I-DI-ERIO-05:MODSAM{n}:CHANNEL1:OUTPUT"
+        assert substituter.subs[key].write.endswith(":Channel1")
+
+
+def test_el2024_0010_is_read_write_so_readers_get_the_rbv(converted):
+    _, substituter, _ = converted
+    rw = substituter.subs["BL21I-DI-ERIO-09:MOD1:CHANNEL1:OUTPUT"]
+    assert rw.writable
+    assert rw.read == rw.write + "_RBV"
+    # a read-only EL1014 leaf has one name for both directions
+    ro = substituter.subs["BL21I-VA-ERIO-04:MOD5:CHANNEL1:INPUT"]
+    assert not ro.writable
+
+
+def test_unmapped_suffixes_are_registered_as_unresolved(converted):
+    _, substituter, _ = converted
+    entry = substituter.unresolved["BL21I-VA-ERIO-04:MOD3:AL_STATE"]
+    assert entry[0] == "unmapped-suffix"
+    assert entry[2] == "BL21I-VA-IOC-01"
+
+
+def test_unknown_entity_types_resolve_by_prefix(converted):
+    _, substituter, _ = converted
+    code, _, chain = substituter.unresolved.get("BL21I-DI-LED-01:CHANNEL1:OUTPUT")
+    assert code == "unknown-entity-type"
+    assert chain == "BL21I-DI-IOC-01"
+
+
+def test_no_leaf_is_shortened_at_the_emitted_prefixes(converted):
+    chains, _, _ = converted
+    for chain in chains:
+        log = DiagnosticLog()
+        predict_prefixes(chain, log)
+        assert [d for d in log if d.code == "shortened-leaf"] == []
+
+
+def test_the_shortening_guard_fires_for_a_four_segment_node_prefix(monkeypatch):
+    """fastcs-catio's *default* node_prefix truncates the channel out of a leaf."""
+    pytest.importorskip("fastcs_catio.naming")
+    chain = parsed("BL21I-VA-IOC-01")
+    monkeypatch.setattr(
+        Chain, "node_prefix", property(lambda self: "{device_prefix}:E1RIO{:02d}")
+    )
+    log = DiagnosticLog()
+    predict_prefixes(chain, log)
+    shortened = [d for d in log if d.code == "shortened-leaf"]
+    assert shortened
+    assert all(d.severity is Severity.ERROR for d in shortened)
+    assert "ai_standard_channel_1_value" in shortened[0].message
+    assert log.failed_chains() == {"BL21I-VA-IOC-01"}
+
+
+def test_unknown_terminal_types_fail_the_chain(tmp_path):
+    pytest.importorskip("fastcs_catio.naming")
+    xml = tmp_path / "BL99Z-XX-IOC-01.xml"
+    xml.write_text(
+        '<?xml version="1.0" ?>\n'
+        '<components arch="linux-x86_64">\n'
+        '<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>\n'
+        '<ethercat.EthercatSlave master="ECATM" name="C1" type_rev="EK1100 rev 0x1"/>\n'
+        '<ethercat.EthercatSlave master="ECATM" name="T1" type_rev="EL9999 rev 0x1"/>\n'
+        "</components>\n"
+    )
+    log = DiagnosticLog()
+    chain = parse_chain(xml, log, ordinal=1)
+    assert chain is not None
+    assert predict_prefixes(chain, log) == {}
+    assert [d.code for d in log] == ["unlabelled-coupler", "unknown-terminal-type"]
+    assert log.failed_chains() == {"BL99Z-XX-IOC-01"}
+
+
+def test_every_consumer_reference_on_bl21i_rewrites_cleanly(
+    converted, expected_references
+):
+    """The end-to-end contract: 177 real references, no errors, no chain lost."""
+    _, substituter, log = converted
+    changed = 0
+    for row in expected_references:
+        if row["entity_type"].startswith("ethercat.auto_"):
+            continue  # the declarations themselves, deleted rather than rewritten
+        after = substituter.rewrite_value(
+            row["value"],
+            attribute=row["attribute"],
+            log=log,
+            ioc=row["ioc"],
+            entity=row["entity_name"],
+        )
+        assert after != row["value"], row
+        changed += 1
+    assert changed == 177
+    assert report_unused_ambiguities(substituter, log) == []
+    assert log.errors == []
+    assert log.failed_chains() == set()
+    # VA-IOC-06's only reference row is its own auto_EL3104 declaration, which
+    # is skipped above -- the entity is deleted by the converter, not rewritten.
+    assert substituter.touched_iocs() == {
+        "BL21I-DI-IOC-01",
+        "BL21I-VA-IOC-01",
+        "BL21I-VA-IOC-02",
+        "BL21I-VA-IOC-04",
+        "BL21I-VA-IOC-05",
+    }
+
+
+def test_a_failed_chain_contributes_no_substitutions():
+    pytest.importorskip("fastcs_catio.naming")
+    log = DiagnosticLog(strict=True)  # promotes device-mod-mismatch to ERROR
+    chains = discover_chains(SAMPLES, log)
+    assert log.failed_chains() == {"BL21I-DI-IOC-01", "BL21I-VA-IOC-01"}
+    substituter = build_substituter(chains, log)
+    assert set(substituter.owners.values()) == {
+        "BL21I-VA-IOC-05",
+        "BL21I-VA-IOC-06",
+    }
+    assert "BL21I-VA-ERIO-01:MOD1:INPUT1:VALUE" not in substituter.subs
+
+
+def test_report_unused_ambiguities_downgrades_only_untouched_ones():
+    pytest.importorskip("fastcs_catio.naming")
+    log = DiagnosticLog()
+    chains = discover_chains(SAMPLES, log)
+    substituter = build_substituter(chains, log)
+    # inject an ambiguity nothing references, and one that is referenced
+    for key in ("BL21I-VA-ERIO-01:MOD9:GHOST", "BL21I-VA-ERIO-01:MOD8:SEEN"):
+        substituter.unresolved[key] = (
+            "ambiguous-legacy-pv",
+            f"{key} maps to more than one fastcs-catio PV",
+            "BL21I-VA-IOC-01",
+        )
+    substituter.rewrite_value(
+        "BL21I-VA-ERIO-01:MOD8:SEEN",
+        attribute="INP",
+        log=log,
+        ioc="BL21I-VA-IOC-04",
+        entity="thing",
+    )
+    assert report_unused_ambiguities(substituter, log) == [
+        "BL21I-VA-ERIO-01:MOD9:GHOST"
+    ]
+    assert codes(log)["ambiguous-legacy-pv"] == 1
+    assert codes(log)["ambiguous-legacy-pv-unused"] == 1
+
+
+def test_slave_dataclass_is_hashable_and_frozen():
+    slave = Slave(1, 1, "EL3104", 1, "P", "slave", "auto_EL3104")
+    assert hash(slave)
+    with pytest.raises(AttributeError):
+        slave.position = 2  # type: ignore[misc]

--- a/tests/test_catio_chains.py
+++ b/tests/test_catio_chains.py
@@ -336,12 +336,18 @@ def test_slave_type_mismatch_is_a_warning():
     assert not log.has_errors()
 
 
-def test_unknown_entity_types_raise_nothing_while_parsing():
-    """`auto_EL2595` / `auto_EL4134` only matter if something references them."""
+def test_every_entity_type_on_the_bl21i_chains_has_a_leaf_table():
+    """No BL21I terminal is left without a translation table.
+
+    `auto_EL2595` and `auto_EL4134` were the last two missing, and they are what
+    kept `BL21I-DI-IOC-01` from converting. Removing either table puts a real
+    beamline back into the skipped set, so assert the coverage directly rather
+    than only through the end-to-end counts.
+    """
     log = DiagnosticLog()
     chain = parsed("BL21I-DI-IOC-01", log)
-    unknown = [s for s in chain.slaves if s.entity_type and not s.is_known]
-    assert {s.entity_type for s in unknown} == {"auto_EL2595", "auto_EL4134"}
+    unknown = {s.entity_type for s in chain.slaves if s.entity_type and not s.is_known}
+    assert unknown == set()
     assert "unknown-entity-type" not in codes(log)
     assert not log.has_errors()
 
@@ -531,11 +537,17 @@ def test_unmapped_suffixes_are_registered_as_unresolved(converted):
     assert entry[2] == "BL21I-VA-IOC-01"
 
 
-def test_unknown_entity_types_resolve_by_prefix(converted):
+def test_a_device_style_name_resolves_without_a_coupler_label(converted):
+    """`BL21I-DI-LED-01` names its device, not its bus slot, and still maps.
+
+    Terminals like this sit on couplers with no derivable label, so they get a
+    declared key and no chain-derived alias. The declared key is the one the
+    legacy IOC actually created, so it is the one that has to work.
+    """
     _, substituter, _ = converted
-    code, _, chain = substituter.unresolved.get("BL21I-DI-LED-01:CHANNEL1:OUTPUT")
-    assert code == "unknown-entity-type"
-    assert chain == "BL21I-DI-IOC-01"
+    new = substituter.subs["BL21I-DI-LED-01:DOXCURRENT:OUTPUTCURRENT"]
+    assert new.write.endswith(":DoxCurrentOutputCurrent")
+    assert new.read.endswith(":DoxCurrentOutputCurrent_RBV")
 
 
 def test_no_leaf_is_shortened_at_the_emitted_prefixes(converted):

--- a/tests/test_catio_cli.py
+++ b/tests/test_catio_cli.py
@@ -312,13 +312,19 @@ def test_existing_description_survives_a_corrupt_file(tmp_path: Path):
 # -- CLI surface -------------------------------------------------------------
 
 
-def test_help_lists_every_option():
+def test_help_lists_every_option(monkeypatch):
+    # Rich styles and wraps help to the perceived terminal. Colour splits an
+    # option name across escape sequences ("--services-repo" becomes
+    # ESC[1;36m-ESC[0mESC[1;36m-servicesESC[0m...), and a narrow width would
+    # break it across lines. CI is such an environment and a developer's shell
+    # usually is not, which is how this passed locally and failed on the runner.
+    # Pin the width and disable colour, then strip anything that survives.
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.setenv("COLUMNS", "200")
     result = CliRunner().invoke(cli, ["catio", "--help"])
     assert result.exit_code == 0
-    # Rich colourises the help when it thinks a terminal is attached, which
-    # splits an option name across escape sequences ("--services-repo" becomes
-    # ESC[1;36m-ESC[0mESC[1;36m-servicesESC[0m..."). CI is such an environment
-    # and a developer's shell usually is not, so strip the codes before looking.
     text = _ANSI_RE.sub("", result.output)
     for option in (
         "--services-repo",

--- a/tests/test_catio_cli.py
+++ b/tests/test_catio_cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -44,6 +45,9 @@ from builder2ibek.catio.cli import (
 )
 
 CATIO_SAMPLES = Path(__file__).parent / "samples" / "catio"
+
+#: CSI escape sequences, as Rich emits them when it colourises help output.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 HAS_FASTCS = importlib.util.find_spec("fastcs_catio") is not None
 HAS_SERVICES = importlib.util.find_spec("builder2ibek.catio.services") is not None
@@ -311,7 +315,11 @@ def test_existing_description_survives_a_corrupt_file(tmp_path: Path):
 def test_help_lists_every_option():
     result = CliRunner().invoke(cli, ["catio", "--help"])
     assert result.exit_code == 0
-    text = result.output
+    # Rich colourises the help when it thinks a terminal is attached, which
+    # splits an option name across escape sequences ("--services-repo" becomes
+    # ESC[1;36m-ESC[0mESC[1;36m-servicesESC[0m..."). CI is such an environment
+    # and a developer's shell usually is not, so strip the codes before looking.
+    text = _ANSI_RE.sub("", result.output)
     for option in (
         "--services-repo",
         "--strict",

--- a/tests/test_catio_cli.py
+++ b/tests/test_catio_cli.py
@@ -1,0 +1,598 @@
+"""Tests for the ``builder2ibek catio`` command body.
+
+``builder2ibek.catio.services`` is written by another agent and may not exist
+yet, so almost every test here drives the flow through a :class:`StubServices`
+injected in place of :func:`builder2ibek.catio.cli._load_services`. The one test
+that exercises the real writer skips itself until that module lands. The fake
+services-repo fixture is deliberately minimal and local to this file rather than
+shared through ``conftest.py``: ``tests/test_catio_services.py`` does not exist
+yet, so there is nothing to factor out with, and a premature ``conftest.py``
+fixture would collide with whatever that file brings.
+
+Anything that has to predict a fastcs-catio PV name needs `fastcs_catio`, which
+builder2ibek's own environment deliberately lacks, so those tests are gated on
+``importorskip``. Run them with the side venv:
+
+    env -u EPICS_ROOT .venv-catio/bin/python -m pytest tests/test_catio_cli.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from builder2ibek.__main__ import cli
+from builder2ibek.catio import cli as catio_cli_module
+from builder2ibek.catio.chains import Chain
+from builder2ibek.catio.cli import (
+    CatioReport,
+    _existing_description,
+    _expand_template,
+    _is_template_xml,
+    _OverriddenChain,
+    _placeholder_line,
+    _scan_placeholders,
+    _xml_dir,
+    apply_prefix_overrides,
+    catio_cli,
+)
+
+CATIO_SAMPLES = Path(__file__).parent / "samples" / "catio"
+
+HAS_FASTCS = importlib.util.find_spec("fastcs_catio") is not None
+HAS_SERVICES = importlib.util.find_spec("builder2ibek.catio.services") is not None
+
+needs_fastcs = pytest.mark.skipif(
+    not HAS_FASTCS, reason="fastcs_catio is only installed in .venv-catio"
+)
+
+
+# -- doubles -----------------------------------------------------------------
+
+
+class StubServices:
+    """A stand-in for ``builder2ibek.catio.services``.
+
+    Implements the module's contract exactly -- ``read_sticky_ordinals``,
+    ``scaffold``, ``write_catio_ioc``, ``write_ioc`` -- and records what it was
+    asked to do. Writes just enough real content that the CLI's placeholder
+    sweep has something to find.
+    """
+
+    def __init__(self, sticky: dict[str, int] | None = None) -> None:
+        self.sticky = sticky or {}
+        self.written_iocs: list[str] = []
+        self.written_chains: list[str] = []
+        self.name_mappings: dict[str, dict[str, str]] = {}
+        self.dry_runs: set[bool] = set()
+
+    def read_sticky_ordinals(self, services_repo: Path) -> dict[str, int]:
+        return dict(self.sticky)
+
+    def scaffold(
+        self, services_repo: Path, folder: str, *, fastcs: bool, dry_run: bool
+    ) -> Path:
+        path = services_repo / "services" / folder
+        if not dry_run:
+            (path / "config").mkdir(parents=True, exist_ok=True)
+        return path
+
+    def write_catio_ioc(
+        self, services_repo: Path, chain: Chain, *, dry_run: bool
+    ) -> list[str]:
+        self.written_chains.append(chain.catio_ioc)
+        self.name_mappings[chain.catio_ioc] = chain.name_mappings()
+        self.dry_runs.add(dry_run)
+        path = self.scaffold(
+            services_repo, chain.services_folder, fastcs=True, dry_run=dry_run
+        )
+        if not dry_run:
+            (path / "values.yaml").write_text(
+                "ioc-instance:\n  image: REPLACE_WITH_FASTCS_IMAGE_URI\n"
+            )
+            (path / "config" / "fastcs.yaml").write_text(
+                json.dumps(chain.name_mappings())
+            )
+        return ["REPLACE_WITH_FASTCS_IMAGE_URI"]
+
+    def write_ioc(
+        self, services_repo: Path, ioc_name: str, ioc, *, dry_run: bool
+    ) -> Path:
+        self.written_iocs.append(ioc_name)
+        self.dry_runs.add(dry_run)
+        path = self.scaffold(
+            services_repo, ioc_name.lower(), fastcs=False, dry_run=dry_run
+        )
+        if not dry_run:
+            (path / "values.yaml").write_text(
+                "ioc-instance:\n  image: REPLACE_WITH_IMAGE_URI\n"
+            )
+            (path / "config" / "ioc.yaml").write_text(
+                f"ioc_name: {ioc_name}\ndescription: {ioc.description}\n"
+                f"entities: {ioc.entities}\n"
+            )
+        return path
+
+
+@pytest.fixture
+def stub(monkeypatch) -> StubServices:
+    services = StubServices()
+    monkeypatch.setattr(catio_cli_module, "_load_services", lambda: services)
+    return services
+
+
+@pytest.fixture
+def services_repo(tmp_path: Path) -> Path:
+    """A minimal services repo: the shared chart plus the two scaffolds."""
+    repo = tmp_path / "i21-services"
+    shared = repo / ".helm-shared"
+    (shared / "templates").mkdir(parents=True)
+    (shared / "Chart.yaml").write_text("apiVersion: v2\nname: ec-service\n")
+    (shared / "templates" / "ioc_instance.yaml").write_text(
+        '{{ include "ioc-instance" . }}\n'
+    )
+    for name, values in (
+        (".ioc_template", "ioc-instance:\n  image: REPLACE_WITH_IMAGE_URI\n"),
+        (
+            ".fastcs_ioc_template",
+            "ioc-instance:\n  image: REPLACE_WITH_FASTCS_IMAGE_URI\n",
+        ),
+    ):
+        folder = repo / "services" / name
+        (folder / "config").mkdir(parents=True)
+        (folder / "values.yaml").write_text(values)
+        (folder / "config" / "ioc.yaml").write_text(
+            "description: REPLACE_WITH_DESCRIPTION\nentities: []\n"
+        )
+        (folder / "Chart.yaml").symlink_to("../../.helm-shared/Chart.yaml")
+        (folder / "templates").symlink_to("../../.helm-shared/templates")
+    return repo
+
+
+#: A synthetic IOC with no EtherCAT anything, standing in for the IOCs this
+#: command must leave entirely alone. Synthetic rather than a real sample
+#: because several real ones (BL21I-MO-IOC-01 among them) make their converter
+#: write a blacklist file into the working directory.
+BYSTANDER_XML = """<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+    <asyn.AsynIP name="BYSTANDER" port="192.168.0.1:7001"/>
+</components>
+"""
+
+
+@pytest.fixture
+def builder_tree(tmp_path: Path) -> Path:
+    """A BUILDER support module: the four chains, two consumers, one bystander."""
+    root = tmp_path / "BL21I-BUILDER"
+    make_iocs = root / "etc" / "makeIocs"
+    make_iocs.mkdir(parents=True)
+    for xml in sorted(CATIO_SAMPLES.glob("*.xml")):
+        shutil.copy(xml, make_iocs / xml.name)
+    (make_iocs / "BL21I-MO-IOC-99.xml").write_text(BYSTANDER_XML)
+    return root
+
+
+def run_catio(builder_path: Path, services_repo: Path, **kwargs) -> int:
+    """Call :func:`catio_cli` and return its exit code rather than raising."""
+    try:
+        catio_cli(builder_path, services_repo, **kwargs)
+    except typer.Exit as exc:
+        return int(exc.exit_code)
+    return 0
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+def test_is_template_xml():
+    assert _is_template_xml(Path("GIGE-FIT-TEMPLATE.xml"))
+    assert _is_template_xml(Path("$(IOC)-thing.xml"))
+    assert not _is_template_xml(Path("BL21I-VA-IOC-02.xml"))
+
+
+def test_xml_dir_prefers_make_iocs(tmp_path: Path):
+    root = tmp_path / "BL21I-BUILDER"
+    (root / "etc" / "makeIocs").mkdir(parents=True)
+    assert _xml_dir(root) == root / "etc" / "makeIocs"
+
+
+def test_xml_dir_accepts_a_leaf_folder(tmp_path: Path):
+    assert _xml_dir(tmp_path) == tmp_path
+
+
+def test_expand_template_leaves_fastcs_placeholders_alone():
+    chain = Chain("BL21I-VA-IOC-01", "BL21I-VA", 3)
+    assert _expand_template("{domain}-E{n}RIO-{:02d}", chain) == (
+        "BL21I-VA-E3RIO-{:02d}"
+    )
+    assert _expand_template("{node_prefix}:{group_alias}{:02d}", chain) == (
+        "{node_prefix}:{group_alias}{:02d}"
+    )
+
+
+def test_overridden_chain_feeds_name_mappings():
+    base = Chain("BL21I-VA-IOC-01", "BL21I-VA", 2)
+    chain = _OverriddenChain(
+        base, node_prefix="{domain}-RIO{n}-{:02d}", device_prefix="{id}:EC{:02d}"
+    )
+    assert chain.node_prefix == "BL21I-VA-RIO2-{:02d}"
+    assert chain.name_mappings() == {
+        "node_prefix": "BL21I-VA-RIO2-{:02d}",
+        "module_prefix": base.module_prefix,
+        "device_prefix": "{id}:EC{:02d}",
+    }
+    # identity of the chain is untouched
+    assert chain.catio_ioc == "BL21I-VA-CATIO-01"
+    assert chain.services_folder == "bl21i-va-catio-01"
+
+
+def test_apply_prefix_overrides_is_a_no_op_without_overrides():
+    chains = [Chain("BL21I-VA-IOC-01", "BL21I-VA", 1)]
+    assert apply_prefix_overrides(chains) is chains
+
+
+def test_apply_prefix_overrides_wraps_every_chain():
+    chains = [
+        Chain("BL21I-VA-IOC-01", "BL21I-VA", 1),
+        Chain("BL21I-DI-IOC-01", "BL21I-DI", 1),
+    ]
+    wrapped = apply_prefix_overrides(chains, node_prefix="{domain}-X{n}-{:02d}")
+    assert [c.node_prefix for c in wrapped] == [
+        "BL21I-VA-X1-{:02d}",
+        "BL21I-DI-X1-{:02d}",
+    ]
+
+
+def test_placeholder_line_qualifies_bare_tokens():
+    folder = Path("services/bl21i-va-catio-01")
+    assert _placeholder_line(folder, "REPLACE_WITH_IMAGE_URI") == (
+        "services/bl21i-va-catio-01: REPLACE_WITH_IMAGE_URI"
+    )
+    assert _placeholder_line(folder, "values.yaml: REPLACE_WITH_X") == (
+        "values.yaml: REPLACE_WITH_X"
+    )
+
+
+def test_scan_placeholders_finds_tokens_and_skips_symlinks(tmp_path: Path):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "chart.yaml").write_text("REPLACE_WITH_SHARED_THING\n")
+    folder = tmp_path / "ioc"
+    (folder / "config").mkdir(parents=True)
+    (folder / "values.yaml").write_text("image: REPLACE_WITH_IMAGE_URI\n")
+    (folder / "config" / "ioc.yaml").write_text("description: REPLACE_WITH_DESCRIPTION")
+    (folder / "templates").symlink_to(shared)
+
+    found = _scan_placeholders(folder)
+
+    assert any(line.endswith("values.yaml: REPLACE_WITH_IMAGE_URI") for line in found)
+    assert any(line.endswith("ioc.yaml: REPLACE_WITH_DESCRIPTION") for line in found)
+    assert not any("SHARED" in line for line in found)
+
+
+def test_scan_placeholders_of_a_missing_folder_is_empty(tmp_path: Path):
+    assert _scan_placeholders(tmp_path / "nope") == []
+
+
+def test_existing_description_round_trips(tmp_path: Path):
+    config = tmp_path / "services" / "bl21i-va-ioc-02" / "config"
+    config.mkdir(parents=True)
+    (config / "ioc.yaml").write_text("description: Vacuum IOC 2\nentities: []\n")
+    assert _existing_description(tmp_path, "BL21I-VA-IOC-02") == "Vacuum IOC 2"
+
+
+def test_existing_description_ignores_scaffold_placeholder(tmp_path: Path):
+    config = tmp_path / "services" / "bl21i-va-ioc-02" / "config"
+    config.mkdir(parents=True)
+    (config / "ioc.yaml").write_text("description: REPLACE_WITH_DESCRIPTION\n")
+    assert _existing_description(tmp_path, "BL21I-VA-IOC-02") == ""
+
+
+def test_existing_description_of_an_unknown_ioc_is_empty(tmp_path: Path):
+    assert _existing_description(tmp_path, "BL21I-VA-IOC-02") == ""
+
+
+def test_existing_description_survives_a_corrupt_file(tmp_path: Path):
+    config = tmp_path / "services" / "bl21i-va-ioc-02" / "config"
+    config.mkdir(parents=True)
+    (config / "ioc.yaml").write_text("description: [unclosed\n")
+    assert _existing_description(tmp_path, "BL21I-VA-IOC-02") == ""
+
+
+# -- CLI surface -------------------------------------------------------------
+
+
+def test_help_lists_every_option():
+    result = CliRunner().invoke(cli, ["catio", "--help"])
+    assert result.exit_code == 0
+    text = result.output
+    for option in (
+        "--services-repo",
+        "--strict",
+        "--no-strict",
+        "--dry-run",
+        "--json",
+        "--node-prefix",
+        "--module-prefix",
+        "--device-prefix",
+    ):
+        assert option in text, option
+    # typer renders the argument's name differently across versions
+    assert "builder_path" in text.lower()
+
+
+def test_services_repo_is_required(builder_tree: Path, stub: StubServices):
+    result = CliRunner().invoke(cli, ["catio", str(builder_tree)])
+    assert result.exit_code != 0
+    assert stub.written_iocs == []
+
+
+def test_missing_builder_path_fails_cleanly(
+    tmp_path: Path, services_repo: Path, stub: StubServices, capsys
+):
+    with pytest.raises(typer.Exit) as exc:
+        catio_cli(tmp_path / "nope", services_repo)
+    assert exc.value.exit_code == 1
+    assert "builder path not found" in capsys.readouterr().err
+
+
+def test_missing_services_repo_fails_cleanly(
+    builder_tree: Path, tmp_path: Path, stub: StubServices, capsys
+):
+    with pytest.raises(typer.Exit) as exc:
+        catio_cli(builder_tree, tmp_path / "nope")
+    assert exc.value.exit_code == 1
+    assert "services repo not found" in capsys.readouterr().err
+
+
+def test_startup_failure_reports_json_when_asked(
+    builder_tree: Path, tmp_path: Path, stub: StubServices, capsys
+):
+    with pytest.raises(typer.Exit):
+        catio_cli(builder_tree, tmp_path / "nope", json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert "services repo not found" in payload["error"]
+
+
+@pytest.mark.skipif(
+    HAS_FASTCS, reason="only meaningful in an environment without fastcs_catio"
+)
+def test_without_fastcs_the_error_names_the_side_venv(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    with pytest.raises(typer.Exit) as exc:
+        catio_cli(builder_tree, services_repo)
+    assert exc.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert ".venv-catio" in err
+    assert stub.written_iocs == []
+    assert stub.written_chains == []
+
+
+# -- end to end --------------------------------------------------------------
+
+
+# The three BL21I-VA chains convert cleanly; ``BL21I-DI-IOC-01`` does not. Its
+# own ``EPICS_BASE.dbpf`` entities set currents on ``BL21I-DI-LED-01`` and
+# ``BL21I-OP-LED-01``, PVs created by ``auto_EL2595`` -- a terminal with no leaf
+# table in ``leaves.py``, so no fastcs-catio name can be predicted for them.
+# That is ``unknown-entity-type``, an ERROR, and it fails the DI chain. Real
+# data, not a fixture quirk: fixing it means teaching ``leaves.py`` about
+# EL2595/EL4134 or dropping those dbpf lines.
+CLEAN_CHAINS = ["BL21I-VA-CATIO-01", "BL21I-VA-CATIO-05", "BL21I-VA-CATIO-06"]
+FAILED_CHAIN = "BL21I-DI-IOC-01"
+
+
+@needs_fastcs
+def test_end_to_end_writes_the_clean_chains_and_their_consumers(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    code = run_catio(builder_tree, services_repo)
+    out = capsys.readouterr().out
+
+    assert code == 1  # the DI chain errored
+    assert sorted(stub.written_chains) == CLEAN_CHAINS
+    # every clean scanner, plus the two pure consumers -- and nothing else
+    assert sorted(stub.written_iocs) == [
+        "BL21I-VA-IOC-01",
+        "BL21I-VA-IOC-02",
+        "BL21I-VA-IOC-04",
+        "BL21I-VA-IOC-05",
+        "BL21I-VA-IOC-06",
+    ]
+    assert "BL21I-MO-IOC-99" not in stub.written_iocs
+    assert stub.dry_runs == {False}
+
+    services = services_repo / "services"
+    assert (services / "bl21i-va-catio-01" / "config" / "fastcs.yaml").is_file()
+    assert (services / "bl21i-va-ioc-02" / "config" / "ioc.yaml").is_file()
+    assert not (services / "bl21i-mo-ioc-99").exists()
+    assert not (services / "bl21i-di-catio-01").exists()
+
+    assert "Chains discovered: 4" in out
+    assert "Chains converted:  3" in out
+    assert "Chains failed:     1" in out
+    assert "REPLACE_WITH_FASTCS_IMAGE_URI" in out
+    assert "REPLACE_WITH_IMAGE_URI" in out
+    assert "sticky" in out
+
+
+@needs_fastcs
+def test_the_failed_chain_blocks_its_own_scanner_ioc(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    run_catio(builder_tree, services_repo, json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    skipped = {item["ioc"]: item for item in payload["iocs_skipped"]}
+    assert list(skipped) == [FAILED_CHAIN]
+    assert skipped[FAILED_CHAIN]["blocked_by"] == [FAILED_CHAIN]
+    assert skipped[FAILED_CHAIN]["own_errors"] is True
+    assert [c for c in payload["chains"] if not c["converted"]] == [
+        c for c in payload["chains"] if c["scanner_ioc"] == FAILED_CHAIN
+    ]
+
+
+@needs_fastcs
+def test_end_to_end_rewrites_every_legacy_reference(
+    builder_tree: Path, services_repo: Path, stub: StubServices
+):
+    """The whole point: no legacy ERIO PV survives in a written consumer."""
+    run_catio(builder_tree, services_repo)
+    written = (
+        services_repo / "services" / "bl21i-va-ioc-02" / "config" / "ioc.yaml"
+    ).read_text()
+    assert "-ERIO-" not in written
+    assert "BL21I-VA-E1RIO-" in written
+
+
+@needs_fastcs
+def test_dry_run_writes_nothing(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    before = sorted(p.name for p in (services_repo / "services").iterdir())
+
+    run_catio(builder_tree, services_repo, dry_run=True)
+
+    assert stub.dry_runs == {True}
+    assert sorted(p.name for p in (services_repo / "services").iterdir()) == before
+    out = capsys.readouterr().out
+    assert "DRY RUN -- nothing was written" in out
+    # the analysis still ran in full
+    assert "Chains converted:  3" in out
+
+
+@needs_fastcs
+def test_json_output_is_the_only_thing_on_stdout(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    run_catio(builder_tree, services_repo, json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert set(payload) >= {
+        "chains",
+        "iocs_written",
+        "iocs_skipped",
+        "placeholders",
+        "diagnostics",
+    }
+    assert len(payload["chains"]) == 4
+    assert "BL21I-VA-IOC-02" in payload["iocs_written"]
+    assert all("severity" in d for d in payload["diagnostics"])
+    assert any("REPLACE_WITH" in p for p in payload["placeholders"])
+
+
+@needs_fastcs
+def test_strict_also_fails_the_device_mod_mismatch_chain(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    """--strict promotes device-mod-mismatch, which additionally fails VA-IOC-01."""
+    code = run_catio(builder_tree, services_repo, strict=True)
+    assert code == 1
+
+    out = capsys.readouterr().out
+    assert sorted(stub.written_chains) == ["BL21I-VA-CATIO-05", "BL21I-VA-CATIO-06"]
+    assert "Chains failed:     2" in out
+
+    blocked = {
+        line.strip().split()[0]
+        for line in out.splitlines()
+        if "blocked by chain" in line
+    }
+    assert {"BL21I-DI-IOC-01", "BL21I-VA-IOC-01"} <= blocked
+
+
+@needs_fastcs
+def test_strict_names_the_chain_that_blocked_each_skipped_ioc(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    run_catio(builder_tree, services_repo, strict=True, json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    skipped = {item["ioc"]: item for item in payload["iocs_skipped"]}
+    assert skipped["BL21I-VA-IOC-01"]["blocked_by"] == ["BL21I-VA-IOC-01"]
+    # A consumer of a skipped chain is reported even though the chain was
+    # dropped before substitution, so its references never resolved at all.
+    assert skipped["BL21I-VA-IOC-02"]["own_errors"] is True
+    assert all("blocked_by" in item for item in payload["iocs_skipped"])
+
+
+@needs_fastcs
+def test_node_prefix_override_reaches_the_generated_ioc(
+    builder_tree: Path, services_repo: Path, stub: StubServices, capsys
+):
+    run_catio(
+        builder_tree, services_repo, node_prefix="{domain}-CAT{n}-{:02d}", json_out=True
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    predicted = {c["catio_ioc"]: c["node_prefix"] for c in payload["chains"]}
+    assert predicted["BL21I-VA-CATIO-01"] == "BL21I-VA-CAT1-{:02d}"
+    # the names written into config/fastcs.yaml come from the same source
+    assert stub.name_mappings["BL21I-VA-CATIO-01"]["node_prefix"] == (
+        "BL21I-VA-CAT1-{:02d}"
+    )
+    written = (
+        services_repo / "services" / "bl21i-va-ioc-02" / "config" / "ioc.yaml"
+    ).read_text()
+    assert "BL21I-VA-CAT1-" in written
+
+
+@needs_fastcs
+def test_sticky_ordinals_are_honoured(
+    builder_tree: Path, services_repo: Path, monkeypatch, capsys
+):
+    stub = StubServices(sticky={"BL21I-VA-CATIO-01": 7})
+    monkeypatch.setattr(catio_cli_module, "_load_services", lambda: stub)
+
+    run_catio(builder_tree, services_repo, json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    ordinals = {c["catio_ioc"]: c["ordinal"] for c in payload["chains"]}
+    assert ordinals["BL21I-VA-CATIO-01"] == 7
+    assert ordinals["BL21I-VA-CATIO-05"] == 1
+
+
+@needs_fastcs
+def test_the_command_is_reachable_through_the_typer_app(
+    builder_tree: Path, services_repo: Path, stub: StubServices
+):
+    result = CliRunner().invoke(
+        cli,
+        ["catio", str(builder_tree), "--services-repo", str(services_repo), "--json"],
+    )
+    assert result.exit_code == 1, result.output
+    assert sorted(stub.written_chains) == CLEAN_CHAINS
+
+
+@pytest.mark.skipif(
+    not HAS_SERVICES, reason="builder2ibek.catio.services not written yet"
+)
+@needs_fastcs
+def test_end_to_end_with_the_real_services_writer(
+    builder_tree: Path, services_repo: Path
+):
+    """Loose on purpose: the contract's outcome, not services.py's internals."""
+    run_catio(builder_tree, services_repo)
+    services = services_repo / "services"
+    assert (services / "bl21i-va-catio-01").is_dir()
+    assert (services / "bl21i-va-ioc-02" / "config" / "ioc.yaml").is_file()
+    assert not (services / "bl21i-mo-ioc-99").exists()
+    assert not (services / "bl21i-di-catio-01").exists()
+
+
+def test_report_renders_without_any_placeholders():
+    from builder2ibek.catio.diagnostics import DiagnosticLog
+
+    report = CatioReport(
+        builder_path="/b", services_repo="/s", strict=False, dry_run=False
+    )
+    text = catio_cli_module._render_report(report, DiagnosticLog())
+    assert "Placeholders to fill in:\n  (none)" in text
+    assert "0 errors, 0 warnings" in text

--- a/tests/test_catio_cli.py
+++ b/tests/test_catio_cli.py
@@ -392,15 +392,18 @@ def test_without_fastcs_the_error_names_the_side_venv(
 # -- end to end --------------------------------------------------------------
 
 
-# The three BL21I-VA chains convert cleanly; ``BL21I-DI-IOC-01`` does not. Its
-# own ``EPICS_BASE.dbpf`` entities set currents on ``BL21I-DI-LED-01`` and
-# ``BL21I-OP-LED-01``, PVs created by ``auto_EL2595`` -- a terminal with no leaf
-# table in ``leaves.py``, so no fastcs-catio name can be predicted for them.
-# That is ``unknown-entity-type``, an ERROR, and it fails the DI chain. Real
-# data, not a fixture quirk: fixing it means teaching ``leaves.py`` about
-# EL2595/EL4134 or dropping those dbpf lines.
-CLEAN_CHAINS = ["BL21I-VA-CATIO-01", "BL21I-VA-CATIO-05", "BL21I-VA-CATIO-06"]
-FAILED_CHAIN = "BL21I-DI-IOC-01"
+# All four BL21I chains convert. ``BL21I-DI-IOC-01`` was the last holdout --
+# its own ``EPICS_BASE.dbpf`` entities set currents on ``BL21I-DI-LED-01..03``
+# and ``BL21I-OP-LED-01``, PVs created by ``auto_EL2595`` -- and it converts now
+# that ``leaves.py`` knows EL2595 and EL4134 and fastcs-catio selects the EL2595
+# drive current. The failure path is exercised by synthetic chains in
+# ``test_catio_regressions.py`` instead of by a real beamline staying broken.
+CLEAN_CHAINS = [
+    "BL21I-DI-CATIO-01",
+    "BL21I-VA-CATIO-01",
+    "BL21I-VA-CATIO-05",
+    "BL21I-VA-CATIO-06",
+]
 
 
 @needs_fastcs
@@ -410,10 +413,11 @@ def test_end_to_end_writes_the_clean_chains_and_their_consumers(
     code = run_catio(builder_tree, services_repo)
     out = capsys.readouterr().out
 
-    assert code == 1  # the DI chain errored
+    assert code == 0  # every chain converts
     assert sorted(stub.written_chains) == CLEAN_CHAINS
-    # every clean scanner, plus the two pure consumers -- and nothing else
+    # every scanner, plus the two pure consumers -- and nothing else
     assert sorted(stub.written_iocs) == [
+        "BL21I-DI-IOC-01",
         "BL21I-VA-IOC-01",
         "BL21I-VA-IOC-02",
         "BL21I-VA-IOC-04",
@@ -425,32 +429,32 @@ def test_end_to_end_writes_the_clean_chains_and_their_consumers(
 
     services = services_repo / "services"
     assert (services / "bl21i-va-catio-01" / "config" / "fastcs.yaml").is_file()
+    assert (services / "bl21i-di-catio-01" / "config" / "fastcs.yaml").is_file()
     assert (services / "bl21i-va-ioc-02" / "config" / "ioc.yaml").is_file()
     assert not (services / "bl21i-mo-ioc-99").exists()
-    assert not (services / "bl21i-di-catio-01").exists()
 
     assert "Chains discovered: 4" in out
-    assert "Chains converted:  3" in out
-    assert "Chains failed:     1" in out
+    assert "Chains converted:  4" in out
+    assert "Chains failed:     0" in out
     assert "REPLACE_WITH_FASTCS_IMAGE_URI" in out
     assert "REPLACE_WITH_IMAGE_URI" in out
     assert "sticky" in out
 
 
 @needs_fastcs
-def test_the_failed_chain_blocks_its_own_scanner_ioc(
+def test_nothing_is_skipped_when_every_chain_converts(
     builder_tree: Path, services_repo: Path, stub: StubServices, capsys
 ):
+    """The skip machinery is exercised on synthetic chains in the regressions.
+
+    Here the point is the opposite: a clean beamline must report nothing
+    skipped and no unconverted chain at all.
+    """
     run_catio(builder_tree, services_repo, json_out=True)
     payload = json.loads(capsys.readouterr().out)
 
-    skipped = {item["ioc"]: item for item in payload["iocs_skipped"]}
-    assert list(skipped) == [FAILED_CHAIN]
-    assert skipped[FAILED_CHAIN]["blocked_by"] == [FAILED_CHAIN]
-    assert skipped[FAILED_CHAIN]["own_errors"] is True
-    assert [c for c in payload["chains"] if not c["converted"]] == [
-        c for c in payload["chains"] if c["scanner_ioc"] == FAILED_CHAIN
-    ]
+    assert payload["iocs_skipped"] == []
+    assert [c for c in payload["chains"] if not c["converted"]] == []
 
 
 @needs_fastcs
@@ -479,7 +483,7 @@ def test_dry_run_writes_nothing(
     out = capsys.readouterr().out
     assert "DRY RUN -- nothing was written" in out
     # the analysis still ran in full
-    assert "Chains converted:  3" in out
+    assert "Chains converted:  4" in out
 
 
 @needs_fastcs
@@ -581,7 +585,7 @@ def test_the_command_is_reachable_through_the_typer_app(
         cli,
         ["catio", str(builder_tree), "--services-repo", str(services_repo), "--json"],
     )
-    assert result.exit_code == 1, result.output
+    assert result.exit_code == 0, result.output
     assert sorted(stub.written_chains) == CLEAN_CHAINS
 
 
@@ -598,7 +602,7 @@ def test_end_to_end_with_the_real_services_writer(
     assert (services / "bl21i-va-catio-01").is_dir()
     assert (services / "bl21i-va-ioc-02" / "config" / "ioc.yaml").is_file()
     assert not (services / "bl21i-mo-ioc-99").exists()
-    assert not (services / "bl21i-di-catio-01").exists()
+    assert (services / "bl21i-di-catio-01").is_dir()
 
 
 def test_report_renders_without_any_placeholders():

--- a/tests/test_catio_diagnostics.py
+++ b/tests/test_catio_diagnostics.py
@@ -1,0 +1,220 @@
+"""Unit tests for `builder2ibek.catio.diagnostics`."""
+
+import json
+
+import pytest
+
+from builder2ibek.catio.diagnostics import (
+    CODES,
+    STRICT_PROMOTIONS,
+    Diagnostic,
+    DiagnosticLog,
+    Severity,
+)
+
+
+def test_every_code_has_a_severity():
+    assert set(CODES) == {
+        "mod-out-of-range",
+        "leaf-type-mismatch",
+        "coupler-label-conflict",
+        "unknown-chain-label",
+        "unknown-terminal-type",
+        "unknown-entity-type",
+        "unmapped-suffix",
+        "ambiguous-legacy-pv",
+        "shortened-leaf",
+        "duplicate-coupler-label",
+        "ambiguous-legacy-pv-unused",
+        "device-mod-mismatch",
+        "unlabelled-coupler",
+        "device-without-mod",
+        "slave-type-mismatch",
+        "link-direction-guess",
+        "dropped-reference",
+    }
+    assert all(isinstance(s, Severity) for s in CODES.values())
+
+
+@pytest.mark.parametrize("code", sorted(CODES))
+def test_default_severity_is_recorded(code):
+    log = DiagnosticLog()
+    assert log.add(code, "detail").severity is CODES[code]
+
+
+def test_strict_promotions_are_warnings_by_default():
+    assert STRICT_PROMOTIONS == frozenset({"device-mod-mismatch"})
+    assert all(CODES[c] is Severity.WARNING for c in STRICT_PROMOTIONS)
+
+
+@pytest.mark.parametrize("code", sorted(CODES))
+def test_strict_promotes_only_the_listed_codes(code):
+    strict = DiagnosticLog(strict=True)
+    expected = Severity.ERROR if code in STRICT_PROMOTIONS else CODES[code]
+    assert strict.add(code, "detail").severity is expected
+
+
+def test_unknown_code_is_rejected():
+    log = DiagnosticLog()
+    with pytest.raises(KeyError, match="unknown diagnostic code 'no-such-code'"):
+        log.add("no-such-code", "detail")
+    assert len(log) == 0
+
+
+def test_add_returns_and_stores_all_location_fields():
+    log = DiagnosticLog()
+    diagnostic = log.add(
+        "mod-out-of-range",
+        "MOD9 exceeds 8 terminals",
+        chain="BL21I-VA-IOC-01",
+        ioc="BL21I-VA-IOC-05",
+        entity="VAFAN4",
+        attribute="rio_dinput",
+    )
+    assert list(log) == [diagnostic]
+    assert diagnostic == Diagnostic(
+        code="mod-out-of-range",
+        severity=Severity.ERROR,
+        message="MOD9 exceeds 8 terminals",
+        chain="BL21I-VA-IOC-01",
+        ioc="BL21I-VA-IOC-05",
+        entity="VAFAN4",
+        attribute="rio_dinput",
+    )
+    assert str(diagnostic) == (
+        "error [mod-out-of-range] BL21I-VA-IOC-05, entity VAFAN4, "
+        "arg rio_dinput: MOD9 exceeds 8 terminals"
+    )
+
+
+def test_errors_and_warnings_partition_the_log():
+    log = DiagnosticLog()
+    error = log.add("unmapped-suffix", "AL_STATE")
+    warning = log.add("unlabelled-coupler", "no DEVICE")
+    assert log.errors == [error]
+    assert log.warnings == [warning]
+    assert len(log) == 2
+    assert log.has_errors()
+
+
+def test_no_errors_when_only_warnings():
+    log = DiagnosticLog()
+    log.add("slave-type-mismatch", "EL1014 declared, EL1004 found")
+    assert not log.has_errors()
+    assert log.failed_chains() == set()
+    assert log.failed_iocs() == set()
+
+
+def test_failed_chains_and_iocs_come_from_errors_only():
+    log = DiagnosticLog()
+    log.add("unmapped-suffix", "AL_STATE", chain="CHAIN-A", ioc="IOC-1")
+    log.add("shortened-leaf", "truncated", chain="CHAIN-B")
+    log.add("ambiguous-legacy-pv", "two targets", ioc="IOC-2")
+    # warnings must not condemn a chain or an IOC
+    log.add("link-direction-guess", "assumed read", chain="CHAIN-C", ioc="IOC-3")
+    assert log.failed_chains() == {"CHAIN-A", "CHAIN-B"}
+    assert log.failed_iocs() == {"IOC-1", "IOC-2"}
+
+
+def test_strict_failure_sets_propagate():
+    log = DiagnosticLog(strict=True)
+    log.add("device-mod-mismatch", "MOD3 at position 4", chain="CHAIN-A", ioc="IOC-1")
+    assert log.failed_chains() == {"CHAIN-A"}
+    assert log.failed_iocs() == {"IOC-1"}
+
+
+def test_render_groups_errors_before_warnings_and_sorts_chains():
+    log = DiagnosticLog()
+    # deliberately added out of order
+    log.add("unlabelled-coupler", "w-zeta", chain="CHAIN-Z")
+    log.add("unmapped-suffix", "e-no-chain")
+    log.add("unmapped-suffix", "e-beta", chain="CHAIN-B")
+    log.add("shortened-leaf", "e-alpha", chain="CHAIN-A")
+    log.add("device-without-mod", "w-no-chain")
+    report = log.render()
+    assert report.splitlines() == [
+        "ERRORS",
+        "  chain CHAIN-A",
+        "    error [shortened-leaf] chain CHAIN-A: e-alpha",
+        "  chain CHAIN-B",
+        "    error [unmapped-suffix] chain CHAIN-B: e-beta",
+        "  (no chain)",
+        "    error [unmapped-suffix]: e-no-chain",
+        "",
+        "WARNINGS",
+        "  chain CHAIN-Z",
+        "    warning [unlabelled-coupler] chain CHAIN-Z: w-zeta",
+        "  (no chain)",
+        "    warning [device-without-mod]: w-no-chain",
+        "",
+        "3 errors, 2 warnings",
+    ]
+
+
+def test_render_ordering_is_independent_of_insertion_order():
+    entries = [
+        ("unmapped-suffix", "m1", "CHAIN-B", "IOC-2"),
+        ("mod-out-of-range", "m2", "CHAIN-A", "IOC-1"),
+        ("unmapped-suffix", "m3", "CHAIN-A", "IOC-1"),
+        ("link-direction-guess", "m4", "CHAIN-A", "IOC-3"),
+        ("unlabelled-coupler", "m5", None, None),
+    ]
+    forward = DiagnosticLog()
+    backward = DiagnosticLog()
+    for code, message, chain, ioc in entries:
+        forward.add(code, message, chain=chain, ioc=ioc)
+    for code, message, chain, ioc in reversed(entries):
+        backward.add(code, message, chain=chain, ioc=ioc)
+    assert forward.render() == backward.render()
+
+
+def test_render_of_empty_log_is_just_the_summary():
+    assert DiagnosticLog().render() == "0 errors, 0 warnings"
+
+
+def test_render_summary_counts_all_diagnostics():
+    log = DiagnosticLog()
+    log.add("unmapped-suffix", "a", chain="CHAIN-A")
+    log.add("shortened-leaf", "b", chain="CHAIN-A")
+    log.add("unlabelled-coupler", "c", chain="CHAIN-A")
+    assert log.render().endswith("\n\n2 errors, 1 warnings")
+
+
+def test_to_json_is_serialisable_and_ordered():
+    log = DiagnosticLog()
+    log.add("unmapped-suffix", "second-added-first", chain="CHAIN-A", ioc="IOC-1")
+    log.add(
+        "link-direction-guess",
+        "guess",
+        chain="CHAIN-B",
+        ioc="IOC-2",
+        entity="femto200",
+        attribute="OUTGB0",
+    )
+    payload = log.to_json()
+    assert json.loads(json.dumps(payload)) == payload
+    assert [d["message"] for d in payload] == ["second-added-first", "guess"]
+    assert payload[1] == {
+        "code": "link-direction-guess",
+        "severity": "warning",
+        "message": "guess",
+        "chain": "CHAIN-B",
+        "ioc": "IOC-2",
+        "entity": "femto200",
+        "attribute": "OUTGB0",
+    }
+    assert all(isinstance(d["severity"], str) for d in payload)
+
+
+def test_diagnostic_str_omits_absent_location_parts():
+    assert str(Diagnostic("shortened-leaf", Severity.ERROR, "boom")) == (
+        "error [shortened-leaf]: boom"
+    )
+    assert str(
+        Diagnostic("shortened-leaf", Severity.ERROR, "boom", chain="CHAIN-A")
+    ) == ("error [shortened-leaf] chain CHAIN-A: boom")
+    assert str(
+        Diagnostic(
+            "shortened-leaf", Severity.ERROR, "boom", chain="CHAIN-A", ioc="IOC-1"
+        )
+    ) == ("error [shortened-leaf] IOC-1: boom")

--- a/tests/test_catio_ethercat.py
+++ b/tests/test_catio_ethercat.py
@@ -1,0 +1,255 @@
+"""
+Tests for the ethercat converter and the catio plumbing in convert.py.
+
+Deliberately duck-typed: no import of builder2ibek.catio.substitute, so these
+tests do not depend on modules that are still being written.
+"""
+
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from builder2ibek.builder import Builder
+from builder2ibek.convert import (
+    convert_file,
+    convert_to_ioc,
+    dispatch,
+    write_ioc_yaml,
+)
+from builder2ibek.converters import ethercat
+from builder2ibek.converters.epics_base import InterruptVector
+from builder2ibek.converters.ethercat import CatioContext, finalize
+from builder2ibek.types import Generic_IOC
+
+TODO_COMMAND = (
+    "# TODO: ethercat support requires major rewrite for "
+    "epics-containers — switch to fastcs-catio"
+)
+
+ETHERCAT_XML = """<?xml version="1.0" ?>
+<components arch="linux-x86_64">
+  <ethercat.EthercatMaster name="MASTER" socket="/tmp/ethercat.sock"/>
+  <ethercat.EthercatSlave name="SLAVE1" position="1" type_name="EL3104"
+    type_rev="0x00120000" oversample="0"/>
+  <ethercat.auto_EL3104 PORT="SLAVE1" DEVICE="BL21I-VA-ERIO-01:MOD1"/>
+  <calculation.Calc name="CALC1" INPA="BL21I-VA-ERIO-01:MOD1:AI1 CP"
+    INPB="BL21I-VA-ERIO-01:MOD1:AI2 CP" CALC="A+B"/>
+</components>
+"""
+
+
+class StubSubstituter:
+    """Minimal object satisfying the Substituter.rewrite_entity contract."""
+
+    def __init__(self, subs: dict[str, str]):
+        self.subs = subs
+        self.calls: list[tuple[str, str | None]] = []
+        self.dropped: list[tuple[str, int, int]] = []
+
+    def report_dropped(self, raw_entities, kept_entities, *, log, ioc) -> list[str]:
+        self.dropped.append((ioc, len(list(raw_entities)), len(list(kept_entities))))
+        return []
+
+    def rewrite_entity(self, entity: dict, *, log, ioc: str) -> bool:
+        self.calls.append((ioc, entity.get("type")))
+        changed = False
+        for key, value in list(entity.items()):
+            if not isinstance(value, str):
+                continue
+            new = " ".join(self.subs.get(tok, tok) for tok in value.split(" "))
+            if new != value:
+                entity[key] = new
+                changed = True
+        return changed
+
+
+class StubLog:
+    """Stand-in for DiagnosticLog -- the stub substituter never writes to it."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple] = []
+
+    def add(self, code, message, **kwargs):
+        self.entries.append((code, message, kwargs))
+
+
+SUBS = {
+    "BL21I-VA-ERIO-01:MOD1:AI1": "BL21I-VA-E1RIO-01:AI01:Channel1",
+    "BL21I-VA-ERIO-01:MOD1:AI2": "BL21I-VA-E1RIO-01:AI01:Channel2",
+}
+
+
+def convert_xml(xml_str: str, catio=None) -> Generic_IOC:
+    builder = Builder()
+    builder.load_string(xml_str)
+    return dispatch(builder, Path("inline.xml"), catio=catio)
+
+
+def entity_types(ioc: Generic_IOC) -> list[str]:
+    return [e["type"] for e in ioc.entities]
+
+
+def calc_entity(ioc: Generic_IOC) -> dict:
+    (calc,) = [e for e in ioc.entities if e["type"] == "calculation.Calc"]
+    return calc
+
+
+# --- ethercat entity conversion (unchanged behaviour) ----------------------
+
+
+def test_ethercat_master_becomes_post_startup_todo():
+    ioc = convert_xml(ETHERCAT_XML)
+    (placeholder,) = [
+        e for e in ioc.entities if e["type"] == "epics.PostStartupCommand"
+    ]
+    assert placeholder["command"] == TODO_COMMAND
+    # the master's own args are gone
+    assert "socket" not in placeholder
+    assert "name" not in placeholder
+
+
+def test_other_ethercat_entities_are_dropped():
+    ioc = convert_xml(ETHERCAT_XML)
+    assert not [t for t in entity_types(ioc) if t.startswith("ethercat.")]
+
+
+def test_dead_global_is_gone():
+    """_dummy_inserted leaked across IOCs in a multi-IOC process."""
+    assert not hasattr(ethercat, "_dummy_inserted")
+
+
+def test_two_masters_both_become_placeholders():
+    """No per-process state: a second master converts exactly like the first."""
+    two = ETHERCAT_XML.replace(
+        '<ethercat.EthercatMaster name="MASTER" socket="/tmp/ethercat.sock"/>',
+        '<ethercat.EthercatMaster name="MASTER" socket="/tmp/a.sock"/>\n'
+        '  <ethercat.EthercatMaster name="MASTER2" socket="/tmp/b.sock"/>',
+    )
+    ioc = convert_xml(two)
+    placeholders = [e for e in ioc.entities if e["type"] == "epics.PostStartupCommand"]
+    assert len(placeholders) == 2
+    assert all(p["command"] == TODO_COMMAND for p in placeholders)
+
+
+# --- finalize: no catio context -------------------------------------------
+
+
+def test_no_catio_context_converts_as_before():
+    plain = convert_xml(ETHERCAT_XML)
+    assert calc_entity(plain)["INPA"] == "BL21I-VA-ERIO-01:MOD1:AI1 CP"
+    assert "catio" not in plain.model_dump()
+
+
+def test_finalize_is_a_noop_without_context():
+    ioc = Generic_IOC(
+        ioc_name="x",
+        description="",
+        entities=[{"type": "a.B", "v": "hello"}],
+        source_file=Path("x.xml"),
+    )
+    finalize(ioc)
+    assert ioc.entities == [{"type": "a.B", "v": "hello"}]
+
+
+# --- finalize: with a catio context ----------------------------------------
+
+
+def test_catio_context_rewrites_entity_values():
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(ETHERCAT_XML, catio=ctx)
+
+    calc = calc_entity(ioc)
+    assert calc["INPA"] == "BL21I-VA-E1RIO-01:AI01:Channel1 CP"
+    assert calc["INPB"] == "BL21I-VA-E1RIO-01:AI01:Channel2 CP"
+
+
+def test_catio_context_sees_every_entity_and_the_ioc_name():
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(ETHERCAT_XML, catio=ctx)
+
+    assert {ioc_name for ioc_name, _ in sub.calls} == {"BL21I-VA-IOC-02"}
+    assert len(sub.calls) == len(ioc.entities)
+    # including the entities dispatch() adds by default
+    assert "devIocStats.iocAdminSoft" in {t for _, t in sub.calls}
+
+
+def test_catio_attribute_is_removed_from_the_model():
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(ETHERCAT_XML, catio=ctx)
+
+    assert getattr(ioc, "catio", None) is None
+    assert "catio" not in ioc.model_dump()
+
+
+def test_catio_attribute_is_removed_even_if_rewriting_raises():
+    class Boom:
+        def rewrite_entity(self, entity, *, log, ioc):
+            raise RuntimeError("boom")
+
+    ioc = Generic_IOC(
+        ioc_name="x",
+        description="",
+        entities=[{"type": "a.B"}],
+        source_file=Path("x.xml"),
+    )
+    ioc.catio = CatioContext(substituter=Boom(), log=StubLog(), ioc_name="X")
+    with pytest.raises(RuntimeError):
+        finalize(ioc)
+    assert "catio" not in ioc.model_dump()
+
+
+def test_catio_key_absent_from_written_yaml(tmp_path: Path):
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(ETHERCAT_XML, catio=ctx)
+
+    out = tmp_path / "ioc.yaml"
+    write_ioc_yaml(ioc, out, "/epics/ibek-defs/ioc.schema.json")
+
+    text = out.read_text()
+    # "catio" as a top-level YAML key (the TODO placeholder legitimately
+    # mentions fastcs-catio in a value)
+    assert "\ncatio" not in text
+    assert "BL21I-VA-E1RIO-01:AI01:Channel1 CP" in text
+
+    loaded = YAML().load(text)
+    assert set(loaded) == {"ioc_name", "description", "entities"}
+
+
+# --- convert_to_ioc / write_ioc_yaml split ---------------------------------
+
+
+def test_convert_to_ioc_matches_convert_file(tmp_path: Path, samples: Path):
+    """The refactor must not change convert_file's output at all."""
+    xml = samples / "BL99P-EA-IOC-05.xml"
+
+    try:
+        via_convert_file = tmp_path / "a.yaml"
+        convert_file(xml, via_convert_file, "/epics/ibek-defs/ioc.schema.json")
+        InterruptVector.reset()
+
+        via_split = tmp_path / "b.yaml"
+        write_ioc_yaml(
+            convert_to_ioc(xml), via_split, "/epics/ibek-defs/ioc.schema.json"
+        )
+    finally:
+        # this module-level counter leaks between conversions
+        InterruptVector.reset()
+
+    assert via_split.read_text() == via_convert_file.read_text()
+
+
+def test_convert_to_ioc_passes_catio_through(tmp_path: Path):
+    xml = tmp_path / "inline.xml"
+    xml.write_text(ETHERCAT_XML)
+
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_to_ioc(xml, catio=ctx)
+
+    assert calc_entity(ioc)["INPA"] == "BL21I-VA-E1RIO-01:AI01:Channel1 CP"
+    assert sub.calls

--- a/tests/test_catio_ethercat.py
+++ b/tests/test_catio_ethercat.py
@@ -176,6 +176,39 @@ def test_catio_context_sees_every_entity_and_the_ioc_name():
     assert "devIocStats.iocAdminSoft" in {t for _, t in sub.calls}
 
 
+def test_catio_run_strips_the_todo_placeholder():
+    """The switch the TODO asks for is what a catio run just did."""
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(ETHERCAT_XML, catio=ctx)
+
+    assert "epics.PostStartupCommand" not in entity_types(ioc)
+    assert TODO_COMMAND not in str(ioc.entities)
+    # the rest of the IOC is untouched
+    assert calc_entity(ioc)["INPA"] == "BL21I-VA-E1RIO-01:AI01:Channel1 CP"
+
+
+def test_catio_run_keeps_unrelated_post_startup_commands():
+    """Only *this* placeholder goes -- a real post-init command must survive."""
+    with_command = ETHERCAT_XML.replace(
+        "</components>",
+        '  <EPICS_BASE.StartupCommand command="dbpf(&quot;X&quot;,1)" '
+        'post_init="True"/>\n</components>',
+    )
+    sub = StubSubstituter(SUBS)
+    ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")
+    ioc = convert_xml(with_command, catio=ctx)
+
+    (kept,) = [e for e in ioc.entities if e["type"] == "epics.PostStartupCommand"]
+    assert kept["command"] == 'dbpf("X",1)'
+
+
+def test_todo_placeholder_survives_a_plain_conversion():
+    """`xml2yaml` has no catio IOC to point at, so the TODO must stay."""
+    ioc = convert_xml(ETHERCAT_XML)
+    assert "epics.PostStartupCommand" in entity_types(ioc)
+
+
 def test_catio_attribute_is_removed_from_the_model():
     sub = StubSubstituter(SUBS)
     ctx = CatioContext(substituter=sub, log=StubLog(), ioc_name="BL21I-VA-IOC-02")

--- a/tests/test_catio_integration.py
+++ b/tests/test_catio_integration.py
@@ -1,0 +1,302 @@
+"""End-to-end tests for ``builder2ibek catio`` over the checked-in samples.
+
+These drive the whole pipeline -- discover chains, predict fastcs-catio names,
+rewrite every consumer, write the services repo -- against
+``tests/samples/catio/``, which is a byte-identical copy of the four BL21I
+EtherCAT scanner XMLs and two of their consumers.
+
+The counts asserted here are checked in on purpose: a regression in the naming
+rule, the dual-key substitution map or the per-chain failure policy shows up as
+a number change rather than as a silent behavioural drift.
+
+The whole module needs the real ``fastcs_catio`` naming API, which is
+deliberately absent from the project venv, so it self-skips under plain
+``uv run``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+
+pytest.importorskip("fastcs_catio")
+
+from builder2ibek.catio.chains import (  # noqa: E402
+    build_substituter,
+    discover_chains,
+)
+from builder2ibek.catio.cli import catio_cli  # noqa: E402
+from builder2ibek.catio.diagnostics import DiagnosticLog  # noqa: E402
+
+CATIO_SAMPLES = Path(__file__).parent / "samples" / "catio"
+
+#: The scanner IOCs, and the ``E{n}RIO`` ordinal each must be allocated.
+#: Ordinals are per ``(beamline, domain)`` in ascending scanner-IOC name order.
+EXPECTED_ORDINALS = {
+    "BL21I-DI-CATIO-01": 1,
+    "BL21I-VA-CATIO-01": 1,
+    "BL21I-VA-CATIO-05": 2,
+    "BL21I-VA-CATIO-06": 3,
+}
+
+#: ``BL21I-DI-IOC-01`` is skipped: it ``dbpf``-writes PVs created by
+#: ``auto_EL2595``, a terminal type ``leaves.py`` has no translation table for,
+#: so ``unknown-entity-type`` (ERROR) fails its chain. See the module docstring
+#: of ``builder2ibek.catio.leaves`` for what adding one would take.
+EXPECTED_FAILED_CHAINS = {"BL21I-DI-IOC-01"}
+
+#: Consumers of a clean chain, so they are rewritten and written out.
+EXPECTED_IOCS_WRITTEN = {
+    "BL21I-VA-IOC-01",
+    "BL21I-VA-IOC-02",
+    "BL21I-VA-IOC-04",
+    "BL21I-VA-IOC-05",
+    "BL21I-VA-IOC-06",
+}
+
+
+@pytest.fixture
+def builder_tree(tmp_path: Path) -> Path:
+    """A BUILDER support module holding just the sampled XMLs."""
+    make_iocs = tmp_path / "BL21I-BUILDER" / "etc" / "makeIocs"
+    make_iocs.mkdir(parents=True)
+    for xml in sorted(CATIO_SAMPLES.glob("*.xml")):
+        shutil.copy(xml, make_iocs / xml.name)
+    return tmp_path / "BL21I-BUILDER"
+
+
+@pytest.fixture
+def services_repo(tmp_path: Path) -> Path:
+    """A minimal services repo: the shared chart plus the two scaffolds."""
+    repo = tmp_path / "i21-services"
+    shared = repo / ".helm-shared"
+    (shared / "templates").mkdir(parents=True)
+    (shared / "Chart.yaml").write_text("apiVersion: v2\nname: ec-service\n")
+    (shared / "templates" / "ioc_instance.yaml").write_text(
+        '{{ include "ioc-instance" . }}\n'
+    )
+    for name, values in (
+        (".ioc_template", "ioc-instance:\n  image: REPLACE_WITH_IMAGE_URI\n"),
+        (
+            ".fastcs_ioc_template",
+            "ioc-instance:\n  image: REPLACE_WITH_FASTCS_IMAGE_URI\n",
+        ),
+    ):
+        folder = repo / "services" / name
+        (folder / "config").mkdir(parents=True)
+        (folder / "values.yaml").write_text(values)
+        (folder / "config" / "ioc.yaml").write_text(
+            "description: REPLACE_WITH_DESCRIPTION\nentities: []\n"
+        )
+        (folder / "Chart.yaml").symlink_to("../../.helm-shared/Chart.yaml")
+        (folder / "templates").symlink_to("../../.helm-shared/templates")
+    return repo
+
+
+def run_catio(builder_path: Path, services_repo: Path, **kwargs) -> int:
+    """Call :func:`catio_cli` and return its exit code rather than raising."""
+    try:
+        catio_cli(builder_path, services_repo, **kwargs)
+    except typer.Exit as exc:
+        return int(exc.exit_code)
+    return 0
+
+
+def folders(services_repo: Path) -> set[str]:
+    """Every non-scaffold service folder name in *services_repo*."""
+    return {
+        child.name
+        for child in (services_repo / "services").iterdir()
+        if child.is_dir() and not child.name.startswith(".")
+    }
+
+
+# -- the full run ------------------------------------------------------------
+
+
+def test_full_run_writes_exactly_the_expected_folders(
+    builder_tree: Path, services_repo: Path, capsys
+):
+    """One fastcs-catio folder per clean chain, plus every rewritten consumer."""
+    code = run_catio(builder_tree, services_repo)
+    capsys.readouterr()
+
+    # Non-zero because BL21I-DI-IOC-01's chain failed.
+    assert code != 0
+
+    expected = {name.lower() for name in EXPECTED_IOCS_WRITTEN} | {
+        "bl21i-va-catio-01",
+        "bl21i-va-catio-05",
+        "bl21i-va-catio-06",
+    }
+    assert folders(services_repo) == expected
+
+    # The failed chain got neither a fastcs-catio IOC nor a rewritten scanner.
+    assert not (services_repo / "services" / "bl21i-di-catio-01").exists()
+    assert not (services_repo / "services" / "bl21i-di-ioc-01").exists()
+
+
+def test_report_names_the_diagnostic_that_blocked_the_failed_chain(
+    builder_tree: Path, services_repo: Path, capsys
+):
+    """A skipped chain must be traceable to a named, actionable diagnostic."""
+    run_catio(builder_tree, services_repo, json_out=True)
+    report = json.loads(capsys.readouterr().out)
+
+    failed = {c["scanner_ioc"] for c in report["chains"] if not c["converted"]}
+    assert failed == EXPECTED_FAILED_CHAINS
+
+    blocking = [
+        d
+        for d in report["diagnostics"]
+        if d["severity"] == "error" and d["chain"] in EXPECTED_FAILED_CHAINS
+    ]
+    assert blocking, "a failed chain must carry at least one error"
+    assert {d["code"] for d in blocking} == {"unknown-entity-type"}
+    # The message must name the terminal type a human has to add a table for.
+    assert all("EL2595" in d["message"] for d in blocking)
+
+    assert [i["ioc"] for i in report["iocs_skipped"]] == ["BL21I-DI-IOC-01"]
+    assert report["iocs_skipped"][0]["blocked_by"] == ["BL21I-DI-IOC-01"]
+
+
+def test_no_written_ioc_still_references_a_legacy_ethercat_pv(
+    builder_tree: Path, services_repo: Path, capsys
+):
+    """The point of the exercise: every legacy ``:MOD<n>:`` reference is gone."""
+    run_catio(builder_tree, services_repo)
+    capsys.readouterr()
+
+    for name in EXPECTED_IOCS_WRITTEN:
+        text = (
+            services_repo / "services" / name.lower() / "config" / "ioc.yaml"
+        ).read_text()
+        assert "-ERIO-" not in text, f"{name} still names a legacy coupler label"
+
+
+# -- reference coverage ------------------------------------------------------
+
+#: Of the 247 sampled references, 70 are the ``ethercat.auto_*`` ``DEVICE=``
+#: declarations themselves. Those entities are deleted by the converter, so
+#: there is nothing to rewrite; the remaining 177 are real consumer references
+#: and every one of them must be rewritten by the substitution map.
+EXPECTED_DECLARATIONS = 70
+EXPECTED_REWRITTEN = 177
+EXPECTED_DIAGNOSED = 0
+
+
+def test_every_sampled_reference_is_rewritten_or_diagnosed(builder_tree: Path):
+    """No reference may be silently left pointing at a record that will not exist.
+
+    Built over *all four* chains -- including the one the CLI skips -- because
+    this asserts the substitution map's coverage, not the failure policy.
+    """
+    references = json.loads((CATIO_SAMPLES / "expected_references.json").read_text())
+    assert len(references) == 247
+
+    log = DiagnosticLog()
+    substituter = build_substituter(discover_chains(builder_tree, log), log)
+
+    rewritten = declarations = diagnosed = 0
+    unaccounted: list[str] = []
+    for ref in references:
+        entity_type, attribute = ref["entity_type"], ref["attribute"]
+        if entity_type.startswith("ethercat.auto_") and attribute == "DEVICE":
+            declarations += 1
+            continue
+        ref_log = DiagnosticLog()
+        new = substituter.rewrite_value(
+            ref["value"],
+            attribute=attribute,
+            log=ref_log,
+            ioc=ref["ioc"],
+            entity=ref["entity_name"],
+        )
+        if new != ref["value"]:
+            rewritten += 1
+        elif len(ref_log):
+            diagnosed += 1
+        else:
+            unaccounted.append(f"{ref['ioc']} {ref['entity_name']}.{attribute}")
+
+    assert unaccounted == []
+    assert declarations == EXPECTED_DECLARATIONS
+    assert rewritten == EXPECTED_REWRITTEN
+    assert diagnosed == EXPECTED_DIAGNOSED
+    assert declarations + rewritten + diagnosed == len(references)
+
+
+#: Substitution-map size over all four chains. Pinned so a change in the naming
+#: rule or the dual-key policy cannot pass unnoticed.
+EXPECTED_SUBSTITUTIONS = 526
+
+
+def test_substitution_map_size_is_stable(builder_tree: Path):
+    log = DiagnosticLog()
+    substituter = build_substituter(discover_chains(builder_tree, log), log)
+    assert len(substituter.subs) == EXPECTED_SUBSTITUTIONS
+    # Every unresolved entry carries a code, so nothing drops out unexplained.
+    assert all(entry[0] for entry in substituter.unresolved.values())
+
+
+# -- stickiness (D11) --------------------------------------------------------
+
+
+def fastcs_configs(services_repo: Path) -> dict[str, bytes]:
+    """``folder name -> config/fastcs.yaml`` bytes, for every generated IOC."""
+    return {
+        path.parent.parent.name: path.read_bytes()
+        for path in sorted(services_repo.glob("services/*/config/fastcs.yaml"))
+    }
+
+
+def test_rerunning_keeps_the_same_ordinals_and_bytes(
+    builder_tree: Path, services_repo: Path, capsys
+):
+    """D11: ordinals are read back from the repo, never reallocated.
+
+    Renumbering on a re-run would repoint every PV rewritten by the first run at
+    a node prefix that no longer exists.
+    """
+    run_catio(builder_tree, services_repo)
+    capsys.readouterr()
+    first = fastcs_configs(services_repo)
+    assert set(first) == {
+        "bl21i-va-catio-01",
+        "bl21i-va-catio-05",
+        "bl21i-va-catio-06",
+    }
+
+    run_catio(builder_tree, services_repo, json_out=True)
+    report = json.loads(capsys.readouterr().out)
+
+    assert fastcs_configs(services_repo) == first
+    assert folders(services_repo) == {
+        name.lower() for name in EXPECTED_IOCS_WRITTEN
+    } | set(first)
+
+    ordinals = {c["catio_ioc"]: c["ordinal"] for c in report["chains"]}
+    assert ordinals == EXPECTED_ORDINALS
+
+
+def test_ordinals_match_the_node_prefix_actually_written(
+    builder_tree: Path, services_repo: Path, capsys
+):
+    """The written ``node_prefix`` and the predicted one are one source (D10)."""
+    run_catio(builder_tree, services_repo, json_out=True)
+    report = json.loads(capsys.readouterr().out)
+
+    for chain in report["chains"]:
+        if not chain["converted"]:
+            continue
+        folder = Path(chain["path"])
+        assert folder.parent.parent == services_repo
+        written = (folder / "config" / "fastcs.yaml").read_text()
+        expected = EXPECTED_ORDINALS[chain["catio_ioc"]]
+        assert chain["ordinal"] == expected
+        assert f'node_prefix: "{chain["node_prefix"]}"' in written
+        assert f"E{expected}RIO" in chain["node_prefix"]

--- a/tests/test_catio_integration.py
+++ b/tests/test_catio_integration.py
@@ -43,14 +43,22 @@ EXPECTED_ORDINALS = {
     "BL21I-VA-CATIO-06": 3,
 }
 
-#: ``BL21I-DI-IOC-01`` is skipped: it ``dbpf``-writes PVs created by
-#: ``auto_EL2595``, a terminal type ``leaves.py`` has no translation table for,
-#: so ``unknown-entity-type`` (ERROR) fails its chain. See the module docstring
-#: of ``builder2ibek.catio.leaves`` for what adding one would take.
-EXPECTED_FAILED_CHAINS = {"BL21I-DI-IOC-01"}
+#: Every BL21I chain converts. ``BL21I-DI-IOC-01`` was the last holdout: it
+#: needed ``auto_EL2595`` and ``auto_EL4134`` leaf tables, and the EL2595 drive
+#: current had to be selected in fastcs-catio's ``terminal_types.yaml``
+#: (fastcs-catio#65) before there was a PV to point its four ``dbpf`` writes at.
+#:
+#: Nothing in the samples exercises the per-chain failure policy any more.
+#: That is covered on purpose by synthetic chains in
+#: ``tests/test_catio_regressions.py`` -- a failed chain failing loudly, a
+#: reference into one erroring, a clean chain not being shadowed by it, and a
+#: straddling consumer being skipped whole -- so the coverage does not depend on
+#: a real beamline staying broken.
+EXPECTED_FAILED_CHAINS: set[str] = set()
 
-#: Consumers of a clean chain, so they are rewritten and written out.
+#: Consumers of a chain, so they are rewritten and written out.
 EXPECTED_IOCS_WRITTEN = {
+    "BL21I-DI-IOC-01",
     "BL21I-VA-IOC-01",
     "BL21I-VA-IOC-02",
     "BL21I-VA-IOC-04",
@@ -125,43 +133,44 @@ def test_full_run_writes_exactly_the_expected_folders(
     code = run_catio(builder_tree, services_repo)
     capsys.readouterr()
 
-    # Non-zero because BL21I-DI-IOC-01's chain failed.
-    assert code != 0
+    # Zero: every chain converts, so no error fired.
+    assert code == 0
 
     expected = {name.lower() for name in EXPECTED_IOCS_WRITTEN} | {
+        "bl21i-di-catio-01",
         "bl21i-va-catio-01",
         "bl21i-va-catio-05",
         "bl21i-va-catio-06",
     }
     assert folders(services_repo) == expected
 
-    # The failed chain got neither a fastcs-catio IOC nor a rewritten scanner.
-    assert not (services_repo / "services" / "bl21i-di-catio-01").exists()
-    assert not (services_repo / "services" / "bl21i-di-ioc-01").exists()
+    # Every chain got both a fastcs-catio IOC and a rewritten scanner.
+    assert (services_repo / "services" / "bl21i-di-catio-01").is_dir()
+    assert (services_repo / "services" / "bl21i-di-ioc-01").is_dir()
 
 
-def test_report_names_the_diagnostic_that_blocked_the_failed_chain(
+def test_the_whole_beamline_converts_with_no_chain_blocked(
     builder_tree: Path, services_repo: Path, capsys
 ):
-    """A skipped chain must be traceable to a named, actionable diagnostic."""
+    """Every BL21I chain converts, so nothing is skipped and no error fires.
+
+    This is the guard on the leaf tables: dropping ``auto_EL2595`` or
+    ``auto_EL4134``, or fastcs-catio deselecting the EL2595 drive current again,
+    puts ``BL21I-DI-IOC-01`` straight back into ``iocs_skipped``.
+    """
     run_catio(builder_tree, services_repo, json_out=True)
     report = json.loads(capsys.readouterr().out)
 
     failed = {c["scanner_ioc"] for c in report["chains"] if not c["converted"]}
     assert failed == EXPECTED_FAILED_CHAINS
 
-    blocking = [
-        d
-        for d in report["diagnostics"]
-        if d["severity"] == "error" and d["chain"] in EXPECTED_FAILED_CHAINS
-    ]
-    assert blocking, "a failed chain must carry at least one error"
-    assert {d["code"] for d in blocking} == {"unknown-entity-type"}
-    # The message must name the terminal type a human has to add a table for.
-    assert all("EL2595" in d["message"] for d in blocking)
+    assert [d for d in report["diagnostics"] if d["severity"] == "error"] == []
+    assert report["iocs_skipped"] == []
 
-    assert [i["ioc"] for i in report["iocs_skipped"]] == ["BL21I-DI-IOC-01"]
-    assert report["iocs_skipped"][0]["blocked_by"] == ["BL21I-DI-IOC-01"]
+    # The four LED drive currents are dbpf *writes*, so they must land on the
+    # setpoint and never on the read-only `_RBV`.
+    written = [d for d in report["diagnostics"] if d["code"] == "link-direction-guess"]
+    assert written == [], "no writable leaf should be left to a guess"
 
 
 def test_no_written_ioc_still_references_a_legacy_ethercat_pv(
@@ -232,7 +241,15 @@ def test_every_sampled_reference_is_rewritten_or_diagnosed(builder_tree: Path):
 
 #: Substitution-map size over all four chains. Pinned so a change in the naming
 #: rule or the dual-key policy cannot pass unnoticed.
-EXPECTED_SUBSTITUTIONS = 526
+#:
+#: Rose from 526 by 19 when the ``auto_EL2595`` and ``auto_EL4134`` tables were
+#: added: 7 for EL2595 (4 terminals x 1 leaf, declared, plus 3 chain-derived)
+#: and 12 for EL4134 (2 terminals x 4 leaves, declared, plus 4 chain-derived).
+#: Fewer chain-derived aliases than declared keys because an alias needs a
+#: coupler label, and several ``BL21I-DI`` couplers have none -- every entity on
+#: them declares a device-style ``DEVICE=`` with no ``:MOD`` part, so there is
+#: nothing to derive a label from. None of the shortfall is a dropped collision.
+EXPECTED_SUBSTITUTIONS = 545
 
 
 def test_substitution_map_size_is_stable(builder_tree: Path):
@@ -266,6 +283,7 @@ def test_rerunning_keeps_the_same_ordinals_and_bytes(
     capsys.readouterr()
     first = fastcs_configs(services_repo)
     assert set(first) == {
+        "bl21i-di-catio-01",
         "bl21i-va-catio-01",
         "bl21i-va-catio-05",
         "bl21i-va-catio-06",

--- a/tests/test_catio_regressions.py
+++ b/tests/test_catio_regressions.py
@@ -19,17 +19,20 @@ from pathlib import Path
 import pytest
 import typer
 
-from builder2ibek.catio.chains import (
+# Ahead of the builder2ibek.catio imports: those reach fastcs_catio lazily today,
+# but if one ever grows a module-scope import this file must skip rather than
+# fail collection.
+fastcs_catio = pytest.importorskip("fastcs_catio")
+
+from builder2ibek.catio.chains import (  # noqa: E402
     build_substituter,
     discover_chains,
 )
-from builder2ibek.catio.cli import catio_cli
-from builder2ibek.catio.diagnostics import DiagnosticLog, Severity
-from builder2ibek.catio.substitute import Substituter
-from builder2ibek.convert import convert_to_ioc
-from builder2ibek.converters.ethercat import CatioContext
-
-fastcs_catio = pytest.importorskip("fastcs_catio")
+from builder2ibek.catio.cli import catio_cli  # noqa: E402
+from builder2ibek.catio.diagnostics import DiagnosticLog, Severity  # noqa: E402
+from builder2ibek.catio.substitute import NewPv, Substituter  # noqa: E402
+from builder2ibek.convert import convert_to_ioc  # noqa: E402
+from builder2ibek.converters.ethercat import CatioContext  # noqa: E402
 
 
 def write_chain(directory: Path, ioc: str, body: str) -> Path:
@@ -433,3 +436,45 @@ def test_the_scanners_own_ethercat_entities_are_not_reported_as_dropped(
     )
 
     assert [d for d in log if d.code == "dropped-reference"] == []
+
+
+def test_a_second_pv_in_the_value_does_not_decide_the_first_ones_direction():
+    """A writer followed by a reader must not be pulled onto the readback.
+
+    `_trailing_flags` used to join every token after the PV, so in
+    "PV1 PP PV2 CP" the reader's `CP` reached PV1 and rewrote a writable
+    output link to its read-only `_RBV` -- a PV the IOC cannot write.
+    """
+    writer = NewPv(read="NEW:A_RBV", write="NEW:A")
+    reader = NewPv(read="NEW:B_RBV", write="NEW:B")
+    sub = Substituter(
+        {"OLD:A": writer, "OLD:B": reader},
+        owners={"OLD:A": "SCANNER", "OLD:B": "SCANNER"},
+        unresolved={},
+        known_labels={},
+    )
+    log = DiagnosticLog()
+
+    out = sub.rewrite_value(
+        "OLD:A PP OLD:B CP", attribute="OUTGB0", log=log, ioc="IOC", entity="E"
+    )
+
+    assert out == "NEW:A PP NEW:B_RBV CP"
+
+
+def test_a_lone_pv_still_sees_its_own_flags():
+    """The companion check: the scan must not stop too early either."""
+    reader = NewPv(read="NEW:B_RBV", write="NEW:B")
+    sub = Substituter(
+        {"OLD:B": reader},
+        owners={"OLD:B": "SCANNER"},
+        unresolved={},
+        known_labels={},
+    )
+    log = DiagnosticLog()
+
+    out = sub.rewrite_value(
+        "OLD:B CP MS", attribute="whatever", log=log, ioc="IOC", entity="E"
+    )
+
+    assert out == "NEW:B_RBV CP MS"

--- a/tests/test_catio_regressions.py
+++ b/tests/test_catio_regressions.py
@@ -1,0 +1,435 @@
+"""Regression tests for defects found by adversarial review of `catio`.
+
+One test per defect, each named after what went wrong. They are kept together
+rather than folded into the per-module files so that the guarantees bought by
+each fix stay legible as a set: every one of these is a way the tool used to
+emit, or silently keep, a PV reference pointing at a record no IOC creates.
+
+The chains here are written out in full rather than derived from
+``tests/samples/catio/``: each defect needs a topology the real BL21I XMLs do
+not contain (or contain only by luck), and a fixture that drifts with the
+samples would stop testing the defect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+
+from builder2ibek.catio.chains import (
+    build_substituter,
+    discover_chains,
+)
+from builder2ibek.catio.cli import catio_cli
+from builder2ibek.catio.diagnostics import DiagnosticLog, Severity
+from builder2ibek.catio.substitute import Substituter
+from builder2ibek.convert import convert_to_ioc
+from builder2ibek.converters.ethercat import CatioContext
+
+fastcs_catio = pytest.importorskip("fastcs_catio")
+
+
+def write_chain(directory: Path, ioc: str, body: str) -> Path:
+    """Write one builder XML holding *body* between the ``components`` tags."""
+    directory.mkdir(parents=True, exist_ok=True)
+    xml = directory / f"{ioc}.xml"
+    xml.write_text(
+        '<?xml version="1.0" ?>\n'
+        '<components arch="linux-x86_64">\n'
+        f"{body}\n"
+        "</components>\n"
+    )
+    return xml
+
+
+MASTER = '\t<ethercat.EthercatMaster name="ECATM" socket="/tmp/socket0"/>'
+
+
+def slave(name: str, type_rev: str) -> str:
+    return (
+        f'\t<ethercat.EthercatSlave master="ECATM" name="{name}" '
+        f'position="{name}" type_rev="{type_rev}"/>'
+    )
+
+
+def built(tmp_path: Path, ioc: str, body: str) -> tuple[Substituter, DiagnosticLog]:
+    """Discover and build a substituter from a single one-chain XML."""
+    write_chain(tmp_path, ioc, body)
+    log = DiagnosticLog()
+    return build_substituter(discover_chains(tmp_path, log), log), log
+
+
+# -- 1: a declared DEVICE= without a ':MOD' part ------------------------------
+
+# `BL21I-OP-LED-01`, `BL21I-MO-PIEZO-01` and `BL21I-DI-LED-0*` are all real
+# BL21I terminals named after the device they drive rather than their bus slot.
+# The declared-key family used to be gated on the `LABEL:MODn` shape, so their
+# PVs -- the ones the legacy IOC really created -- were never registered, and
+# `LEGACY_PV_RE` cannot catch the leftovers because they carry no `-ERIO-`.
+DEVICE_CHAIN = "\n".join(
+    [
+        MASTER,
+        slave("S0", "EK1100 rev 0x00120000"),
+        slave("S1", "EL1014 rev 0x00120000"),
+        slave("S2", "EL2024-0010 rev 0x0012000a"),
+        '\t<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-01:MOD1" PORT="S1" name="E1"/>',
+        '\t<ethercat.auto_EL2024_0010 DEVICE="BL21I-OP-LED-01" PORT="S2" name="E2"/>',
+    ]
+)
+
+
+def test_device_without_mod_still_registers_its_declared_pvs(tmp_path):
+    sub, log = built(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+
+    assert sub.subs["BL21I-OP-LED-01:CHANNEL1:OUTPUT"].write == (
+        "BL21I-VA-E1RIO-01:12VDO01:Channel1"
+    )
+    # and the chain-derived alias still resolves to the same terminal
+    assert (
+        sub.subs["BL21I-VA-ERIO-01:MOD2:CHANNEL1:OUTPUT"]
+        == sub.subs["BL21I-OP-LED-01:CHANNEL1:OUTPUT"]
+    )
+    # ignoring it for *label derivation* is still right, and still reported
+    assert [d.code for d in log if d.code == "device-without-mod"] == [
+        "device-without-mod"
+    ]
+
+
+def test_device_without_mod_reference_is_rewritten_not_passed_through(tmp_path):
+    sub, log = built(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+
+    rewritten = sub.rewrite_value(
+        "BL21I-OP-LED-01:CHANNEL1:OUTPUT PP",
+        attribute="OUTGB0",
+        log=log,
+        ioc="BL21I-OP-IOC-01",
+        entity="femto",
+    )
+    assert rewritten == "BL21I-VA-E1RIO-01:12VDO01:Channel1 PP"
+    assert sub.touched_iocs() == {"BL21I-OP-IOC-01"}
+
+
+# -- 2: an orphaned sticky ordinal ---------------------------------------------
+
+
+def test_a_sticky_pin_with_no_scanner_still_reserves_its_ordinal(tmp_path):
+    """A deployed catio IOC owns its E{n}RIO names whether or not its XML lives.
+
+    Its scanner XML being renamed or retired must not hand ordinal 1 to a live
+    chain in the same domain: two IOCs would then serve identical PV names.
+    """
+    write_chain(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    log = DiagnosticLog()
+
+    chains = discover_chains(tmp_path, log, sticky={"BL21I-VA-CATIO-09": 1})
+
+    assert [(c.scanner_ioc, c.ordinal) for c in chains] == [("BL21I-VA-IOC-01", 2)]
+    assert chains[0].node_prefix == "BL21I-VA-E2RIO-{:02d}"
+
+
+def test_an_orphan_pin_in_another_domain_reserves_nothing(tmp_path):
+    write_chain(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    log = DiagnosticLog()
+
+    chains = discover_chains(tmp_path, log, sticky={"BL21I-DI-CATIO-09": 1})
+
+    assert chains[0].ordinal == 1
+
+
+def test_two_pins_on_one_ordinal_are_a_corrupt_repo_even_when_orphaned(tmp_path):
+    write_chain(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    log = DiagnosticLog()
+
+    with pytest.raises(ValueError, match="pins ordinal 1 to both"):
+        discover_chains(
+            tmp_path,
+            log,
+            sticky={"BL21I-VA-CATIO-08": 1, "BL21I-VA-CATIO-09": 1},
+        )
+
+
+# -- 3 and 4: a chain that fails before substitution ---------------------------
+
+# EL9999 is in no `terminal_types.yaml`, so this chain fails inside
+# `predict_prefixes` -- before it can contribute a single key. Its terminals'
+# names must still be recognised, or a consumer straddling it is written with
+# the reference left dangling and nothing in the report says so.
+FAILED_CHAIN = "\n".join(
+    [
+        MASTER,
+        slave("C1", "EK1100 rev 0x00120000"),
+        slave("T1", "EL2024-0010 rev 0x00120000"),
+        '\t<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD1" PORT="T1"'
+        ' name="DIG1"/>',
+        slave("T2", "EL2024-0010 rev 0x00120000"),
+        '\t<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-LED-01" PORT="T2" name="LED1"/>',
+        slave("T3", "EL9999 rev 0x00120000"),
+    ]
+)
+
+
+@pytest.fixture
+def straddled(tmp_path) -> tuple[Substituter, DiagnosticLog]:
+    """One failed chain and one clean one, both in the same tree."""
+    write_chain(tmp_path, "BL21I-DI-IOC-01", FAILED_CHAIN)
+    write_chain(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    log = DiagnosticLog()
+    return build_substituter(discover_chains(tmp_path, log), log), log
+
+
+def test_a_failed_chain_still_fails_loudly(straddled):
+    sub, log = straddled
+    assert "BL21I-DI-IOC-01" in log.failed_chains()
+    assert sub.subs, "the clean chain must still contribute its keys"
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        # a declared DEVICE= with no `-ERIO-` segment: LEGACY_PV_RE cannot see it
+        "BL21I-DI-LED-01:CHANNEL1:OUTPUT",
+        # and one reached through the failed chain's coupler label
+        "BL21I-DI-ERIO-01:MOD1:CHANNEL1:OUTPUT",
+    ],
+)
+def test_a_reference_into_a_failed_chain_errors_and_names_that_chain(straddled, token):
+    sub, log = straddled
+
+    value = sub.rewrite_value(
+        f"{token} PP",
+        attribute="OUT",
+        log=log,
+        ioc="BL21I-DI-IOC-02",
+        entity="G1",
+    )
+
+    assert value == f"{token} PP", "an unresolvable reference is left alone"
+    raised = [d for d in log if d.ioc == "BL21I-DI-IOC-02"]
+    assert [d.severity for d in raised] == [Severity.ERROR]
+    # named, so the report can say which chain has to be fixed
+    assert raised[0].chain == "BL21I-DI-IOC-01"
+    assert sub.references("BL21I-DI-IOC-02") == {"BL21I-DI-IOC-01"}
+
+
+def test_a_clean_chain_is_never_shadowed_by_a_failed_one(straddled):
+    """The failed chain's prefixes must not swallow a converted chain's keys."""
+    sub, log = straddled
+
+    value = sub.rewrite_value(
+        "BL21I-VA-ERIO-01:MOD1:CHANNEL1:INPUT CP",
+        attribute="INP",
+        log=log,
+        ioc="BL21I-DI-IOC-02",
+        entity="G2",
+    )
+
+    assert value == "BL21I-VA-E1RIO-01:24VDI01:Channel1 CP"
+    assert [d for d in log if d.ioc == "BL21I-DI-IOC-02"] == []
+    assert sub.references("BL21I-DI-IOC-02") == {"BL21I-VA-IOC-01"}
+
+
+# -- 5: leaf-type-mismatch ------------------------------------------------------
+
+# The entity type decides which leaf table is used, but fastcs-catio builds its
+# attributes from the *slave's own* type. Where the two disagree the predicted
+# name -- or its `_RBV` suffix -- is for a PV that will not exist.
+MISBOUND = "\n".join(
+    [
+        MASTER,
+        slave("S0", "EK1100 rev 0x00120000"),
+        slave("S1", "EL1014 rev 0x00120000"),
+        slave("S2", "EL2024-0010 rev 0x0012000a"),
+        # an EL3104 table on an EL1014: the attribute does not exist at all
+        '\t<ethercat.auto_EL3104 DEVICE="BL21I-VA-ERIO-01:MOD1" PORT="S1" name="E1"/>',
+        # an EL1014 table on an EL2024-0010: `channel_n` exists but is R/W
+        '\t<ethercat.auto_EL1014 DEVICE="BL21I-VA-ERIO-01:MOD2" PORT="S2" name="E2"/>',
+    ]
+)
+
+
+def test_a_leaf_absent_from_the_real_terminal_is_an_error(tmp_path):
+    _, log = built(tmp_path, "BL21I-VA-IOC-01", MISBOUND)
+
+    absent = [d for d in log if d.code == "leaf-type-mismatch" and d.entity == "E1"]
+    assert absent, "auto_EL3104 leaves do not exist on an EL1014"
+    assert all(d.severity is Severity.ERROR for d in absent)
+    assert "ai_standard_channel_1_value" in " ".join(d.message for d in absent)
+
+
+def test_a_writability_disagreement_is_an_error(tmp_path):
+    _, log = built(tmp_path, "BL21I-VA-IOC-01", MISBOUND)
+
+    mismatched = [d for d in log if d.code == "leaf-type-mismatch" and d.entity == "E2"]
+    assert len(mismatched) == 4, "one per channel"
+    assert "_RBV" in mismatched[0].message
+
+
+def test_a_correctly_bound_chain_raises_no_leaf_type_mismatch(tmp_path):
+    _, log = built(tmp_path, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+
+    assert [d for d in log if d.code == "leaf-type-mismatch"] == []
+
+
+def test_el2024_bound_to_the_0010_table_is_not_a_leaf_type_mismatch(tmp_path):
+    """The one real BL21I `slave-type-mismatch`, and it is harmless.
+
+    Five DI terminals are plain `EL2024` bound to `auto_EL2024_0010`. Both
+    types give fastcs-catio the same four read/write `channel_n` attributes, so
+    only the module prefix differs -- and that is predicted from the slave's own
+    type. Promoting this to an error would fail a chain for nothing.
+    """
+    body = "\n".join(
+        [
+            MASTER,
+            slave("S0", "EK1100 rev 0x00120000"),
+            slave("S1", "EL2024 rev 0x00120000"),
+            '\t<ethercat.auto_EL2024_0010 DEVICE="BL21I-DI-ERIO-01:MOD1" PORT="S1"'
+            ' name="E1"/>',
+        ]
+    )
+    sub, log = built(tmp_path, "BL21I-DI-IOC-01", body)
+
+    assert [d.code for d in log] == ["slave-type-mismatch"]
+    assert not log.has_errors()
+    assert sub.subs["BL21I-DI-ERIO-01:MOD1:CHANNEL1:OUTPUT"].write == (
+        "BL21I-DI-E1RIO-01:24VDO01:Channel1"
+    )
+
+
+# -- 3, end to end: the straddling consumer must not be written ----------------
+
+
+@pytest.fixture
+def services_repo(tmp_path: Path) -> Path:
+    """A minimal services repo: the shared chart plus the two scaffolds."""
+    repo = tmp_path / "services-repo"
+    shared = repo / ".helm-shared"
+    (shared / "templates").mkdir(parents=True)
+    (shared / "Chart.yaml").write_text("apiVersion: v2\nname: ec-service\n")
+    (shared / "templates" / "ioc_instance.yaml").write_text("{}\n")
+    for name in (".ioc_template", ".fastcs_ioc_template"):
+        folder = repo / "services" / name
+        (folder / "config").mkdir(parents=True)
+        (folder / "values.yaml").write_text(
+            "ioc-instance:\n  image: REPLACE_WITH_IMAGE_URI\n"
+        )
+        (folder / "config" / "ioc.yaml").write_text(
+            "description: REPLACE_WITH_DESCRIPTION\nentities: []\n"
+        )
+        (folder / "Chart.yaml").symlink_to("../../.helm-shared/Chart.yaml")
+        (folder / "templates").symlink_to("../../.helm-shared/templates")
+    return repo
+
+
+#: References one PV from each chain. The DI one is a declared `DEVICE=` with
+#: no `-ERIO-` segment, which is exactly what used to slip through unnoticed.
+STRADDLING_CONSUMER = "\n".join(
+    [
+        '\t<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-01" id="1" name="G1"'
+        ' plog_adc_pv="BL21I-DI-LED-01:CHANNEL1:OUTPUT"/>',
+        '\t<mks9xx.mks9xxGauge P="BL21I-VA-GAUGE-02" id="2" name="G2"'
+        ' plog_adc_pv="BL21I-VA-ERIO-01:MOD1:CHANNEL1:INPUT"/>',
+    ]
+)
+
+
+@pytest.fixture
+def straddling_tree(tmp_path: Path) -> Path:
+    root = tmp_path / "BL21I-BUILDER"
+    make_iocs = root / "etc" / "makeIocs"
+    write_chain(make_iocs, "BL21I-DI-IOC-01", FAILED_CHAIN)
+    write_chain(make_iocs, "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    write_chain(make_iocs, "BL21I-DI-IOC-02", STRADDLING_CONSUMER)
+    return root
+
+
+def run_catio(builder_path: Path, services_repo: Path, **kwargs) -> int:
+    try:
+        catio_cli(builder_path, services_repo, **kwargs)
+    except typer.Exit as exc:
+        return int(exc.exit_code)
+    return 0
+
+
+def test_an_ioc_straddling_a_build_time_failure_is_skipped_whole(
+    straddling_tree: Path, services_repo: Path, capsys
+):
+    """Half-rewritten is worse than unconverted, and the report must say why.
+
+    The DI chain dies inside ``predict_prefixes`` -- before it contributes a
+    single key -- so it used to leave no trace the consumer's reference could
+    hit. The consumer was written with the DI PV untouched, no diagnostic, and
+    no mention in the report.
+    """
+    code = run_catio(straddling_tree, services_repo, json_out=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 1
+    assert payload["iocs_written"] == ["BL21I-VA-IOC-01"]
+    skipped = {item["ioc"]: item for item in payload["iocs_skipped"]}
+    assert skipped["BL21I-DI-IOC-02"]["blocked_by"] == ["BL21I-DI-IOC-01"]
+    assert not (services_repo / "services" / "bl21i-di-ioc-02").exists()
+
+
+# -- 6: a reference inside an entity the conversion drops ----------------------
+
+# `records.*` has no ibek equivalent and is deleted outright, taking any
+# EtherCAT reference inside it with it. Two real BL21I IOCs
+# (BL21I-MO-IOC-02, -06) depend on a chain solely through a `records.calcout`,
+# and used to appear in no section of the report at all.
+DROPPING_CONSUMER = "\n".join(
+    [
+        '\t<records.calcout name="C1" CALC="A"'
+        ' OUT="BL21I-VA-ERIO-01:MOD1:CHANNEL1:INPUT NPP MS"/>',
+    ]
+)
+
+
+def converted(tmp_path: Path, body: str, sub: Substituter, log: DiagnosticLog):
+    xml = write_chain(tmp_path / "consumer", "BL21I-VA-IOC-02", body)
+    return convert_to_ioc(
+        xml, catio=CatioContext(substituter=sub, log=log, ioc_name="BL21I-VA-IOC-02")
+    )
+
+
+def test_a_reference_lost_with_a_dropped_entity_is_reported(tmp_path: Path):
+    sub, log = built(tmp_path / "chain", "BL21I-VA-IOC-01", DEVICE_CHAIN)
+
+    ioc = converted(tmp_path, DROPPING_CONSUMER, sub, log)
+
+    assert "calcout" not in str(ioc.entities), "the entity really is dropped"
+    dropped = [d for d in log if d.code == "dropped-reference"]
+    assert len(dropped) == 1
+    assert dropped[0].severity is Severity.WARNING
+    assert dropped[0].ioc == "BL21I-VA-IOC-02"
+    assert dropped[0].attribute == "OUT"
+    assert dropped[0].chain == "BL21I-VA-IOC-01"
+    assert "BL21I-VA-ERIO-01:MOD1:CHANNEL1:INPUT" in dropped[0].message
+
+
+def test_a_reference_that_survived_conversion_is_not_reported_as_dropped(
+    tmp_path: Path,
+):
+    sub, log = built(tmp_path / "chain", "BL21I-VA-IOC-01", DEVICE_CHAIN)
+
+    ioc = converted(tmp_path, STRADDLING_CONSUMER, sub, log)
+
+    assert [d for d in log if d.code == "dropped-reference"] == []
+    assert "BL21I-VA-E1RIO-01:24VDI01:Channel1" in str(ioc.entities)
+
+
+def test_the_scanners_own_ethercat_entities_are_not_reported_as_dropped(
+    tmp_path: Path,
+):
+    """Their replacement is the generated catio IOC, not a hand-written record."""
+    sub, log = built(tmp_path / "chain", "BL21I-VA-IOC-01", DEVICE_CHAIN)
+    xml = tmp_path / "chain" / "BL21I-VA-IOC-01.xml"
+
+    convert_to_ioc(
+        xml, catio=CatioContext(substituter=sub, log=log, ioc_name="BL21I-VA-IOC-01")
+    )
+
+    assert [d for d in log if d.code == "dropped-reference"] == []

--- a/tests/test_catio_regressions.py
+++ b/tests/test_catio_regressions.py
@@ -478,3 +478,50 @@ def test_a_lone_pv_still_sees_its_own_flags():
     )
 
     assert out == "NEW:B_RBV CP MS"
+
+
+def test_dbpf_writes_so_it_must_not_be_pointed_at_the_readback():
+    """`epics.dbpf` caputs at startup; its target cannot be a read-only `_RBV`.
+
+    Its attribute is named `pv`, which no name heuristic can read a direction
+    into, so the rule fell through to "assume reading" and rewrote BL21I's four
+    LED drive currents to `...DoxCurrentOutputCurrent_RBV` -- a PV the IOC then
+    fails to caput. The entity type settles it where the attribute name cannot.
+    """
+    current = NewPv(read="NEW:DO01:Cur_RBV", write="NEW:DO01:Cur")
+    sub = Substituter(
+        {"OLD-LED-01:DOXCURRENT:OUTPUTCURRENT": current},
+        owners={"OLD-LED-01:DOXCURRENT:OUTPUTCURRENT": "SCANNER"},
+        unresolved={},
+        known_labels={},
+    )
+    log = DiagnosticLog()
+    entity = {
+        "type": "epics.dbpf",
+        "pv": "OLD-LED-01:DOXCURRENT:OUTPUTCURRENT",
+        "value": "170",
+    }
+
+    sub.rewrite_entity(entity, log=log, ioc="BL21I-DI-IOC-01")
+
+    assert entity["pv"] == "NEW:DO01:Cur"
+    # and it is no longer a guess, so it must not be reported as one
+    assert [d for d in log if d.code == "link-direction-guess"] == []
+
+
+def test_an_unknown_entity_type_still_falls_through_to_the_guess():
+    """The companion: the override must not swallow the general case."""
+    current = NewPv(read="NEW:DO01:Cur_RBV", write="NEW:DO01:Cur")
+    sub = Substituter(
+        {"OLD:X": current},
+        owners={"OLD:X": "SCANNER"},
+        unresolved={},
+        known_labels={},
+    )
+    log = DiagnosticLog()
+    entity = {"type": "some.other", "pv": "OLD:X"}
+
+    sub.rewrite_entity(entity, log=log, ioc="IOC")
+
+    assert entity["pv"] == "NEW:DO01:Cur_RBV"
+    assert [d.code for d in log] == ["link-direction-guess"]

--- a/tests/test_catio_services.py
+++ b/tests/test_catio_services.py
@@ -1,0 +1,652 @@
+"""Tests for :mod:`builder2ibek.catio.services`.
+
+Every test builds a throwaway services repo in ``tmp_path`` with the same shape
+as ``/workspaces/i21-services``: relative ``Chart.yaml`` / ``templates``
+symlinks into ``../../.helm-shared/``, an ``.ioc_template`` and a
+``.fastcs_ioc_template``. Nothing here touches a real repo.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from builder2ibek.catio.chains import Chain
+from builder2ibek.catio.services import (
+    CATIO_CONTROLLER_TYPE,
+    IBEK_PLACEHOLDERS,
+    IOC_SCHEMA,
+    is_legacy,
+    read_sticky_ordinals,
+    scaffold,
+    write_catio_ioc,
+    write_ioc,
+)
+from builder2ibek.types import Generic_IOC
+
+CHART = "\n".join(
+    [
+        "# A Helm Chart for an IOC instance",
+        "apiVersion: v2",
+        "name: ec-service",
+        "version: 1.0.1",
+        "",
+    ]
+)
+
+LEGACY_CHART = "\n".join(
+    [
+        "# A Helm Chart for an IOC instance",
+        "apiVersion: v2",
+        "name: ec-legacy-service",
+        "version: 1.0.0",
+        "",
+    ]
+)
+
+IOC_TEMPLATE_VALUES = """\
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+ioc-instance:
+  image: REPLACE_WITH_IMAGE_URI
+"""
+
+IOC_TEMPLATE_CONFIG = """\
+# yaml-language-server: $schema=../ioc.schema.json
+
+ioc_name: "{{ _global.get_env('IOC_NAME') }}"
+
+description: REPLACE_WITH_DESCRIPTION
+
+entities: []
+"""
+
+FASTCS_TEMPLATE_VALUES = """\
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+ioc-instance:
+  image: REPLACE_WITH_FASTCS_IMAGE_URI
+  args:
+    - stdio-socket --ptty "fastcs-example run /epics/ioc/config/controller.yaml"
+
+  livenessExecutable: ""
+  preStopExecutable: ""
+"""
+
+FASTCS_TEMPLATE_CONFIG = """\
+# EXAMPLE CONTROLLER CONFIGURATION YAML REPLACE WITH YOURS
+
+controller:
+  ip_settings:
+    ip: "localhost"
+"""
+
+LEGACY_VALUES = """\
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+dev-c7:
+  iocVersion: 5-19
+"""
+
+#: A real ibek IOC whose *image tag* contains "dev-c7". Deleting this folder
+#: would be a data-loss bug -- ``bl21i-ea-ioc-01-debug`` is exactly this shape.
+DEV_C7_IMAGE_VALUES = """\
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+ioc-instance:
+  image: ghcr.io/diamondlightsource/dev-c7:2025.11.1-beta.1
+"""
+
+
+def _link(where: Path, name: str, target: str) -> None:
+    os.symlink(target, where / name)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal but structurally faithful services repo."""
+    shared = tmp_path / ".helm-shared"
+    (shared / "templates").mkdir(parents=True)
+    (shared / "Chart.yaml").write_text(CHART)
+    (shared / "LegacyChart.yaml").write_text(LEGACY_CHART)
+    (shared / "values.schema.json").write_text("{}\n")
+    (shared / "templates" / "ioc_instance.yaml").write_text(
+        '{{ include "ioc-instance" . }}\n'
+    )
+
+    services = tmp_path / "services"
+
+    ibek = services / ".ioc_template"
+    (ibek / "config").mkdir(parents=True)
+    _link(ibek, "Chart.yaml", "../../.helm-shared/Chart.yaml")
+    _link(ibek, "templates", "../../.helm-shared/templates")
+    (ibek / "values.yaml").write_text(IOC_TEMPLATE_VALUES)
+    (ibek / "config" / "ioc.yaml").write_text(IOC_TEMPLATE_CONFIG)
+
+    fastcs = services / ".fastcs_ioc_template"
+    (fastcs / "config").mkdir(parents=True)
+    _link(fastcs, "Chart.yaml", "../../.helm-shared/Chart.yaml")
+    _link(fastcs, "templates", "../../.helm-shared/templates")
+    (fastcs / "values.yaml").write_text(FASTCS_TEMPLATE_VALUES)
+    (fastcs / "config" / "controller.yaml").write_text(FASTCS_TEMPLATE_CONFIG)
+
+    return tmp_path
+
+
+@pytest.fixture
+def chain() -> Chain:
+    return Chain(scanner_ioc="BL21I-VA-IOC-01", domain="BL21I-VA", ordinal=1)
+
+
+def _make_legacy(repo: Path, folder: str) -> Path:
+    """A ``dev-c7`` IOC folder, exactly as the real ones look."""
+    target = repo / "services" / folder
+    target.mkdir(parents=True)
+    _link(target, "Chart.yaml", "../../.helm-shared/LegacyChart.yaml")
+    (target / "values.yaml").write_text(LEGACY_VALUES)
+    return target
+
+
+def _load(path: Path):
+    return YAML(typ="safe").load(path)
+
+
+# --- scaffold ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fastcs", [False, True])
+def test_scaffold_creates_relative_symlinks(repo: Path, fastcs: bool) -> None:
+    folder = scaffold(repo, "bl21i-va-catio-01", fastcs=fastcs, dry_run=False)
+
+    chart = folder / "Chart.yaml"
+    templates = folder / "templates"
+    assert chart.is_symlink()
+    assert templates.is_symlink()
+    assert os.readlink(chart) == "../../.helm-shared/Chart.yaml"
+    assert os.readlink(templates) == "../../.helm-shared/templates"
+    # and the relative links actually resolve inside this repo
+    assert chart.resolve() == (repo / ".helm-shared" / "Chart.yaml").resolve()
+    assert (templates / "ioc_instance.yaml").is_file()
+
+
+def test_scaffold_copies_template_files(repo: Path) -> None:
+    folder = scaffold(repo, "bl21i-va-ioc-09", fastcs=False, dry_run=False)
+    assert (folder / "values.yaml").read_text() == IOC_TEMPLATE_VALUES
+    assert (folder / "config" / "ioc.yaml").read_text() == IOC_TEMPLATE_CONFIG
+
+
+def test_scaffold_fastcs_uses_the_fastcs_template(repo: Path) -> None:
+    folder = scaffold(repo, "bl21i-va-catio-01", fastcs=True, dry_run=False)
+    assert (folder / "config" / "controller.yaml").is_file()
+    assert not (folder / "config" / "ioc.yaml").exists()
+
+
+def test_scaffold_dry_run_writes_nothing(repo: Path) -> None:
+    before = sorted(p.name for p in (repo / "services").iterdir())
+    folder = scaffold(repo, "bl21i-va-catio-01", fastcs=True, dry_run=True)
+
+    assert folder == repo / "services" / "bl21i-va-catio-01"
+    assert not folder.exists()
+    assert sorted(p.name for p in (repo / "services").iterdir()) == before
+
+
+def test_scaffold_needs_a_services_directory(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="no services directory"):
+        scaffold(tmp_path, "bl21i-va-catio-01", fastcs=False, dry_run=False)
+
+
+@pytest.mark.parametrize(
+    "folder", ["", ".legacy_ioc_template", ".ioc_template", "..", "a/b"]
+)
+def test_scaffold_refuses_a_non_instance_folder(repo: Path, folder: str) -> None:
+    """`.legacy_ioc_template` is itself a dev-c7 folder -- never delete it."""
+    with pytest.raises(ValueError, match="not an IOC instance folder name"):
+        scaffold(repo, folder, fastcs=False, dry_run=False)
+    assert (repo / "services" / ".ioc_template" / "values.yaml").is_file()
+
+
+def test_scaffold_needs_the_template(repo: Path) -> None:
+    shutil.rmtree(repo / "services" / ".fastcs_ioc_template")
+    with pytest.raises(FileNotFoundError, match=r"\.fastcs_ioc_template"):
+        scaffold(repo, "bl21i-va-catio-01", fastcs=True, dry_run=False)
+
+
+def test_scaffold_keeps_an_existing_non_legacy_folder(repo: Path) -> None:
+    folder = repo / "services" / "bl21i-va-ioc-09"
+    (folder / "config").mkdir(parents=True)
+    (folder / "values.yaml").write_text("ioc-instance:\n  image: real:1.2.3\n")
+    (folder / "config" / "ioc.yaml").write_text("description: mine\n")
+    (folder / "keep-me.yaml").write_text("hand written\n")
+
+    scaffold(repo, "bl21i-va-ioc-09", fastcs=False, dry_run=False)
+
+    # nothing real was clobbered ...
+    assert (folder / "values.yaml").read_text() == (
+        "ioc-instance:\n  image: real:1.2.3\n"
+    )
+    assert (folder / "config" / "ioc.yaml").read_text() == "description: mine\n"
+    assert (folder / "keep-me.yaml").is_file()
+    # ... but the missing symlinks were added
+    assert (folder / "Chart.yaml").is_symlink()
+    assert (folder / "templates").is_symlink()
+
+
+def test_scaffold_recreates_a_folder_linked_to_the_legacy_chart(repo: Path) -> None:
+    """A LegacyChart link alone makes a folder legacy, dev-c7 key or not."""
+    folder = repo / "services" / "bl21i-va-ioc-09"
+    folder.mkdir(parents=True)
+    _link(folder, "Chart.yaml", "../../.helm-shared/LegacyChart.yaml")
+    (folder / "values.yaml").write_text("ioc-instance: {}\n")
+
+    scaffold(repo, "bl21i-va-ioc-09", fastcs=False, dry_run=False)
+
+    assert os.readlink(folder / "Chart.yaml") == "../../.helm-shared/Chart.yaml"
+    assert (folder / "values.yaml").read_text() == IOC_TEMPLATE_VALUES
+
+
+def test_scaffold_repoints_a_stale_symlink(repo: Path) -> None:
+    """A non-legacy folder whose links drifted is repaired, not deleted."""
+    folder = repo / "services" / "bl21i-va-ioc-09"
+    folder.mkdir(parents=True)
+    _link(folder, "Chart.yaml", "../../../elsewhere/Chart.yaml")
+    _link(folder, "templates", "../../../elsewhere/templates")
+    (folder / "values.yaml").write_text("ioc-instance:\n  image: real:1.2.3\n")
+
+    scaffold(repo, "bl21i-va-ioc-09", fastcs=False, dry_run=False)
+
+    assert os.readlink(folder / "Chart.yaml") == "../../.helm-shared/Chart.yaml"
+    assert os.readlink(folder / "templates") == "../../.helm-shared/templates"
+    assert "real:1.2.3" in (folder / "values.yaml").read_text()
+
+
+def test_scaffold_replaces_a_real_file_squatting_on_a_symlink(repo: Path) -> None:
+    folder = repo / "services" / "bl21i-va-ioc-09"
+    folder.mkdir(parents=True)
+    (folder / "Chart.yaml").write_text("a real file, not a link\n")
+    (folder / "templates").mkdir()
+    (folder / "templates" / "junk.yaml").write_text("junk\n")
+
+    scaffold(repo, "bl21i-va-ioc-09", fastcs=False, dry_run=False)
+
+    assert (folder / "Chart.yaml").is_symlink()
+    assert (folder / "templates").is_symlink()
+    assert (repo / ".helm-shared" / "templates" / "ioc_instance.yaml").is_file()
+
+
+# --- the legacy dev-c7 rule --------------------------------------------------
+
+
+def test_is_legacy_detects_both_signals(repo: Path) -> None:
+    folder = _make_legacy(repo, "bl21i-va-ioc-02")
+    assert is_legacy(folder)
+
+    # values.yaml alone is enough
+    (folder / "Chart.yaml").unlink()
+    assert is_legacy(folder)
+
+
+def test_is_legacy_ignores_a_dev_c7_image_tag(repo: Path) -> None:
+    """``bl21i-ea-ioc-01-debug`` is an ibek IOC whose image tag says dev-c7."""
+    folder = repo / "services" / "bl21i-ea-ioc-01-debug"
+    folder.mkdir(parents=True)
+    _link(folder, "Chart.yaml", "../../.helm-shared/Chart.yaml")
+    (folder / "values.yaml").write_text(DEV_C7_IMAGE_VALUES)
+
+    assert "dev-c7" in (folder / "values.yaml").read_text()
+    assert not is_legacy(folder)
+
+
+def test_is_legacy_false_for_a_missing_folder(repo: Path) -> None:
+    assert not is_legacy(repo / "services" / "nope")
+
+
+def test_legacy_folder_is_deleted_and_recreated(repo: Path) -> None:
+    folder = _make_legacy(repo, "bl21i-va-ioc-02")
+    (folder / "leftover.yaml").write_text("stale\n")
+
+    scaffold(repo, "bl21i-va-ioc-02", fastcs=False, dry_run=False)
+
+    assert not (folder / "leftover.yaml").exists()
+    assert os.readlink(folder / "Chart.yaml") == "../../.helm-shared/Chart.yaml"
+    assert (folder / "values.yaml").read_text() == IOC_TEMPLATE_VALUES
+    assert (folder / "config" / "ioc.yaml").is_file()
+
+
+def test_deleting_a_legacy_folder_does_not_follow_the_templates_symlink(
+    repo: Path,
+) -> None:
+    """The nightmare case: rmtree descending ``templates`` into .helm-shared."""
+    folder = _make_legacy(repo, "bl21i-va-ioc-02")
+    # a legacy folder with a stray templates symlink (belt and braces)
+    _link(folder, "templates", "../../.helm-shared/templates")
+    shared_file = repo / ".helm-shared" / "templates" / "ioc_instance.yaml"
+    assert shared_file.is_file()
+
+    scaffold(repo, "bl21i-va-ioc-02", fastcs=False, dry_run=False)
+
+    assert shared_file.is_file()
+    assert (repo / ".helm-shared" / "Chart.yaml").is_file()
+    assert (repo / ".helm-shared" / "LegacyChart.yaml").is_file()
+
+
+def test_legacy_folder_is_untouched_on_a_dry_run(repo: Path) -> None:
+    folder = _make_legacy(repo, "bl21i-va-ioc-02")
+    scaffold(repo, "bl21i-va-ioc-02", fastcs=False, dry_run=True)
+    assert (folder / "values.yaml").read_text() == LEGACY_VALUES
+
+
+# --- write_catio_ioc ---------------------------------------------------------
+
+
+def test_write_catio_ioc_layout(repo: Path, chain: Chain) -> None:
+    write_catio_ioc(repo, chain, dry_run=False)
+    folder = repo / "services" / "bl21i-va-catio-01"
+
+    assert sorted(p.name for p in folder.iterdir()) == [
+        "Chart.yaml",
+        "config",
+        "templates",
+        "values.yaml",
+    ]
+    assert sorted(p.name for p in (folder / "config").iterdir()) == ["fastcs.yaml"]
+
+
+def test_write_catio_ioc_removes_the_example_controller_yaml(
+    repo: Path, chain: Chain
+) -> None:
+    write_catio_ioc(repo, chain, dry_run=False)
+    config = repo / "services" / "bl21i-va-catio-01" / "config"
+    assert (config / "fastcs.yaml").is_file()
+    assert not (config / "controller.yaml").exists()
+
+
+def test_write_catio_ioc_name_mappings_come_from_the_chain(
+    repo: Path, chain: Chain
+) -> None:
+    write_catio_ioc(repo, chain, dry_run=False)
+    doc = _load(repo / "services" / "bl21i-va-catio-01" / "config" / "fastcs.yaml")
+
+    (controller,) = doc["controllers"]
+    assert controller["id"] == "BL21I-VA-CATIO-01"
+    assert controller["type"] == CATIO_CONTROLLER_TYPE
+    assert controller["name_mappings"] == chain.name_mappings()
+    assert controller["tcp_settings"]["target_port"] == 27905
+    assert controller["route"] == {
+        "route_name": "",
+        "user_name": "Administrator",
+        "password": "1",
+    }
+    assert controller["scan_timings"] == {
+        "poll_period": 1.0,
+        "notification_period": 0.2,
+    }
+    (transport,) = doc["transport"]
+    assert transport["epicsca"] == {}
+    assert transport["gui"]["output_dir"] == "./screens"
+    assert "BL21I-VA-IOC-01" in transport["gui"]["title"]
+
+
+def test_write_catio_ioc_node_prefix_is_not_a_re_derivation(repo: Path) -> None:
+    """A second chain must get its own ordinal, straight from the Chain."""
+    chain = Chain(scanner_ioc="BL21I-DI-IOC-01", domain="BL21I-DI", ordinal=3)
+    write_catio_ioc(repo, chain, dry_run=False)
+    doc = _load(repo / "services" / "bl21i-di-catio-01" / "config" / "fastcs.yaml")
+    mappings = doc["controllers"][0]["name_mappings"]
+    assert mappings["node_prefix"] == "BL21I-DI-E3RIO-{:02d}"
+    assert mappings["node_prefix"] == chain.node_prefix
+    assert mappings["device_prefix"] == chain.device_prefix
+    assert mappings["module_prefix"] == chain.module_prefix
+
+
+def test_write_catio_ioc_values_yaml(repo: Path, chain: Chain) -> None:
+    write_catio_ioc(repo, chain, dry_run=False)
+    text = (repo / "services" / "bl21i-va-catio-01" / "values.yaml").read_text()
+
+    assert text.startswith(
+        "# yaml-language-server: $schema=../../.helm-shared/values.schema.json\n"
+    )
+    assert "stdio-expose --ptty --stdin --ctrl-d" in text
+    assert "stdio-socket" not in text
+    assert "fastcs-catio run /epics/ioc/config/fastcs.yaml" in text
+
+    doc = YAML(typ="safe").load(text)
+    assert set(doc) == {"ioc-instance"}
+    instance = doc["ioc-instance"]
+    assert instance["image"].startswith("ghcr.io/diamondlightsource/fastcs-catio:")
+    assert instance["livenessExecutable"] == ""
+    assert instance["preStopExecutable"] == ""
+    assert len(instance["args"]) == 1
+
+
+def test_write_catio_ioc_returns_its_placeholders(repo: Path, chain: Chain) -> None:
+    placeholders = write_catio_ioc(repo, chain, dry_run=False)
+    assert placeholders == ["REPLACE_WITH_ADS_SERVER_IP", "REPLACE_WITH_PINNED_TAG"]
+
+    written = "".join(
+        p.read_text()
+        for p in sorted((repo / "services" / "bl21i-va-catio-01").rglob("*.yaml"))
+        if p.is_file() and not p.is_symlink()
+    )
+    for placeholder in placeholders:
+        assert placeholder in written
+
+
+def test_write_catio_ioc_dry_run_writes_nothing(repo: Path, chain: Chain) -> None:
+    before = sorted(p.name for p in (repo / "services").iterdir())
+
+    placeholders = write_catio_ioc(repo, chain, dry_run=True)
+
+    assert placeholders == ["REPLACE_WITH_ADS_SERVER_IP", "REPLACE_WITH_PINNED_TAG"]
+    assert not (repo / "services" / "bl21i-va-catio-01").exists()
+    assert sorted(p.name for p in (repo / "services").iterdir()) == before
+
+
+def test_write_catio_ioc_is_idempotent(repo: Path, chain: Chain) -> None:
+    first = write_catio_ioc(repo, chain, dry_run=False)
+    folder = repo / "services" / "bl21i-va-catio-01"
+    text = (folder / "config" / "fastcs.yaml").read_text()
+
+    second = write_catio_ioc(repo, chain, dry_run=False)
+
+    assert first == second
+    assert (folder / "config" / "fastcs.yaml").read_text() == text
+    assert not (folder / "config" / "controller.yaml").exists()
+
+
+def test_write_catio_ioc_replaces_a_legacy_folder(repo: Path, chain: Chain) -> None:
+    folder = _make_legacy(repo, "bl21i-va-catio-01")
+    (folder / "values.yaml").write_text(LEGACY_VALUES)
+
+    write_catio_ioc(repo, chain, dry_run=False)
+
+    assert "dev-c7" not in (folder / "values.yaml").read_text()
+    assert os.readlink(folder / "Chart.yaml") == "../../.helm-shared/Chart.yaml"
+
+
+# --- read_sticky_ordinals ----------------------------------------------------
+
+
+def test_sticky_ordinals_round_trip(repo: Path) -> None:
+    """The stickiness loop: what we write is what we read back."""
+    chains = [
+        Chain(scanner_ioc="BL21I-VA-IOC-01", domain="BL21I-VA", ordinal=1),
+        Chain(scanner_ioc="BL21I-VA-IOC-05", domain="BL21I-VA", ordinal=2),
+        Chain(scanner_ioc="BL21I-DI-IOC-01", domain="BL21I-DI", ordinal=1),
+    ]
+    for one in chains:
+        write_catio_ioc(repo, one, dry_run=False)
+
+    assert read_sticky_ordinals(repo) == {
+        "BL21I-VA-CATIO-01": 1,
+        "BL21I-VA-CATIO-05": 2,
+        "BL21I-DI-CATIO-01": 1,
+    }
+
+
+def test_sticky_ordinals_survive_double_digits(repo: Path) -> None:
+    write_catio_ioc(
+        repo,
+        Chain(scanner_ioc="BL21I-VA-IOC-01", domain="BL21I-VA", ordinal=12),
+        dry_run=False,
+    )
+    assert read_sticky_ordinals(repo) == {"BL21I-VA-CATIO-01": 12}
+
+
+def test_sticky_ordinals_empty_repo(repo: Path) -> None:
+    assert read_sticky_ordinals(repo) == {}
+
+
+def test_sticky_ordinals_missing_services_dir(tmp_path: Path) -> None:
+    assert read_sticky_ordinals(tmp_path) == {}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("this: [is not: valid yaml\n", id="unparseable"),
+        pytest.param("", id="empty"),
+        pytest.param("- a\n- list\n", id="not-a-mapping"),
+        pytest.param("controllers: not-a-list\n", id="controllers-not-a-list"),
+        pytest.param("controllers:\n  - just-a-string\n", id="entry-not-a-mapping"),
+        pytest.param(
+            "controller:\n  serial_settings:\n    port: /dev/ttyUSB0\n",
+            id="singular-controller-mapping",
+        ),
+        pytest.param(
+            "controllers:\n"
+            "  - id: BL01C-EA-OTHER-01\n"
+            "    type: fastcs_other.Controller\n"
+            "    name_mappings:\n"
+            '      node_prefix: "X-E9RIO-{:02d}"\n',
+            id="another-fastcs-project",
+        ),
+        pytest.param(
+            f"controllers:\n"
+            f"  - id: BL21I-VA-CATIO-01\n"
+            f"    type: {CATIO_CONTROLLER_TYPE}\n",
+            id="no-name-mappings",
+        ),
+        pytest.param(
+            f"controllers:\n"
+            f"  - id: BL21I-VA-CATIO-01\n"
+            f"    type: {CATIO_CONTROLLER_TYPE}\n"
+            f"    name_mappings:\n"
+            f'      node_prefix: "BL21I-VA-RIO-{{:02d}}"\n',
+            id="node-prefix-without-an-ordinal",
+        ),
+        pytest.param(
+            f"controllers:\n"
+            f"  - type: {CATIO_CONTROLLER_TYPE}\n"
+            f"    name_mappings:\n"
+            f'      node_prefix: "BL21I-VA-E1RIO-{{:02d}}"\n',
+            id="no-id",
+        ),
+    ],
+)
+def test_sticky_ordinals_tolerates_junk(repo: Path, text: str) -> None:
+    junk = repo / "services" / "bl01c-ea-other-01" / "config"
+    junk.mkdir(parents=True)
+    (junk / "fastcs.yaml").write_text(text)
+
+    good = Chain(scanner_ioc="BL21I-VA-IOC-01", domain="BL21I-VA", ordinal=4)
+    write_catio_ioc(repo, good, dry_run=False)
+
+    assert read_sticky_ordinals(repo) == {"BL21I-VA-CATIO-01": 4}
+
+
+def test_sticky_ordinals_ignores_controller_yaml(repo: Path) -> None:
+    """A FastCS IOC using the other config filename is not our business."""
+    other = repo / "services" / "bl01c-mo-ppanda-01" / "config"
+    other.mkdir(parents=True)
+    (other / "controller.yaml").write_text(
+        f"controllers:\n"
+        f"  - id: SOMETHING-CATIO-99\n"
+        f"    type: {CATIO_CONTROLLER_TYPE}\n"
+        f"    name_mappings:\n"
+        f'      node_prefix: "X-E7RIO-{{:02d}}"\n'
+    )
+    assert read_sticky_ordinals(repo) == {}
+
+
+# --- write_ioc ---------------------------------------------------------------
+
+
+def _ioc(description: str = "an IOC") -> Generic_IOC:
+    return Generic_IOC(
+        ioc_name="{{ _global.get_env('IOC_NAME') }}",
+        description=description,
+        entities=[
+            {"type": "epics.EpicsEnvSet", "name": "EPICS_TZ", "value": "GMT0BST"}
+        ],
+        source_file=Path("BL21I-VA-IOC-02.xml"),
+    )
+
+
+def test_write_ioc_layout_and_schema(repo: Path) -> None:
+    folder = write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=False)
+
+    assert folder == repo / "services" / "bl21i-va-ioc-02"
+    assert (folder / "Chart.yaml").is_symlink()
+    assert (folder / "templates").is_symlink()
+
+    text = (folder / "config" / "ioc.yaml").read_text()
+    assert text.startswith(f"# yaml-language-server: $schema={IOC_SCHEMA}\n")
+
+    doc = YAML(typ="safe").load(text)
+    assert doc["description"] == "an IOC"
+    assert doc["entities"][0]["type"] == "epics.EpicsEnvSet"
+    assert "source_file" not in doc
+
+
+def test_write_ioc_leaves_the_image_placeholder(repo: Path) -> None:
+    folder = write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=False)
+    values = (folder / "values.yaml").read_text()
+    for placeholder in IBEK_PLACEHOLDERS:
+        assert placeholder in values
+
+
+def test_write_ioc_keeps_a_pinned_image(repo: Path) -> None:
+    folder = repo / "services" / "bl21i-va-ioc-02"
+    folder.mkdir(parents=True)
+    (folder / "values.yaml").write_text("ioc-instance:\n  image: real:1.2.3\n")
+
+    write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=False)
+
+    assert "real:1.2.3" in (folder / "values.yaml").read_text()
+
+
+def test_write_ioc_replaces_a_legacy_folder(repo: Path) -> None:
+    folder = _make_legacy(repo, "bl21i-va-ioc-02")
+
+    write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=False)
+
+    assert "dev-c7" not in (folder / "values.yaml").read_text()
+    assert os.readlink(folder / "Chart.yaml") == "../../.helm-shared/Chart.yaml"
+    assert (folder / "config" / "ioc.yaml").is_file()
+
+
+def test_write_ioc_fills_an_empty_description(repo: Path) -> None:
+    ioc = _ioc(description="")
+    folder = write_ioc(repo, "BL21I-VA-IOC-02", ioc, dry_run=False)
+    doc = YAML(typ="safe").load(folder / "config" / "ioc.yaml")
+    assert doc["description"] == "BL21I-VA-IOC-02, converted by builder2ibek catio"
+
+
+def test_write_ioc_does_not_write_ioc_schema_json(repo: Path) -> None:
+    """``ibek pattern schema`` generates that, from a pre-commit hook."""
+    folder = write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=False)
+    assert not (folder / "ioc.schema.json").exists()
+
+
+def test_write_ioc_dry_run_writes_nothing(repo: Path) -> None:
+    before = sorted(p.name for p in (repo / "services").iterdir())
+
+    folder = write_ioc(repo, "BL21I-VA-IOC-02", _ioc(), dry_run=True)
+
+    assert folder == repo / "services" / "bl21i-va-ioc-02"
+    assert not folder.exists()
+    assert sorted(p.name for p in (repo / "services").iterdir()) == before

--- a/tests/test_catio_substitute.py
+++ b/tests/test_catio_substitute.py
@@ -1,0 +1,337 @@
+"""Unit tests for `builder2ibek.catio.substitute`.
+
+Pure module -- no fastcs_catio, no file I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder2ibek.catio.diagnostics import DiagnosticLog
+from builder2ibek.catio.substitute import (
+    LEGACY_PV_RE,
+    NewPv,
+    Substituter,
+    link_is_reading,
+)
+
+# A read-only EL1014 channel and a read/write EL2024-0010 channel, as
+# chains.build_substituter would produce them.
+DI_IN = "BL21I-DI-ERIO-10:MOD1:CHANNEL1:INPUT"
+DI_IN_NEW = "BL21I-DI-E1RIO-10:24VDI01:Channel1"
+DI_OUT = "BL21I-DI-ERIO-10:MOD2:CHANNEL1:OUTPUT"
+DI_OUT_W = "BL21I-DI-E1RIO-10:12VDO01:Channel1"
+DI_OUT_R = "BL21I-DI-E1RIO-10:12VDO01:Channel1_RBV"
+
+SCANNER = "BL21I-DI-IOC-01"
+CONSUMER = "BL21I-DI-IOC-04"
+
+
+def make_substituter(**kwargs) -> Substituter:
+    """A Substituter over the two demo PVs, with overridable dictionaries."""
+    subs = {
+        DI_IN: NewPv.same(DI_IN_NEW),
+        DI_OUT: NewPv(read=DI_OUT_R, write=DI_OUT_W),
+    }
+    owners = {DI_IN: SCANNER, DI_OUT: SCANNER}
+    kwargs.setdefault("subs", subs)
+    kwargs.setdefault("owners", owners)
+    kwargs.setdefault("unresolved", {})
+    kwargs.setdefault("known_labels", {"BL21I-DI-ERIO-10": SCANNER})
+    return Substituter(**kwargs)
+
+
+def rewrite(sub: Substituter, value: str, *, attribute: str = "INP", **kwargs) -> str:
+    # note: an empty DiagnosticLog is falsy (__len__ == 0), so no `or` here
+    log = kwargs.pop("log", None)
+    if log is None:
+        log = DiagnosticLog()
+    return sub.rewrite_value(
+        value,
+        attribute=attribute,
+        log=log,
+        ioc=kwargs.pop("ioc", CONSUMER),
+        entity=kwargs.pop("entity", "demo"),
+    )
+
+
+# -- NewPv ------------------------------------------------------------------
+
+
+def test_new_pv_same_sets_both_directions():
+    pv = NewPv.same("X:Y")
+    assert (pv.read, pv.write, pv.writable) == ("X:Y", "X:Y", False)
+
+
+def test_new_pv_distinct_is_writable():
+    assert NewPv(read="X:Y_RBV", write="X:Y").writable
+
+
+# -- link direction ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", ["CP", "CPP", "MS", "MSS", "MSI"])
+def test_rule1_read_flags_win(flag):
+    # rule 1 beats an output-looking attribute name
+    assert link_is_reading("OUT", flag) is True
+
+
+@pytest.mark.parametrize("flag", ["PP", "NPP"])
+def test_rule2_write_flags(flag):
+    assert link_is_reading("INP", flag) is False
+
+
+@pytest.mark.parametrize("attribute", ["OUT", "out3", "DOL", "OUTPUT", "a_out_b"])
+def test_rule3_output_attribute_names(attribute):
+    assert link_is_reading(attribute, "") is False
+
+
+@pytest.mark.parametrize("attribute", ["INP", "inp2", "INPUT", "IN", "a_in_b"])
+def test_rule4_input_attribute_names(attribute):
+    assert link_is_reading(attribute, "") is True
+
+
+def test_rule5_undecidable_returns_none():
+    assert link_is_reading("VAL", "") is None
+    assert link_is_reading("rio_dinput", "") is None
+
+
+@pytest.mark.parametrize("attribute", ["INPA", "INPL", "OUTGB0", "OUTHIS"])
+def test_epics_calc_link_names_are_undecidable_by_name(attribute):
+    """The specified regexes need a digit or a `_` boundary after `inp`/`out`.
+
+    `INPA`..`INPL` and femto200's `OUTGB0`/`OUTHIS` therefore fall through to
+    rule 5. In practice rules 1-2 decide them: the real femto200 values carry
+    `PP`. Anything left over defaults to reading and warns for a writable leaf.
+    """
+    assert link_is_reading(attribute, "") is None
+    assert link_is_reading(attribute, "PP") is False
+
+
+def test_read_flag_beats_write_flag():
+    assert link_is_reading("VAL", "PP CP") is True
+
+
+# -- rewrite_value ----------------------------------------------------------
+
+
+def test_trailing_flag_and_whitespace_preserved():
+    sub = make_substituter()
+    assert (
+        rewrite(sub, f"{DI_IN} CP", attribute="VAL") == f"{DI_IN_NEW} CP"
+    )  # only the PV token changed
+
+
+def test_odd_whitespace_runs_survive_byte_for_byte():
+    sub = make_substituter()
+    out = rewrite(sub, f"  {DI_IN}\t\t CP  MS ", attribute="VAL")
+    assert out == f"  {DI_IN_NEW}\t\t CP  MS "
+
+
+def test_writable_leaf_read_via_cp_flag():
+    sub = make_substituter()
+    assert rewrite(sub, f"{DI_OUT} CP", attribute="VAL") == f"{DI_OUT_R} CP"
+
+
+def test_writable_leaf_written_via_pp_flag():
+    sub = make_substituter()
+    assert rewrite(sub, f"{DI_OUT} PP", attribute="VAL") == f"{DI_OUT_W} PP"
+
+
+def test_writable_leaf_written_via_attribute_name():
+    sub = make_substituter()
+    assert rewrite(sub, DI_OUT, attribute="OUT") == DI_OUT_W
+
+
+def test_writable_leaf_read_via_attribute_name():
+    sub = make_substituter()
+    assert rewrite(sub, DI_OUT, attribute="INP1") == DI_OUT_R
+
+
+def test_link_direction_guess_only_for_writable_leaf():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    # read-only leaf, undecidable attribute -> no warning
+    assert rewrite(sub, DI_IN, attribute="VAL", log=log) == DI_IN_NEW
+    assert len(log) == 0
+    # writable leaf, undecidable attribute -> reading, plus a warning
+    assert rewrite(sub, DI_OUT, attribute="VAL", log=log) == DI_OUT_R
+    codes = [d.code for d in log]
+    assert codes == ["link-direction-guess"]
+    guess = next(iter(log))
+    assert (guess.ioc, guess.entity, guess.attribute) == (CONSUMER, "demo", "VAL")
+    assert guess.chain == SCANNER
+
+
+# -- unresolved -------------------------------------------------------------
+
+
+def test_unresolved_token_diagnosed_and_left_in_place():
+    pv = "BL21I-DI-ERIO-01:MOD5:CHANNEL1:INPUT"
+    sub = make_substituter(
+        unresolved={pv: ("ambiguous-legacy-pv", "two couplers claim MOD5", SCANNER)}
+    )
+    log = DiagnosticLog()
+    assert rewrite(sub, f"{pv} CP", attribute="VAL", log=log) == f"{pv} CP"
+    (diag,) = list(log)
+    assert diag.code == "ambiguous-legacy-pv"
+    assert diag.message == "two couplers claim MOD5"
+    assert diag.chain == SCANNER
+    assert diag.ioc == CONSUMER
+    # the IOC still counts as depending on the chain that blocked it
+    assert sub.references(CONSUMER) == {SCANNER}
+    assert sub.touched_iocs() == set()
+
+
+# -- unknown tokens ---------------------------------------------------------
+
+
+def test_known_label_with_bad_mod_is_mod_out_of_range():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    bad = "BL21I-DI-ERIO-10:MOD99:CHANNEL1:INPUT"
+    assert rewrite(sub, bad, attribute="VAL", log=log) == bad
+    (diag,) = list(log)
+    assert diag.code == "mod-out-of-range"
+    assert diag.chain == SCANNER
+    assert "BL21I-DI-ERIO-10" in diag.message
+    assert "MOD99:CHANNEL1:INPUT" in diag.message
+    assert sub.references(CONSUMER) == {SCANNER}
+
+
+def test_unknown_label_fails_the_consumer_not_a_chain():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    bad = "BL21I-XX-ERIO-77:MOD1:CHANNEL1:INPUT"
+    assert rewrite(sub, bad, attribute="VAL", log=log) == bad
+    (diag,) = list(log)
+    assert diag.code == "unknown-chain-label"
+    assert diag.chain is None
+    assert diag.ioc == CONSUMER
+    assert sub.references(CONSUMER) == set()
+
+
+def test_non_pv_strings_are_untouched_and_undiagnosed():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    for value in [
+        "some free text about ERIO couplers",
+        "BL21I-DI-ERIO-10",  # no colon, so not a PV reference
+        "1.5",
+        "",
+        "   ",
+    ]:
+        assert rewrite(sub, value, attribute="VAL", log=log) == value
+    assert len(log) == 0
+
+
+def test_legacy_pv_re_needs_a_colon_and_an_erio_segment():
+    assert LEGACY_PV_RE.match(DI_IN)
+    assert not LEGACY_PV_RE.match("BL21I-DI-ERIO-10")
+    assert not LEGACY_PV_RE.match("BL21I-DI-VALV-01:STA")
+
+
+# -- multiple PVs -----------------------------------------------------------
+
+
+def test_two_pvs_in_one_value_both_rewritten():
+    sub = make_substituter()
+    out = rewrite(sub, f"{DI_IN} {DI_OUT}", attribute="INP")
+    assert out == f"{DI_IN_NEW} {DI_OUT_R}"
+
+
+def test_second_pv_is_rewritten_even_when_the_first_is_unresolved():
+    pv = "BL21I-DI-ERIO-10:MOD9:CHANNEL1:INPUT"
+    sub = make_substituter(
+        unresolved={pv: ("ambiguous-legacy-pv", "dropped", SCANNER)},
+    )
+    log = DiagnosticLog()
+    out = rewrite(sub, f"{pv} {DI_IN} CP", attribute="VAL", log=log)
+    assert out == f"{pv} {DI_IN_NEW} CP"
+    assert [d.code for d in log] == ["ambiguous-legacy-pv"]
+
+
+# -- rewrite_entity ---------------------------------------------------------
+
+
+def test_rewrite_entity_rewrites_strings_and_reports_change():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    entity = {
+        "type": "calc.CalcOut",
+        "name": "myCalc",
+        "INPA": f"{DI_IN} CP",
+        "OUT": DI_OUT,
+        "SCAN": "1 second",
+        "PREC": 3,
+    }
+    assert sub.rewrite_entity(entity, log=log, ioc=CONSUMER) is True
+    assert entity["INPA"] == f"{DI_IN_NEW} CP"
+    assert entity["OUT"] == DI_OUT_W
+    assert entity["SCAN"] == "1 second"
+    assert entity["PREC"] == 3
+    assert entity["type"] == "calc.CalcOut"
+    assert len(log) == 0
+
+
+def test_rewrite_entity_never_rewrites_the_type_key():
+    sub = make_substituter(subs={"calc.CalcOut": NewPv.same("REWRITTEN")}, owners={})
+    entity = {"type": "calc.CalcOut", "name": "myCalc"}
+    assert sub.rewrite_entity(entity, log=DiagnosticLog(), ioc=CONSUMER) is False
+    assert entity["type"] == "calc.CalcOut"
+
+
+def test_rewrite_entity_returns_false_when_nothing_matched():
+    sub = make_substituter()
+    entity = {"type": "asyn.AsynIP", "name": "port", "P": "BL21I-DI-01"}
+    assert sub.rewrite_entity(entity, log=DiagnosticLog(), ioc=CONSUMER) is False
+
+
+def test_rewrite_entity_passes_the_entity_name_to_diagnostics():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    # INP decides by rule 4, VAL falls through to the guess
+    entity = {"type": "calc.Calc", "name": "myCalc", "INP": DI_OUT, "VAL": DI_OUT}
+    sub.rewrite_entity(entity, log=log, ioc=CONSUMER)
+    (diag,) = list(log)
+    assert diag.code == "link-direction-guess"
+    assert diag.entity == "myCalc"
+    assert diag.attribute == "VAL"
+
+
+def test_rewrite_entity_tolerates_a_missing_name():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    entity = {"type": "calc.Calc", "VAL": DI_OUT}
+    assert sub.rewrite_entity(entity, log=log, ioc=CONSUMER) is True
+    (diag,) = list(log)
+    assert diag.entity is None
+
+
+# -- bookkeeping ------------------------------------------------------------
+
+
+def test_references_and_touched_iocs():
+    sub = make_substituter()
+    log = DiagnosticLog()
+    rewrite(sub, DI_IN, attribute="INP", log=log, ioc="BL21I-DI-IOC-02")
+    rewrite(sub, "nothing here", attribute="INP", log=log, ioc="BL21I-DI-IOC-03")
+    assert sub.references("BL21I-DI-IOC-02") == {SCANNER}
+    assert sub.references("BL21I-DI-IOC-03") == set()
+    assert sub.references("never-seen") == set()
+    assert sub.touched_iocs() == {"BL21I-DI-IOC-02"}
+
+
+def test_references_returns_a_copy():
+    sub = make_substituter()
+    rewrite(sub, DI_IN, attribute="INP")
+    got = sub.references(CONSUMER)
+    got.add("mutated")
+    assert sub.references(CONSUMER) == {SCANNER}
+
+
+def test_identical_replacement_counts_as_a_reference_but_not_a_rewrite():
+    sub = make_substituter(subs={DI_IN: NewPv.same(DI_IN)}, owners={DI_IN: SCANNER})
+    assert rewrite(sub, DI_IN, attribute="INP") == DI_IN
+    assert sub.references(CONSUMER) == {SCANNER}
+    assert sub.touched_iocs() == set()


### PR DESCRIPTION
DLS is replacing the custom `ethercat` scanner with **fastcs-catio**, which
auto-discovers the EtherCAT chain and generates its own PV names. Those names
differ from the legacy ones, so migrating a beamline means predicting them
before any hardware exists and rewriting every consumer IOC's references.

This adds `builder2ibek catio <BLxxI-BUILDER> --services-repo <path>`, which does
the whole beamline in one invocation — an IOC may consume more than one chain,
so it has to be written once, complete.

### Instructions to reviewer on how to test:

1. `env -u EPICS_ROOT uv run pytest` — 321 passed, 27 skipped. The 27 skips are
   the name-prediction tests; they need `fastcs_catio`, which is deliberately
   **not** a dependency (its release pins a `fastcs` version no longer on PyPI,
   so adding it breaks `uv lock`). With both projects installed the same suite
   is 368 passed, 2 skipped.
2. `uv run builder2ibek catio --help` — works without `fastcs_catio`; only
   name prediction imports it, lazily.
3. Against a **copy** of a services repo:
   `builder2ibek catio /dls_sw/work/R3.14.12.7/support/BL21I-BUILDER --services-repo <copy> --dry-run`
   On BL21I: 4 chains discovered, 3 converted, 5 IOCs written, exit 1.
4. Confirm the checked-in sample YAMLs are untouched — `git diff d328761 -- tests/samples/*.yaml`
   is empty. The `convert.py` refactor is meant to be transparent.

### The three decisions worth reviewing

**Names are predicted, not reimplemented.** Prediction is delegated to
`fastcs_catio.naming`. That module is not in this PR — it currently exists only
locally, and needs to land in fastcs-catio on top of PR #63
(`gui/inline-root-controllers`), which is where `group_alias` and the shortening
budget it depends on live. **So this branch cannot do name prediction against
fastcs-catio `main` yet.** Everything else — chain modelling, diagnostics, the
report — works without it.

**The substitution map is keyed on both names a consumer might have used**: the
declared `DEVICE=` and the chain-derived `{label}:MOD{position}`, each including
the leaf. Keying on one alone misses every consumer that followed the other.
The pair also makes BL21I's real defects harmless — an `auto_EL1014` that
restarts its MOD numbering still lands on the right terminal, opaque labels like
`MODSAM3` need no parsing, and two couplers sharing a label stops being fatal.
Where one legacy PV would resolve to two different new PVs, the entry is dropped
and diagnosed rather than guessed at.

**Failure is per chain, and loud.** An error skips just that chain; every clean
chain still converts. An IOC is written only when *every* chain it references is
clean, so a straddling IOC is skipped whole rather than half-rewritten. Exit
code is non-zero whenever an error fired.

### Known limitation

`BL21I-DI-IOC-01` does not convert. It references PVs from `auto_EL2595`, a
terminal with no entry in `leaves.py`, so its new names genuinely cannot be
predicted — the report says exactly that and names the terminal to add.
Unblocking it is a data job (add EL2595 and EL4134 leaf tables), deliberately
not guessed at here: a wrong table would silently point `dbpf` calls at records
that will never exist, which is strictly worse than a loud failure.

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `catio` command for EtherCAT configuration conversion to fastcs-catio.
  * Discovers chains, converts eligible IOCs, updates PV references, and generates service configurations.
  * Supports dry runs, strict validation, JSON reports, and configurable PV prefixes.
  * Preserves existing service settings and chain numbering across repeat conversions.

* **Diagnostics**
  * Reports unresolved mappings, invalid chains, conversion failures, and skipped conversions.

* **Documentation**
  * Added conversion workflows, design guidance, and sample configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->