### PR TITLE
Set up ibek-defs on devcontainer create, and harden update-schema

### DIFF
--- a/.claude/skills/ibek-pattern-vendoring/SKILL.md
+++ b/.claude/skills/ibek-pattern-vendoring/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ibek-pattern-vendoring
+description: Operational knowledge and foot-guns for the epics-containers `ibek pattern` runtime-support vendoring system — vendoring/check/restore mechanics, the strict integrity-check policy, and the pre-commit/CI/packaging traps. Use when working on ibek `pattern`/`runtime` commands, services-template-helm pre-commit hooks or ci_verify.sh, runtime-lock.yaml, or the t01/bl01 services repos.
+---
+
+# ibek pattern runtime-support vendoring
+
+`ibek pattern add|update|check|restore|schema` vendors a runtime-support file-set
+(`*.ibek.support.yaml` plus optional `.proto`/`.protocol`/`.template`/`.db`) from a
+central library into `services/<instance>/config/`, prepending a deterministic
+`# Vendored from <src>@<ver> — DO NOT EDIT` header and recording each file's sha256
+in `services/<instance>/runtime-lock.yaml`. Libraries: `ibek-runtime-streamdevice`,
+`ibek-runtime-support`. Shipped in **ibek 4.6.0** (`ibek pattern`, `ibek runtime place-files`).
+
+## check / dirty semantics
+- `ibek pattern check <instance>` → **exit 1** on any hash mismatch (drift).
+- `--allow-dirty` (or `IBEK_ALLOW_DIRTY=1`) downgrades mismatches to *warnings*
+  (exit 0). It also makes the CLI still print "vendored files match the lock" — misleading.
+- A lock entry whose value is `DIRTY # <reason>` is tolerated **even without** the
+  flag (handled by `is_dirty()` before the allow-dirty logic). This is the sanctioned,
+  visible way to keep a deliberate edit to a vendored file.
+- **Policy (this project): strict on every branch** — hooks/CI run `check` WITHOUT
+  `--allow-dirty`. To diverge deliberately: mark the lock entry `DIRTY # <reason>`.
+  To try a throwaway edit: `git commit --no-verify` and tolerate red branch CI
+  (red doesn't block deploying the branch to a cluster).
+
+## FOOT-GUN 1 — pre-commit / shell loops mask non-last failures
+A `bash -c 'for x in …; do cmd "$x"; done'` exits with the status of the **last**
+iteration only. A failing earlier item (e.g. an edited vendored file in a
+first-sorting instance like `bl01t-di-cam-01`) is silently masked by any later item
+that passes → hook reports "Passed". Compounded by pre-commit **hiding a passing
+hook's stdout**, so even a warning is invisible. Always keep `|| rc=1` + `exit "${rc}"`
+— never rely on the loop's own exit status. Current canonical shape scopes to the
+*changed* instances via `pass_filenames: true`, mapping each path back to its folder:
+```bash
+bash -c '
+  rc=0
+  for i in $(printf "%s\n" "$@" | cut -d/ -f1-2 | sort -u); do   # changed instances, de-duped
+    [ -f "${i}/runtime-lock.yaml" ] || continue
+    uvx --python 3.13 --from ibek --constraints requirements.txt ibek pattern check "${i}" || rc=1
+  done
+  exit "${rc}"' ibek-pattern-check                               # $0 placeholder; files land in "$@"
+```
+Don't hard-code the ibek version in the hook: `--from ibek --constraints requirements.txt`
+makes uvx resolve ibek to whatever `requirements.txt` pins (`==`, `>=`, **or** a `name @
+git+…` direct ref — uv constraints honour all three), so `requirements.txt` is the single
+source of truth and auto-tracks the DLS-GitLab requirements variant in those repos.
+The old `shopt -s nullglob; for … in services/*/…` form (looping *every* instance on any
+change) still works but is slower and floods errors/skip-noise from unrelated instances.
+ioc-schema narrows `files:` to `config/ioc.yaml|ioc.schema.json|values.yaml`; pattern-check
+keeps a broad `^services/` trigger so edits to DO-NOT-EDIT vendored files still fire. Both
+add `exclude: ^services/\.` (skip the `.ioc_template` skeleton). A top-level `set -e`/`set
+-xe` (as in `ci_verify.sh`) also avoids the mask — it aborts on first failure; the bug
+bites loops *without* it.
+
+## FOOT-GUN 2 — `>=` version specs exclude pre-releases
+`ibek>=X` will NOT install a pre-release `Xb2` — pip/uv skip pre-releases unless the
+specifier names one (or nothing stable satisfies it). During a beta window pin
+`==Xb2` or `>=Xb2`; switch to `>=X` once the final is out. This is why an image with
+`ibek>=3.3.4` pulled stable `3.3.7` (no `place-files`) instead of the `4.6.0` beta.
+Verify with `uv pip install --dry-run "<spec>"` in a scratch venv.
+
+## FOOT-GUN 3 — pre-commit partitions files across parallel workers
+With `pass_filenames: true`, pre-commit runs the hook once per CPU-sized partition of the
+file list (xargs-style), in parallel. It splits by *file*, so one instance's files can land
+in different partitions and each partition's `sort -u` re-runs that instance → duplicate
+work and duplicated output (obvious under `--all-files`). Fix: **`require_serial: true`** →
+a single invocation with the whole list, so `sort -u` de-dupes globally and each instance
+runs once. (pre-commit also chunks for ARG_MAX, but that only bites at hundreds of files.)
+
+## FOOT-GUN 4 — surfacing a soft-skip without failing the commit
+pre-commit hides a *passing* hook's output, so `ibek pattern schema`'s soft-skip (exit 0
+when the base schema 404s, e.g. a beta image) is invisible. Write just that line to
+`/dev/tty` (bypasses pre-commit's capture; shows even on a pass). Three traps, all verified:
+- **bare `… | tee | grep > /dev/tty`** (no file arg) pipes everything into grep and sends
+  *only* matches to the tty — the full output never reaches stdout/stderr, so on a real
+  failure with no tty (CI) the pipe tears down and pre-commit shows a **blank** "Failed".
+  Emit the full output as its **own** statement first (`printf "%s\n" "${out}"`), then warn.
+- **`grep … > /dev/tty 2>/dev/null`** does NOT suppress the no-tty error: bash opens (and
+  fails) `> /dev/tty` *before* applying the trailing `2>/dev/null`. Use group level:
+  `{ … > /dev/tty; } 2>/dev/null || true`.
+- **`[ -w /dev/tty ]`** is a false guard — `/dev/tty` is always present with `rw` perms, so
+  the test passes even when `open()` fails (ENXIO, no controlling terminal).
+
+## Other conventions
+- **Merge library PRs with a merge commit, not squash**, so version tags stay
+  ancestors of `main`. Watch tag-prefix consistency (`v0.1.0` vs `0.1.1`).
+- **Pushing to `gilesknap/t01-services` needs the `../t01-gh` PAT** — the cached
+  token lacks write. epics-containers repos push fine via the cached token:
+  `GIT_CONFIG_GLOBAL=/dev/null git -c credential.helper='!gh auth git-credential' push https://github.com/<owner>/<repo>.git <branch>`.
+- Template source of truth is `services-template-helm` (`template/ci_verify.sh`,
+  `template/.pre-commit-config.yaml`); services repos inherit changes via `copier update`
+  of a **released tag** (not the branch tip).
+- **copier is delta-based, not recopy.** `copier update` replays the *diff* between the
+  old and new template versions onto the service repo. So a rendered file that has
+  **diverged** from the template (hand-edits, or drift from an old template) is NOT
+  silently healed — copier only re-renders it if the new template version actually
+  *changes that file*. Consequence both ways: (a) if a file diverged but the template
+  didn't touch it, `copier update` leaves the divergence — fix by overwriting from
+  `template/<file>` or `copier recopy -f`; (b) once the template *does* change the file,
+  `copier update` re-renders it and the divergence is replaced (verified: t01's diverged
+  `ci_verify.sh` healed to byte-identical-to-template after a template-touching update).
+  Drift diagnostic: `copier recopy -f --skip-tasks` on a throwaway clone, then diff.
+  (Gotcha tracked in epics-containers.github.io issue #232.)
+- **Library version pins move fast during a rollout — verify, don't trust notes.** ibek
+  4.6.0 was *yanked* (broken `ibek pattern` CLI) and replaced by 4.6.1; the real floor
+  became `ibek>=4.6.1`. Always `gh release list` / check PyPI for the live version rather
+  than reusing a number from an earlier session.
+
+## Consuming a pattern — image ibek floor, library map, schema, sim wiring
+- **The IMAGE must bake ibek ≥ 4.6.1 to *consume* a pattern, not just the workstation.**
+  `ibek pattern add` runs on the workstation and succeeds regardless; consumption happens
+  at container start, where `ioc/start.sh` runs `ibek runtime generate2 config`, which only
+  discovers vendored `config/*.ibek.support.yaml` on ibek ≥ 4.6.1. An IOC image built with
+  older ibek silently fails to load the pattern **at boot** (not at `add`). Check the
+  image's pinned floor in its `requirements.txt`: `ioc-streamdevice` pins `ibek>=4.6.1`;
+  `ioc-adsimdetector` pinned `ibek>=3.3.1` and needed a rebuild + new tag before its image
+  could consume patterns.
+- **`name@<ver>` pins a GIT REF, not a GitHub Release.** `ibek pattern add` clones the
+  library with `git clone --depth 1 --branch <ver>` (sources.py `_clone_pattern`). The
+  pinnable version is therefore a git tag, which can diverge from Releases:
+  `ibek-runtime-support` had git tag `v0.1.0` and **no** GitHub release;
+  `ibek-runtime-streamdevice` had release `0.1.1`. Verify with `git ls-remote --tags <url>`
+  / `git -C <clone> tag`, NOT just `gh release list`. (Reinforces the tag-prefix-drift
+  warning above: `v0.1.0` vs `0.1.1` will break the pin.)
+- **Library map** (defaults from sources.py `DEFAULT_LIBRARIES` → `github.com/epics-containers/<name>`;
+  override via `--source <uri|path>` or `IBEK_PATTERN_LIBRARIES="name=uri,..."` — a fork is
+  just `--source` a local clone path or the fork URL):
+  - `ibek-runtime-support` → non-StreamDevice runtime entities. Pattern `detectorPlugins`
+    has TWO entity_models — `gdaPlugins` (full GDA set; needs **ffmpegServer**) and
+    `detectorPlugins` (light Ophyd set; **ADCore-only**). A stock `ioc-adsimdetector` image
+    builds only ADSimDetector+ADCore (no ffmpegServer) → only the **light** model works.
+  - `ibek-runtime-streamdevice` → per-device StreamDevice file-sets (proto+template+support;
+    lakeshore340, …).
+- **`ibek pattern add` regenerates `config/ioc.schema.json`** by fetching the *image's*
+  published base schema (`<ioc-repo>/releases/download/<image-tag>/ibek.ioc.schema.json`)
+  and merging the vendored entities in. If that tag/asset isn't published yet the schema
+  step soft-skips → the editor flags the vendored entity as an unknown type. So a
+  not-yet-published image tag breaks BOTH runtime consumption AND editor validation.
+- **Compose-track sims need a sidecar, not localhost.** A StreamDevice IOC in the
+  `docker compose` track joins the `channel_access` bridge and cannot reach a simulator on
+  host `localhost`. Run the sim as a sidecar compose service on `channel_access` and point
+  `asyn.AsynIP` at the service name (the lakeshore340 sim binds `0.0.0.0:<port>`).

--- a/.claude/skills/ibek-pattern-vendoring/SKILL.md
+++ b/.claude/skills/ibek-pattern-vendoring/SKILL.md
@@ -10,7 +10,9 @@ description: Operational knowledge and foot-guns for the epics-containers `ibek 
 central library into `services/<instance>/config/`, prepending a deterministic
 `# Vendored from <src>@<ver> — DO NOT EDIT` header and recording each file's sha256
 in `services/<instance>/runtime-lock.yaml`. Libraries: `ibek-runtime-streamdevice`,
-`ibek-runtime-support`. Shipped in **ibek 4.6.0** (`ibek pattern`, `ibek runtime place-files`).
+`ibek-runtime-support`. Shipped in **ibek 4.6.0** (`ibek pattern`, `ibek runtime
+place-files`), but 4.6.0 was yanked, so the real floor is **`ibek>=4.6.1`** — see
+the version-pin note under "Other conventions".
 
 ## check / dirty semantics
 - `ibek pattern check <instance>` → **exit 1** on any hash mismatch (drift).

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -12,10 +12,16 @@ pre-commit install --install-hooks
 # silently move an already checked out submodule back to the pinned commit,
 # losing whatever the developer had there.
 if [ -f .gitmodules ]; then
-    readarray -t uninitialised < <(git submodule status | awk '/^-/ {print $2}')
+    # Capture the status first: a failure inside <( ) is not caught by set -e,
+    # so a broken `git submodule status` would silently read as "nothing to do".
+    submodule_status=$(git submodule status)
+    readarray -t uninitialised < <(printf '%s\n' "${submodule_status}" | awk '/^-/ {print $2}')
     for submodule in "${uninitialised[@]}"; do
         echo "Initialising submodule ${submodule}"
-        git submodule update --init -- "${submodule}"
+        # ibek-support-dls is on Diamond's internal GitLab, which is unreachable
+        # from outside DLS, so warn rather than fail the whole container create.
+        git submodule update --init -- "${submodule}" ||
+            echo "WARNING: could not initialise ${submodule}, continuing without it"
     done
 fi
 

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -3,8 +3,24 @@ set -euo pipefail
 
 # Install Python dependencies and pre-commit hooks
 uv venv --clear
+hash -r
 uv sync
 pre-commit install --install-hooks
 
-# Initialise git submodules if any are declared
-[ -f .gitmodules ] && git submodule update --init || true
+# Initialise only the submodules that are not checked out yet -- `git submodule
+# status` prefixes those with '-'. A blanket `git submodule update --init` would
+# silently move an already checked out submodule back to the pinned commit,
+# losing whatever the developer had there.
+if [ -f .gitmodules ]; then
+    readarray -t uninitialised < <(git submodule status | awk '/^-/ {print $2}')
+    for submodule in "${uninitialised[@]}"; do
+        echo "Initialising submodule ${submodule}"
+        git submodule update --init -- "${submodule}"
+    done
+fi
+
+# Populate $EPICS_ROOT/ibek-defs (defaults to /epics/ibek-defs) with links to the
+# support yaml from both submodules. `ibek runtime generate2` resolves entity
+# models from that folder and from the IOC config folder -- it never reads
+# ibek-support*/ directly, so without this every entity fails validation.
+./update-schema

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ uv run pytest "tests/test_file_conversion.py::test_convert[BL11I-CS-IOC-09]"
 Regenerate expected outputs and schema:
 
 ```bash
+./update-schema
 ./tests/samples/make_samples.sh
 ./update-schema
 ```

--- a/update-schema
+++ b/update-schema
@@ -17,11 +17,26 @@ if [ ${#defs[@]} -eq 0 ]; then
     exit 1
 fi
 
+# A support folder that is present but empty yields a partial ibek-defs, whose
+# symptom is a handful of entities failing rather than an obvious error. Say so.
+shopt -s nullglob
+for support in "$THISDIR"/ibek-support*/; do
+    contributed=("${support}"*/*.ibek.support.yaml)
+    if [ ${#contributed[@]} -eq 0 ]; then
+        echo "WARNING: ${support} holds no *.ibek.support.yaml;" \
+             "entities from it will be missing" >&2
+    fi
+done
+shopt -u nullglob
+
 # set up the generic IOC-like environment for ibek
 mkdir -p "$EPICS_ROOT/ibek-defs/"
 rm -f "$EPICS_ROOT"/ibek-defs/*
 ln -srf "${defs[@]}" "$EPICS_ROOT/ibek-defs/"
 
-# generate into a temp file first so a failure leaves no truncated schema behind
-ibek ioc generate-schema > "$EPICS_ROOT/ibek-defs/.ioc.schema.json.tmp"
-mv "$EPICS_ROOT/ibek-defs/.ioc.schema.json.tmp" "$EPICS_ROOT/ibek-defs/ioc.schema.json"
+# generate into a temp file first so a failure leaves no truncated schema behind.
+# It is a dotfile, which the rm above does not glob, so clean it up on the way out.
+tmp_schema="$EPICS_ROOT/ibek-defs/.ioc.schema.json.tmp"
+trap 'rm -f "${tmp_schema}"' EXIT
+ibek ioc generate-schema > "${tmp_schema}"
+mv "${tmp_schema}" "$EPICS_ROOT/ibek-defs/ioc.schema.json"

--- a/update-schema
+++ b/update-schema
@@ -1,11 +1,27 @@
 #!/bin/bash
 
+set -euo pipefail
+
 THISDIR=$(dirname $0)
 EPICS_ROOT="${EPICS_ROOT:-/epics}"
 
+# ibek resolves entity models from $EPICS_ROOT/ibek-defs, never from
+# ibek-support*/ directly, so collect the support yaml from both submodules here.
+shopt -s nullglob
+defs=("$THISDIR"/ibek-support*/*/*.ibek.support.yaml)
+shopt -u nullglob
+
+if [ ${#defs[@]} -eq 0 ]; then
+    echo "ERROR: no *.ibek.support.yaml found under $THISDIR/ibek-support*/" >&2
+    echo "       are the submodules initialised? git submodule update --init" >&2
+    exit 1
+fi
+
 # set up the generic IOC-like environment for ibek
 mkdir -p "$EPICS_ROOT/ibek-defs/"
-rm $EPICS_ROOT/ibek-defs/*
-ln -srf $THISDIR/ibek-support*/*/*.ibek.support.yaml "$EPICS_ROOT/ibek-defs/"
+rm -f "$EPICS_ROOT"/ibek-defs/*
+ln -srf "${defs[@]}" "$EPICS_ROOT/ibek-defs/"
 
-ibek ioc generate-schema > "$EPICS_ROOT/ibek-defs/ioc.schema.json"
+# generate into a temp file first so a failure leaves no truncated schema behind
+ibek ioc generate-schema > "$EPICS_ROOT/ibek-defs/.ioc.schema.json.tmp"
+mv "$EPICS_ROOT/ibek-defs/.ioc.schema.json.tmp" "$EPICS_ROOT/ibek-defs/ioc.schema.json"


### PR DESCRIPTION
## Why

`ibek runtime generate2` resolves entity models from `$EPICS_ROOT/ibek-defs` and from the IOC config folder — it never reads `ibek-support*/` directly:

```python
if len(definitions) == 0:
    definitions += Path(GLOBALS.IBEK_DEFS).glob("**/*ibek.support.yaml")
    definitions += config_folder.glob("**/*.ibek.support.yaml", recurse_symlinks=True)
```

Nothing populated that folder on container create — `postCreate.sh` did not run `./update-schema`, and neither did the `Dockerfile` or `devcontainer.json`. It only got populated as a side effect of `uv run pytest` (the `ibek_defs` fixture in `tests/conftest.py`). A developer who had not yet run the test suite therefore got no entity models at all, and every entity failed validation. The README lists `./update-schema` under "regenerate expected outputs", which reads as a maintenance step rather than required first-run setup.

## Changes

**`.devcontainer/postCreate.sh`**

- Runs `./update-schema`, so a fresh container can run `generate2` immediately.
- Initialises only the submodules that are not checked out yet (`-` prefix in `git submodule status`). The blanket `git submodule update --init` silently moved an already checked out submodule back to the pinned commit.

**`update-schema`** — hardened, since it now runs under `postCreate.sh`'s `set -euo pipefail`:

- `set -euo pipefail`, so failures are loud rather than silent.
- The glob is collected with `nullglob` into an array and checked. Previously an uninitialised submodule left the glob literal, `ln` failed, and the script carried on to write a schema built from nothing.
- `rm` → `rm -f`, so the first run into an empty `ibek-defs` does not error.
- Schema generated via a temp file, so a failed `ibek ioc generate-schema` leaves no truncated `ioc.schema.json` behind.

**`README.md`** — `./update-schema` before `make_samples.sh`, which needs `ibek-defs` populated first.

The second commit adds the `ibek-pattern-vendoring` skill, unrelated to the above.

## Verification

Submodule handling, tested against a throwaway repo with a real submodule:

| scenario | result |
|---|---|
| submodule checked out at a non-pinned commit | left alone |
| same state, old `git submodule update --init` | moved back to the pin — the bug |
| submodule genuinely missing (`-` prefix) | initialised |
| empty array under `set -euo pipefail` (bash 5.2) | loop runs zero times, exit 0 |
| no support yaml present | exits 1 with an "are the submodules initialised?" message |

`env -u EPICS_ROOT uv run pytest` → 60 passed.

## Note

`update-schema` will now abort container creation if `$EPICS_ROOT` is not writable. That is fine here — the devcontainer is rootless and always runs as root, and `/epics` ships in the image. A `|| true` guard was deliberately not added, since that reintroduces exactly the silent failure this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for managing vendored runtime-support files, version requirements, schema generation, and development workflows.
  - Updated testing instructions to include schema updates before regenerating sample outputs.

- **Developer Experience**
  - Improved development-container setup by initializing required components and refreshing schema links automatically.
  - Enhanced schema generation reliability with clearer initialization errors and safer output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->